### PR TITLE
Add Codex context management skill docs

### DIFF
--- a/skills/CHANGELOG.md
+++ b/skills/CHANGELOG.md
@@ -24,6 +24,18 @@ All notable changes to the reusable Codex skills are tracked here.
   monorepo subprojects, and best-effort opens a new Dev Containers window for
   the running container.
 - Added the `create-pr` Codex skill for branch-safe GitHub PR creation.
+- Added the `config-codex` Codex skill for bootstrapping public-safe local
+  Codex runtime setup, including global `AGENTS.md`, `config.toml` features
+  and MCP servers, hooks, task-state layout, read-only custom agents, and a
+  design README.
+- Added the `global-context-management` Codex skill for keeping complex Codex
+  sessions focused and recoverable with durable task state, concise
+  parent-thread discipline, bounded read-only subagents, local-only hook
+  templates, final risk review guidance, a local-only template validation
+  helper, and a skill-local design README.
+- Added skill-local `README.md` files across reusable skills so each skill
+  folder has human-facing architecture, workflow, core concept, and file
+  responsibility documentation.
 - Added the `onboard-nebius-cxcli` Codex skill as the central onboarding guide
   for Nebius Terraform modules that need to be wired into
   `services/nebius-cxcli`, including catalog-first onboarding and optional
@@ -36,6 +48,12 @@ All notable changes to the reusable Codex skills are tracked here.
 
 ### Changed
 
+- Updated the `global-context-management` hook template so hook commands
+  resolve scripts through `${CODEX_HOME:-$HOME/.codex}` and work with
+  non-default local Codex homes.
+- Tightened the `config-codex` skill contract so existing user `AGENTS.md` and
+  `config.toml` files are patched in place rather than replaced, with
+  conflicts reported instead of silently overwritten.
 - Tightened the `helmchart` Codex skill with more accurate `appVersion`
   guidance, dependency-aware strict validation, safer securityContext and RBAC
   mutation rules, trigger-scope metadata, a reusable chart validation helper,

--- a/skills/README.md
+++ b/skills/README.md
@@ -4,6 +4,11 @@ This folder contains public, reusable Codex skills for common engineering
 workflows. Each skill lives in its own folder and is discovered by the presence
 of `SKILL.md`.
 
+This root README is the concise index and install guide. Each skill folder also
+has a local `README.md` that explains what the skill does, its architecture,
+core concepts, workflow, and important files. `SKILL.md` remains the runtime
+instruction file Codex loads when the skill is used.
+
 For skill-specific release notes, see [CHANGELOG.md](CHANGELOG.md).
 
 ## Included Skills
@@ -12,7 +17,9 @@ For skill-specific release notes, see [CHANGELOG.md](CHANGELOG.md).
 - Skill folder alignment and validation: `align-skill`
 - Disposable Ubuntu project container setup: `attach-ubuntu`
 - Branch-safe and conflict-free GitHub pull request creation: `create-pr`
+- Public-safe local Codex runtime configuration: `config-codex`
 - GitHub Actions authoring and review: `github-workflows`
+- Global context management for long Codex tasks: `global-context-management`
 - Stack-aware `.gitignore` generation and cleanup: `gitignore`
 - Helm chart hardening and validation: `helmchart`
 - Shell, Markdown, and Python linting: `linter`
@@ -106,12 +113,28 @@ PRs, avoid duplicate PRs for the same head branch, preserve one PR per branch,
 stage complete monorepo local work with `git add -A` when committing current
 dirty changes, and report readiness plus manual merge order.
 
+### `config-codex`
+
+`config-codex` bootstraps or aligns a user's local Codex runtime setup from
+public-safe templates. Use it for `$CODEX_HOME` layout, global `AGENTS.md`
+policy, `config.toml` features and MCP servers, hooks, task-state directories,
+custom read-only agents, and validation without copying personal paths or
+secrets into a public repository.
+
 ### `github-workflows`
 
 `github-workflows` is the repository workflow skill for creating, reviewing,
 and standardizing GitHub Actions. Use it for PR and merge CI, release
 automation, container publication, merge-bot safety, permissions hardening, and
 monorepo-friendly workflow structure.
+
+### `global-context-management`
+
+`global-context-management` keeps complex Codex sessions focused and
+recoverable by using durable task-state files, limiting noisy parent-thread
+exploration, delegating bounded read-only investigation when useful, and
+reviewing risk before final answers. Its public skill files stay generic; local
+hooks, custom agent config, and task-state files belong under `$CODEX_HOME`.
 
 ### `gitignore`
 

--- a/skills/align-skill/README.md
+++ b/skills/align-skill/README.md
@@ -1,0 +1,55 @@
+# Align Skill
+
+`align-skill` reviews and improves Codex or Agent Skill folders. Use it when a
+skill needs structure, metadata, references, assets, scripts, trigger behavior,
+vendor-doc grounding, safety guardrails, or validation evidence aligned.
+
+## What It Does
+
+- Checks `SKILL.md` front matter, scope, trigger quality, and workflow clarity.
+- Validates optional `agents/`, `assets/`, `references/`, and `scripts/`
+  surfaces.
+- Verifies vendor-specific claims against official documentation when needed.
+- Adds guardrails for destructive actions, secrets, live systems, and external
+  services.
+- Runs static skill validation before reporting readiness.
+
+## Architecture
+
+```text
+Skill folder
+  |
+  +--> SKILL.md runtime instructions
+  +--> agents/openai.yaml metadata
+  +--> references/ detailed docs
+  +--> assets/ reusable templates
+  `--> scripts/ deterministic helpers
+        |
+        v
+align-skill checks structure, safety, docs, and validation
+```
+
+## Workflow
+
+1. Detect the target skill scope.
+2. Inspect current skill files and nearby repository conventions.
+3. Verify relevant product or API claims against official docs.
+4. Apply focused updates to metadata, instructions, references, assets, or
+   scripts.
+5. Run `scripts/validate-skill-structure.py` when available.
+6. Report validation, skipped live checks, and remaining uncertainty.
+
+## Core Concepts
+
+- Keep `SKILL.md` concise for progressive disclosure.
+- Move detailed references and templates into supporting folders.
+- Do not broaden a skill until its trigger becomes hard to reason about.
+- Do not claim runtime activation unless the target Codex surface proves it.
+
+## Files
+
+- `SKILL.md`: runtime alignment workflow for skills.
+- `agents/openai.yaml`: UI metadata.
+- `references/`: canonical structure, safety, vendor, and trigger guidance.
+- `assets/`: report and plan templates.
+- `scripts/validate-skill-structure.py`: static skill folder validator.

--- a/skills/align/README.md
+++ b/skills/align/README.md
@@ -1,0 +1,54 @@
+# Align
+
+`align` is the repository consistency skill. Use it when a project needs a
+senior review-and-repair pass across implementation, wiring, tests, CI,
+configuration, CLI behavior, help text, documentation, and changelog entries.
+
+## What It Does
+
+- Inspects the actual project contract before editing.
+- Finds mismatches between code, tests, workflows, docs, and examples.
+- Applies small, evidence-backed fixes instead of broad rewrites.
+- Keeps behavior changes aligned with tests and user-facing documentation.
+- Reports remaining uncertainty instead of guessing.
+
+## Architecture
+
+```text
+User asks for alignment
+  |
+  v
+Map the relevant project contract
+  |
+  v
+Compare code, tests, docs, workflows, and config
+  |
+  v
+Patch confirmed inconsistencies
+  |
+  v
+Run focused validation and report residual risk
+```
+
+## Workflow
+
+1. Inspect the relevant codebase surfaces before changing anything.
+2. Establish the intended behavior from nearby evidence.
+3. Prioritize real bugs, broken wiring, stale docs, missing tests, and unsafe
+   assumptions.
+4. Patch the smallest responsible surface.
+5. Update tests, docs, examples, help text, and changelog entries when they are
+   affected.
+6. Validate with focused commands first, then broader checks when appropriate.
+
+## Core Concepts
+
+- Evidence beats speculation.
+- Preserve intended behavior unless a bug or stale contract is proven.
+- Prefer one canonical path over compatibility shims unless requested.
+- Keep edits easy to review.
+
+## Files
+
+- `SKILL.md`: runtime alignment workflow and guardrails.
+- `agents/openai.yaml`: UI metadata and invocation prompt.

--- a/skills/attach-ubuntu/README.md
+++ b/skills/attach-ubuntu/README.md
@@ -1,0 +1,50 @@
+# Attach Ubuntu
+
+`attach-ubuntu` creates or reuses a disposable Ubuntu container for the current
+project on macOS. It helps test Linux behavior while keeping the host machine
+clean.
+
+## What It Does
+
+- Starts or reuses an Ubuntu Docker container for a project.
+- Bind-mounts the project into the container at `/workdir`.
+- Prepares attached-container VS Code defaults.
+- Installs baseline Ubuntu build tooling and Python project dependencies when
+  requested by the helper.
+- Best-effort opens a Dev Containers window.
+
+## Architecture
+
+```text
+Current project
+  |
+  v
+attach-ubuntu helper
+  |
+  v
+Docker container with /workdir bind mount
+  |
+  v
+Optional VS Code Dev Containers attachment
+```
+
+## Workflow
+
+1. Confirm Docker Desktop and the Dev Containers extension are available.
+2. Identify the current project root and container name.
+3. Launch or reuse the project container.
+4. Mount the project at `/workdir`.
+5. Prepare container-local tooling and editor defaults.
+6. Return the container status and commands for manual follow-up.
+
+## Core Concepts
+
+- The container is disposable; project files stay on the host bind mount.
+- Git metadata is preserved because the repository is mounted directly.
+- The helper is meant for local validation, not production deployment.
+
+## Files
+
+- `SKILL.md`: runtime instructions and execution policy.
+- `scripts/attach-ubuntu.sh`: container launch and attachment helper.
+- `agents/openai.yaml`: UI metadata.

--- a/skills/config-codex/README.md
+++ b/skills/config-codex/README.md
@@ -1,0 +1,298 @@
+# Config Codex
+
+`config-codex` is a public Codex skill for bootstrapping a local Codex runtime
+setup similar to the global context-management setup used in this skills repo.
+It packages the design, templates, and validation workflow needed to configure
+Codex without publishing personal paths or secrets.
+
+## What It Does
+
+The skill helps a user create or align this local layout:
+
+```text
+$CODEX_HOME/
+|-- AGENTS.md
+|-- config.toml
+|-- hooks.json
+|-- hooks/
+|   |-- session_start_context.py
+|   `-- user_prompt_context.py
+|-- agents/
+|   |-- repo_mapper.toml
+|   |-- test_strategist.toml
+|   `-- risk_reviewer.toml
+`-- task-state/
+```
+
+It also points Codex at user-installed skills under `$HOME/.agents/skills`,
+including `global-context-management` and `config-codex`.
+
+## Design Goal
+
+The goal is repeatable local setup, not copying a live laptop configuration.
+Public files in this repo stay generic. Rendered files under a user's
+`$CODEX_HOME` can contain that user's real paths, but they should not be
+committed.
+
+The setup is intentionally split into two layers:
+
+- `config-codex`: configures the Codex runtime layout and local policy files.
+- `global-context-management`: governs how Codex should work during complex
+  repository tasks after that runtime setup is active.
+
+## Architecture
+
+```text
+User asks for Codex setup
+  |
+  v
+config-codex skill selects public templates
+  |
+  v
+Existing local files are backed up
+  |
+  v
+$CODEX_HOME is patched or populated
+  |
+  +--> AGENTS.md global policy
+  +--> config.toml features, MCP, skills, custom agents
+  +--> hooks.json and hook scripts
+  +--> read-only custom-agent config layers
+  `--> private task-state directory
+  |
+  v
+Codex is restarted and hooks are reviewed in /hooks
+```
+
+## Core Concepts
+
+### Public Templates, Local Rendering
+
+Assets in this skill use placeholders such as `$CODEX_HOME`, `$HOME`, and
+`<PROJECT_ROOT>`. They are safe to publish. A user or Codex agent renders those
+templates into real files on that user's machine.
+
+### Back Up, Then Patch
+
+Existing `AGENTS.md`, `config.toml`, and `hooks.json` should be backed up
+before changes. For real users, patching is safer than replacing the full file
+because local MCP servers, profiles, app settings, and project trust entries
+may already exist.
+
+For `AGENTS.md` and `config.toml`, patching is not just preferred; it is the
+default contract:
+
+- If the file is missing, create it from the template.
+- If the file exists, preserve unrelated user content and add only the missing
+  guidance, keys, tables, or skill entries.
+- If an existing value conflicts with the template, report it instead of
+  silently overwriting it.
+
+For `AGENTS.md`, add or update only the compact managed context section. For
+`config.toml`, parse the file first and patch the minimum supported settings
+needed for features, MCP servers, custom agent config layers, and skill
+discovery.
+
+### Secrets Stay Out Of Config
+
+The config template references secret environment variable names, not values:
+
+- `CONTEXT7_API_KEY`
+- `GITHUB_TOKEN`
+
+The actual values belong in the user's shell profile, password manager, or
+secret manager. Do not print or commit them.
+
+### Hooks Provide Context
+
+The hook layer injects durable context before Codex starts work:
+
+```text
+Here is the workspace root.
+Here is the task-state file.
+Use global-context-management for complex work.
+Keep the parent thread concise.
+```
+
+Hooks do not implement the task. They make the right context visible to Codex.
+
+### Skills Provide Workflow
+
+`global-context-management` defines the task workflow after hooks inject the
+state path. It tells Codex when to update task state, how to avoid parent-thread
+noise, when to use read-only subagents, and how to validate and review risk.
+
+### Custom Agents Are Read-Only Helpers
+
+The custom agent config layers define three bounded roles:
+
+- `repo_mapper`: maps relevant files, symbols, flows, and conventions.
+- `test_strategist`: identifies focused tests and validation order.
+- `risk_reviewer`: reviews near-final work for defects and missing tests.
+
+They inspect, summarize, and report. The main agent owns edits and final
+decisions.
+
+### Full Access Is A Trusted-Machine Profile
+
+The template mirrors a high-autonomy local developer setup:
+
+```toml
+approval_policy = "never"
+sandbox_mode = "danger-full-access"
+```
+
+Use that profile only on a trusted local machine and trusted repositories. New
+or shared-machine users should tighten these settings before enabling the
+setup.
+
+## Workflow
+
+1. Install the reusable skills:
+
+   ```bash
+   ./install-skills.sh
+   ```
+
+2. Ask Codex to use this skill from the target machine:
+
+   ```text
+   $config-codex Configure my local Codex setup using the public templates. Back up existing files, keep secrets out of config, and validate before telling me it is ready.
+   ```
+
+3. Review the target values:
+
+   ```text
+   $CODEX_HOME=$HOME/.codex
+   skills home=$HOME/.agents/skills
+   project root=<PROJECT_ROOT>
+   ```
+
+4. Let Codex patch local files from the templates in `assets/`. Existing
+   `AGENTS.md` and `config.toml` must be patched in place, not replaced.
+
+5. Validate the rendered setup:
+
+   ```bash
+   python3 -m py_compile \
+     "$CODEX_HOME/hooks/session_start_context.py" \
+     "$CODEX_HOME/hooks/user_prompt_context.py"
+
+   python3 - <<'PY'
+   import os
+   import tomllib
+   from pathlib import Path
+
+   codex_home = Path(os.environ.get("CODEX_HOME", Path.home() / ".codex"))
+   tomllib.loads((codex_home / "config.toml").read_text(encoding="utf-8"))
+   print("config.toml is valid TOML")
+   PY
+
+   python3 - <<'PY'
+   import json
+   import os
+   from pathlib import Path
+
+   codex_home = Path(os.environ.get("CODEX_HOME", Path.home() / ".codex"))
+   json.loads((codex_home / "hooks.json").read_text(encoding="utf-8"))
+   print("hooks.json is valid JSON")
+   PY
+   ```
+
+6. Confirm feature flags:
+
+   ```bash
+   codex features list | rg '^(hooks|multi_agent)\s'
+   ```
+
+   Expected output should show both features enabled:
+
+   ```text
+   hooks        stable  true
+   multi_agent  stable  true
+   ```
+
+7. Restart Codex. For Codex CLI, exit the current session:
+
+   ```text
+   /quit
+   ```
+
+   Then start a fresh session:
+
+   ```bash
+   cd <PROJECT_ROOT>
+   codex
+   ```
+
+   Or start from any directory:
+
+   ```bash
+   codex --cd <PROJECT_ROOT>
+   ```
+
+   For the VS Code extension, run `Developer: Restart Extension Host` from the
+   Command Palette, then open a new Codex chat for the target repo.
+
+8. In the fresh session, open:
+
+   ```text
+   /hooks
+   ```
+
+   Review the two local hook commands. They should point to:
+
+   ```text
+   $CODEX_HOME/hooks/session_start_context.py
+   $CODEX_HOME/hooks/user_prompt_context.py
+   ```
+
+   Trust or enable the hooks only after the paths are local and expected.
+
+9. Run a non-mutating probe:
+
+   ```bash
+   codex exec --ask-for-approval never --cd <PROJECT_ROOT> \
+     "Summarize active instruction sources, available skills/custom agents, and the injected durable task-state path. Do not edit files."
+   ```
+
+   Treat runtime activation as unverified until this probe shows the expected
+   task-state path under:
+
+   ```text
+   $CODEX_HOME/task-state/<workspace>-<hash>/<session-id>/current.md
+   ```
+
+## File Responsibilities
+
+- `SKILL.md`: runtime procedure Codex follows when configuring a user's Codex
+  home.
+- `README.md`: human-facing design, architecture, core concepts, and workflow.
+- `references/local-setup.md`: detailed setup and validation checklist.
+- `assets/AGENTS.md.template`: generic global instruction file.
+- `assets/config.toml.template`: public-safe Codex config template.
+- `assets/hooks.json.template`: hook registration template.
+- `assets/hooks/*.py.template`: context-injection hook templates.
+- `assets/agents/*.toml.template`: read-only custom-agent config templates.
+- `assets/task-state-template.md`: initial durable task-state document.
+- `agents/openai.yaml`: UI metadata and implicit invocation policy.
+
+## Validation For This Skill
+
+From the skills repo root:
+
+```bash
+python3 align-skill/scripts/validate-skill-structure.py config-codex
+markdownlint README.md CHANGELOG.md config-codex/**/*.md
+git diff --check
+```
+
+Also run a targeted public-file scan for personal paths, names, tokens,
+private URLs, and real customer/project identifiers before publishing.
+
+## Sources
+
+- OpenAI Codex skills: <https://developers.openai.com/codex/skills>
+- OpenAI Codex config reference:
+  <https://developers.openai.com/codex/config-reference>
+- OpenAI Codex hooks: <https://developers.openai.com/codex/hooks>

--- a/skills/config-codex/SKILL.md
+++ b/skills/config-codex/SKILL.md
@@ -1,0 +1,137 @@
+---
+name: config-codex
+description: Configure a public-safe Codex home setup for a developer machine, including global AGENTS.md policy, config.toml features and MCP servers, hooks, task-state layout, custom read-only agents, and validation. Use when a user wants Codex configured similarly to this repo's global context-management workflow without copying personal paths or secrets.
+---
+
+# Config Codex
+
+## Purpose
+
+Use this skill to bootstrap or align a user's local Codex runtime setup from
+public-safe templates. The goal is a reusable `$CODEX_HOME` layout with global
+instructions, features, MCP servers, hooks, task-state storage, and custom
+read-only agents that support `global-context-management`.
+
+## Use This Skill For
+
+- Creating or updating a local `$CODEX_HOME` layout.
+- Adding global `AGENTS.md` guidance without replacing unrelated user rules.
+- Patching `config.toml` for supported Codex features, MCP servers, custom
+  agent config layers, and skill discovery.
+- Installing hook and custom-agent templates for global context management.
+- Validating that the resulting local Codex config parses and is ready for
+  hook review.
+
+## Safety Rules
+
+- Never copy a live local config into a public repository.
+- Never persist personal names, absolute home paths, secrets, tokens, private
+  URLs, customer data, raw prompts, command output, stack traces, or broad
+  environment dumps.
+- Store secret values only in the user's shell, password manager, or external
+  secret manager. In `config.toml`, reference secret variable names such as
+  `CONTEXT7_API_KEY` or `GITHUB_TOKEN`.
+- Back up existing local files before editing `AGENTS.md`, `config.toml`, or
+  `hooks.json`.
+- `AGENTS.md` and `config.toml` are patch-only when they already exist. Create
+  them from templates only when they are missing.
+- Do not overwrite, replace, reformat, sort, or regenerate an existing
+  `AGENTS.md` or `config.toml`.
+- Treat full-access settings as intended only for trusted local developer
+  machines.
+
+## Patch-Only Contract
+
+For existing `$CODEX_HOME/AGENTS.md`:
+
+- Preserve all unrelated user rules and ordering.
+- Add a compact `config-codex` managed section only if the equivalent guidance
+  is missing.
+- If managed markers already exist, update only the content between those
+  markers.
+- Do not delete, rewrite, or deduplicate user-authored sections outside the
+  managed block.
+
+For existing `$CODEX_HOME/config.toml`:
+
+- Parse the file before editing.
+- Add only missing keys, tables, or `[[skills.config]]` entries needed for the
+  requested setup.
+- Preserve existing user values, comments, profiles, project trust entries,
+  MCP servers, app settings, and unrelated feature flags.
+- Do not silently change stricter approval or sandbox settings. Report the
+  difference and ask before switching to the trusted-machine full-access
+  profile.
+- If a target MCP server, custom agent, feature flag, or skill entry already
+  exists with different values, report the conflict and patch only after the
+  user confirms the desired value.
+
+## Workflow
+
+1. Identify the target `$CODEX_HOME`; default to `$HOME/.codex`.
+2. Identify the installed skills directory; default to `$HOME/.agents/skills`.
+3. Inspect existing local Codex files with redaction. Do not print secrets.
+4. Back up `AGENTS.md`, `config.toml`, and `hooks.json` when they exist.
+5. Create missing local files from templates, but patch existing
+   `AGENTS.md` and `config.toml` according to the patch-only contract.
+6. Create the local layout:
+   - `$CODEX_HOME/hooks/`
+   - `$CODEX_HOME/agents/`
+   - `$CODEX_HOME/task-state/`
+7. Render or adapt templates from `assets/`:
+   - `AGENTS.md.template`
+   - `config.toml.template`
+   - `hooks.json.template`
+   - hook script templates
+   - custom-agent TOML templates
+   - task-state template
+8. Keep `global-context-management` and `config-codex` installed or enabled as
+   skill folders, not as paths to individual `SKILL.md` files.
+9. Validate local hook scripts, TOML, JSON, feature flags, and secret hygiene.
+10. Tell the user to restart Codex, open `/hooks`, review the two local hooks,
+   and trust them only after confirming the paths are expected.
+
+## Template Rules
+
+Use placeholders in public assets:
+
+- `$CODEX_HOME` for the user's Codex home.
+- `$HOME` for the user's home directory.
+- `$HOME/.agents/skills` for the default user skill install location.
+- `<PROJECT_ROOT>` for the user's trusted repository root.
+
+When writing rendered local files, replace placeholders with that user's real
+paths. Do not commit rendered files. Treat full-file templates as source
+material for missing files; for existing `AGENTS.md` and `config.toml`, extract
+and patch only the missing sections or keys.
+
+## Validation
+
+Use the focused checks in `references/local-setup.md`. At minimum:
+
+- Python-compile hook scripts.
+- Parse `config.toml` with `tomllib`.
+- Parse `hooks.json` with `json`.
+- Confirm `codex features list` reports `hooks` and `multi_agent` enabled.
+- Run a targeted secret/path scan over changed public files.
+
+Do not claim runtime activation is proven until a fresh Codex session has
+loaded the config, the hooks have been trusted in `/hooks`, and a non-mutating
+probe shows the injected task-state path.
+
+## References
+
+- Read `README.md` for the human-facing architecture and core concepts.
+- Read `references/local-setup.md` before applying the setup to a real machine.
+- Use files in `assets/` as templates for rendered local files.
+
+## Output Contract
+
+Return:
+
+- what local files were created or patched
+- what backups were made
+- what validations passed or failed
+- which values still need user-specific replacement
+- how to restart Codex and trust hooks
+- any remaining risk or unverified runtime behavior

--- a/skills/config-codex/agents/openai.yaml
+++ b/skills/config-codex/agents/openai.yaml
@@ -1,0 +1,6 @@
+interface:
+  display_name: "Config Codex"
+  short_description: "Bootstrap a public-safe local Codex runtime setup"
+  default_prompt: "Use $config-codex to configure my local Codex setup from public-safe templates: back up existing files, keep secrets out of config, render global AGENTS.md, config.toml, hooks, custom agents, and task-state layout, then validate and tell me how to restart and trust hooks."
+policy:
+  allow_implicit_invocation: true

--- a/skills/config-codex/assets/AGENTS.md.template
+++ b/skills/config-codex/assets/AGENTS.md.template
@@ -1,0 +1,128 @@
+# Global AGENTS.md
+
+## Purpose
+
+- AGENTS.md is intended as a predictable place to give an agent persistent
+  context and rules that are always on.
+- Keep this file minimal and stable.
+
+## What Belongs Here
+
+- Conventions that apply to most tasks.
+- Security and publication guardrails.
+- Stable coding and review preferences.
+- Global context-management routing.
+- Skill-routing policy.
+
+## What Does Not Belong Here
+
+- On-demand workflows, long step-by-step recipes, or task-specific templates.
+- Raw logs, broad command output, stack traces, or temporary notes.
+- Tool or project-specific scripts and implementations.
+
+## Global Decisions
+
+- Default policy for logic, API, and CLI behavior changes is no legacy
+  compatibility layer and no backward-compatibility shims.
+- When behavior changes, prefer fail-fast behavior and a single canonical path
+  instead of dual old/new code paths.
+- Keep legacy flags, aliases, deprecated branches, migration shims, and
+  compatibility wrappers only when the user explicitly requests them.
+- When making code changes, also update relevant design docs, `README.md`, and
+  the `[Unreleased]` section of `CHANGELOG.md` in the same turn when those
+  files exist and are relevant.
+
+## Security and Publication
+
+- Do not publish or commit any of the following to public repositories or
+  public channels:
+  - API keys, tokens, certificates, or other secrets.
+  - Private endpoints, internal hostnames, or non-public URLs.
+  - Internal confidential materials or customer data.
+  - Proprietary scripts or automation that touches internal infrastructure.
+  - Content copied from internal repos or docs that are not explicitly
+    open-sourced.
+- Never print, persist, or copy secrets into generated files, examples, logs,
+  documentation, task-state files, or final responses.
+- Codex skills should remain public, generic, and reusable, using placeholders
+  for sensitive or environment-specific values.
+
+## Skills
+
+A skill is a set of local instructions to follow that is stored in a
+`SKILL.md` file.
+
+- Skills are discovered dynamically from installed skill directories; do not
+  maintain a static list of all skills in this file.
+- Use a skill for repeatable workflows that should not bloat AGENTS.md.
+- Scripts in skills are reference-only by default. Execute scripts only when
+  the user explicitly requests execution and begins the request with Run,
+  Execute, or an equivalent instruction.
+
+### Skill Auto-Routing
+
+- For non-trivial planning, implementation, debugging, refactoring, migration,
+  architecture, review, testing, CI failure, or multi-file coding tasks, use
+  the `global-context-management` skill.
+- For Codex runtime setup, config, hooks, custom agents, or `$CODEX_HOME`
+  layout work, use the `config-codex` skill.
+- For any request to create, update, fix, or standardize `.gitignore`, always
+  use the `gitignore` skill.
+- For any request to create, refactor, review, or harden shell scripts, Bash,
+  or shell CLI automation, always use the `shell-scripting` skill.
+- For any request to lint, auto-fix, or standardize Shell, Markdown, or Python
+  code quality, always use the `linter` skill.
+- If multiple skill-routing rules apply, use all relevant skills and keep scope
+  minimal.
+- Explicit user requests with `/skill` or `$skill` take precedence.
+- After each pass of code changes, apply the `align` skill.
+
+## Context Management
+
+- Use the durable task-state path injected by global hooks. Do not create
+  repo-local task-state files unless explicitly requested.
+- Keep the parent thread focused on objective, constraints, decisions, current
+  plan, changed files, verification status, risks, and final answer.
+- Keep raw logs, broad file listings, abandoned attempts, broad environment
+  dumps, secrets, customer data, and large copied documentation blocks out of
+  the parent thread.
+- Use bounded read-only subagents for noisy exploration when useful, and use a
+  read-only risk review before finalizing non-trivial changes.
+
+## Memory Policy
+
+- Use Codex memories for stable recurring preferences and repeated
+  project-independent facts.
+- Do not rely on memories for hard requirements. Hard requirements belong in
+  source-controlled project files, tests, CI configuration, AGENTS.md, explicit
+  user instructions, or task-state files.
+- Do not store secrets, private URLs, customer data, or temporary task details
+  in memory.
+
+## Implementation Policy
+
+- Before editing when a task affects multiple files or behavior is unclear,
+  identify the smallest change that satisfies the objective, likely files to
+  change, relevant tests or commands, risks, and rollback points.
+- During implementation, prefer targeted reads over broad scans, implement in
+  small coherent patches, follow existing project conventions, and avoid new
+  dependencies unless necessary.
+- Inspect the diff before running broad checks.
+- Run the narrowest relevant tests first, then broader lint, type, or test
+  commands when appropriate.
+- If tests cannot be run, explain exactly why and provide the command that
+  should be run.
+
+## Vendor Documentation
+
+- For technology, architecture, product, or design questions, verify
+  vendor-specific behavior against official vendor documentation.
+- Do not infer vendor-specific behavior when official documentation is
+  available.
+- If vendor behavior cannot be confirmed from authoritative sources, state that
+  explicitly.
+
+## Final Response Policy
+
+- For code changes, end with a concise summary, files changed, verification
+  performed, and remaining risks or follow-ups.

--- a/skills/config-codex/assets/agents/repo_mapper.toml.template
+++ b/skills/config-codex/assets/agents/repo_mapper.toml.template
@@ -1,0 +1,21 @@
+sandbox_mode = "read-only"
+model_reasoning_effort = "medium"
+developer_instructions = """
+Stay in exploration mode.
+
+Find the smallest useful set of files, symbols, tests, and flows relevant to
+the parent task.
+
+Prefer targeted search and targeted file reads over broad scans.
+
+Do not edit files.
+
+Return:
+- relevant entry points
+- key files and symbols
+- existing conventions
+- likely risks
+- recommended implementation boundaries
+
+Keep the summary concise and actionable.
+"""

--- a/skills/config-codex/assets/agents/risk_reviewer.toml.template
+++ b/skills/config-codex/assets/agents/risk_reviewer.toml.template
@@ -1,0 +1,27 @@
+sandbox_mode = "read-only"
+model_reasoning_effort = "high"
+developer_instructions = """
+Review like a senior owner.
+
+Prioritize real defects over style comments.
+
+Check:
+- correctness
+- regressions
+- security
+- concurrency
+- error handling
+- observability
+- compatibility
+- missing tests
+
+Do not edit files.
+
+Return only concrete findings with:
+- file and symbol
+- why it matters
+- how to reproduce or verify
+- suggested fix direction
+
+If no serious issue is found, say so directly.
+"""

--- a/skills/config-codex/assets/agents/test_strategist.toml.template
+++ b/skills/config-codex/assets/agents/test_strategist.toml.template
@@ -1,0 +1,20 @@
+sandbox_mode = "read-only"
+model_reasoning_effort = "medium"
+developer_instructions = """
+Identify how to verify the requested change.
+
+Do not edit files.
+
+Find existing tests, fixtures, mocks, local commands, CI commands, and
+validation conventions.
+
+Prioritize fast targeted checks before broad suites.
+
+Return:
+- exact test files to inspect or update
+- exact commands to run
+- missing test coverage
+- risk-based verification order
+
+Keep the summary concise and actionable.
+"""

--- a/skills/config-codex/assets/config.toml.template
+++ b/skills/config-codex/assets/config.toml.template
@@ -1,0 +1,98 @@
+#:schema https://developers.openai.com/codex/config-schema.json
+#
+# Public-safe Codex config template.
+# Replace {{CODEX_HOME}}, {{SKILLS_HOME}}, and {{PROJECT_ROOT}} when rendering
+# this file for a real user. Do not commit rendered local files.
+
+model = "gpt-5.5"
+model_reasoning_effort = "xhigh"
+plan_mode_reasoning_effort = "xhigh"
+approval_policy = "never"
+sandbox_mode = "danger-full-access"
+web_search = "live"
+personality = "pragmatic"
+
+project_doc_max_bytes = 65536
+tool_output_token_limit = 12000
+
+[features]
+apps = true
+shell_tool = true
+shell_snapshot = true
+unified_exec = true
+hooks = true
+multi_agent = true
+memories = true
+fast_mode = true
+skill_mcp_dependency_install = true
+
+[agents]
+max_threads = 4
+max_depth = 1
+
+[agents.repo_mapper]
+description = "Read-only codebase explorer for relevant files, symbols, execution paths, dependencies, and conventions."
+nickname_candidates = ["Mapper", "Pathfinder", "Scout"]
+config_file = "agents/repo_mapper.toml"
+
+[agents.test_strategist]
+description = "Read-only verification planner for tests, fixtures, CI commands, local commands, and validation gaps."
+nickname_candidates = ["Verifier", "Test Scout", "Checkmate"]
+config_file = "agents/test_strategist.toml"
+
+[agents.risk_reviewer]
+description = "Read-only reviewer focused on correctness, regressions, security, compatibility, edge cases, and missing tests."
+nickname_candidates = ["Reviewer", "Sentinel", "Auditor"]
+config_file = "agents/risk_reviewer.toml"
+
+[history]
+persistence = "save-all"
+
+[sandbox_workspace_write]
+network_access = true
+writable_roots = ["{{CODEX_HOME}}/task-state"]
+
+[[skills.config]]
+path = "{{SKILLS_HOME}}/global-context-management"
+enabled = true
+
+[[skills.config]]
+path = "{{SKILLS_HOME}}/config-codex"
+enabled = true
+
+[mcp_servers.context7]
+command = "npx"
+args = ["-y", "@upstash/context7-mcp@latest"]
+env_vars = ["CONTEXT7_API_KEY"]
+
+[mcp_servers.playwright]
+command = "npx"
+args = ["-y", "@playwright/mcp@latest"]
+
+[mcp_servers.terraform]
+command = "docker"
+args = ["run", "-i", "--rm", "hashicorp/terraform-mcp-server"]
+
+[mcp_servers.markitdown]
+command = "uvx"
+args = ["markitdown-mcp==0.0.1a4"]
+startup_timeout_sec = 30.0
+
+[mcp_servers.microsoftdocs]
+url = "https://learn.microsoft.com/api/mcp"
+
+[mcp_servers.github]
+url = "https://api.githubcopilot.com/mcp/"
+bearer_token_env_var = "GITHUB_TOKEN"
+
+[mcp_servers.openaiDeveloperDocs]
+url = "https://developers.openai.com/mcp"
+
+[apps._default]
+enabled = true
+
+[projects."{{PROJECT_ROOT}}"]
+trust_level = "trusted"
+
+[projects."{{CODEX_HOME}}"]
+trust_level = "trusted"

--- a/skills/config-codex/assets/hooks.json.template
+++ b/skills/config-codex/assets/hooks.json.template
@@ -1,0 +1,28 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "startup|resume|clear",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 \"{{CODEX_HOME}}/hooks/session_start_context.py\"",
+            "timeout": 10,
+            "statusMessage": "Loading global context policy"
+          }
+        ]
+      }
+    ],
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 \"{{CODEX_HOME}}/hooks/user_prompt_context.py\"",
+            "timeout": 10
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/skills/config-codex/assets/hooks/session_start_context.py.template
+++ b/skills/config-codex/assets/hooks/session_start_context.py.template
@@ -1,0 +1,149 @@
+#!/usr/bin/env python3
+"""Inject a global task-state path at Codex session start.
+
+This hook writes only a minimal task-state scaffold. It does not persist raw
+prompts, command output, stack traces, or secrets.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+from pathlib import Path
+import re
+import subprocess
+import sys
+
+
+STATE_TEMPLATE = """# Current Codex task state
+
+## Workspace
+
+- Root: `{root}`
+
+## Objective
+
+## Constraints
+
+## Current plan
+
+## Decisions made
+
+## Relevant files and symbols
+
+## Commands run
+
+## Test status
+
+## Risks
+
+## Next action
+"""
+
+
+def read_payload() -> dict:
+    try:
+        return json.load(sys.stdin)
+    except Exception:
+        return {}
+
+
+def resolve_root(cwd: str) -> str:
+    cwd = os.path.abspath(cwd)
+
+    try:
+        root = subprocess.check_output(
+            ["git", "-C", cwd, "rev-parse", "--show-toplevel"],
+            text=True,
+            stderr=subprocess.DEVNULL,
+        ).strip()
+    except Exception:
+        root = ""
+
+    return os.path.abspath(root or cwd)
+
+
+def safe_segment(value: str, fallback: str) -> str:
+    safe = re.sub(r"[^A-Za-z0-9._-]+", "-", value).strip("-")
+    return safe[:80] or fallback
+
+
+def chmod_private(path: Path, mode: int) -> None:
+    try:
+        path.chmod(mode)
+    except OSError:
+        pass
+
+
+def state_file_for_payload(root: str, payload: dict) -> Path:
+    codex_home = Path(os.environ.get("CODEX_HOME", Path.home() / ".codex"))
+    codex_home = codex_home.expanduser()
+
+    workspace_name = safe_segment(Path(root).name or "workspace", "workspace")
+    workspace_hash = hashlib.sha256(root.encode("utf-8")).hexdigest()[:12]
+    session_id = payload.get("session_id") or "manual"
+    session_segment = safe_segment(str(session_id), "manual")
+
+    state_dir = (
+        codex_home
+        / "task-state"
+        / f"{workspace_name}-{workspace_hash}"
+        / session_segment
+    )
+    state_dir.mkdir(parents=True, exist_ok=True)
+    chmod_private(codex_home / "task-state", 0o700)
+    chmod_private(state_dir.parent, 0o700)
+    chmod_private(state_dir, 0o700)
+
+    state_file = state_dir / "current.md"
+    if not state_file.exists():
+        state_file.write_text(STATE_TEMPLATE.format(root=root), encoding="utf-8")
+        chmod_private(state_file, 0o600)
+
+    return state_file
+
+
+def main() -> int:
+    payload = read_payload()
+    cwd = payload.get("cwd") or os.getcwd()
+    root = resolve_root(cwd)
+    state_file = state_file_for_payload(root, payload)
+
+    context = f"""Global context management is enabled.
+
+Workspace root: `{root}`
+Durable task-state file: `{state_file}`
+
+Use this task-state file for complex work instead of creating repo-local state
+files.
+
+For non-trivial planning, implementation, debugging, refactoring, migration,
+architecture, review, testing, CI failure, or multi-file work, apply the
+`global-context-management` skill.
+
+Use bounded read-only subagents when useful:
+- `repo_mapper` for code exploration
+- `test_strategist` for verification planning
+- `risk_reviewer` before finalizing risky or non-trivial changes
+
+Keep the parent thread concise and update the task-state file before
+implementation, after major edits, after tests, before compaction, and before
+the final response.
+"""
+
+    print(
+        json.dumps(
+            {
+                "hookSpecificOutput": {
+                    "hookEventName": "SessionStart",
+                    "additionalContext": context,
+                }
+            }
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/config-codex/assets/hooks/user_prompt_context.py.template
+++ b/skills/config-codex/assets/hooks/user_prompt_context.py.template
@@ -1,0 +1,173 @@
+#!/usr/bin/env python3
+"""Inject global context-management guidance for complex prompts."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+from pathlib import Path
+import re
+import subprocess
+import sys
+
+
+COMPLEX_KEYWORDS = (
+    "implement",
+    "refactor",
+    "debug",
+    "fix",
+    "migrate",
+    "migration",
+    "architecture",
+    "design",
+    "test",
+    "tests",
+    "review",
+    "plan",
+    "investigate",
+    "ci",
+    "failing",
+    "failure",
+    "error",
+    "stack trace",
+    "multi-file",
+    "multiple files",
+    "performance",
+    "security",
+    "concurrency",
+    "race",
+    "deadlock",
+    "regression",
+    "root cause",
+    "root-cause",
+)
+
+STATE_TEMPLATE = """# Current Codex task state
+
+## Workspace
+
+- Root: `{root}`
+
+## Objective
+
+## Constraints
+
+## Current plan
+
+## Decisions made
+
+## Relevant files and symbols
+
+## Commands run
+
+## Test status
+
+## Risks
+
+## Next action
+"""
+
+
+def read_payload() -> dict:
+    try:
+        return json.load(sys.stdin)
+    except Exception:
+        return {}
+
+
+def looks_complex(prompt: str) -> bool:
+    lower = prompt.lower()
+    return len(prompt) >= 300 or any(keyword in lower for keyword in COMPLEX_KEYWORDS)
+
+
+def resolve_root(cwd: str) -> str:
+    cwd = os.path.abspath(cwd)
+
+    try:
+        root = subprocess.check_output(
+            ["git", "-C", cwd, "rev-parse", "--show-toplevel"],
+            text=True,
+            stderr=subprocess.DEVNULL,
+        ).strip()
+    except Exception:
+        root = ""
+
+    return os.path.abspath(root or cwd)
+
+
+def safe_segment(value: str, fallback: str) -> str:
+    safe = re.sub(r"[^A-Za-z0-9._-]+", "-", value).strip("-")
+    return safe[:80] or fallback
+
+
+def chmod_private(path: Path, mode: int) -> None:
+    try:
+        path.chmod(mode)
+    except OSError:
+        pass
+
+
+def state_file_for_payload(root: str, payload: dict) -> Path:
+    codex_home = Path(os.environ.get("CODEX_HOME", Path.home() / ".codex"))
+    codex_home = codex_home.expanduser()
+
+    workspace_name = safe_segment(Path(root).name or "workspace", "workspace")
+    workspace_hash = hashlib.sha256(root.encode("utf-8")).hexdigest()[:12]
+    session_id = payload.get("session_id") or "manual"
+    session_segment = safe_segment(str(session_id), "manual")
+
+    state_dir = (
+        codex_home
+        / "task-state"
+        / f"{workspace_name}-{workspace_hash}"
+        / session_segment
+    )
+    state_dir.mkdir(parents=True, exist_ok=True)
+    chmod_private(codex_home / "task-state", 0o700)
+    chmod_private(state_dir.parent, 0o700)
+    chmod_private(state_dir, 0o700)
+
+    state_file = state_dir / "current.md"
+    if not state_file.exists():
+        state_file.write_text(STATE_TEMPLATE.format(root=root), encoding="utf-8")
+        chmod_private(state_file, 0o600)
+
+    return state_file
+
+
+def main() -> int:
+    payload = read_payload()
+    prompt = payload.get("prompt") or ""
+    if not looks_complex(prompt):
+        return 0
+
+    cwd = payload.get("cwd") or os.getcwd()
+    root = resolve_root(cwd)
+    state_file = state_file_for_payload(root, payload)
+
+    context = f"""This prompt should use global context management.
+
+Durable task-state file: `{state_file}`
+
+Apply the `global-context-management` skill. Keep raw exploration output out of
+the parent context. Use `repo_mapper` and `test_strategist` for read-heavy
+exploration when useful. Use `risk_reviewer` before finalizing non-trivial code
+changes.
+"""
+
+    print(
+        json.dumps(
+            {
+                "hookSpecificOutput": {
+                    "hookEventName": "UserPromptSubmit",
+                    "additionalContext": context,
+                }
+            }
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/config-codex/assets/task-state-template.md
+++ b/skills/config-codex/assets/task-state-template.md
@@ -1,0 +1,21 @@
+# Current Codex task state
+
+## Workspace
+
+## Objective
+
+## Constraints
+
+## Current plan
+
+## Decisions made
+
+## Relevant files and symbols
+
+## Commands run
+
+## Test status
+
+## Risks
+
+## Next action

--- a/skills/config-codex/references/local-setup.md
+++ b/skills/config-codex/references/local-setup.md
@@ -1,0 +1,225 @@
+# Local Setup Reference
+
+Use this reference when applying `config-codex` to a real machine. Public repo
+files must stay generic; rendered local files belong under that user's
+`$CODEX_HOME`.
+
+## Inputs
+
+Collect these values first:
+
+```text
+CODEX_HOME=${CODEX_HOME:-$HOME/.codex}
+SKILLS_HOME=$HOME/.agents/skills
+PROJECT_ROOT=<PROJECT_ROOT>
+```
+
+Use real paths only in local rendered files and commands. Do not commit them.
+
+## Backup
+
+Back up existing files before editing:
+
+```bash
+CODEX_HOME="${CODEX_HOME:-$HOME/.codex}"
+ts="$(date +%Y%m%d%H%M%S)"
+
+mkdir -p "$CODEX_HOME"
+
+for file in AGENTS.md config.toml hooks.json; do
+  if [ -f "$CODEX_HOME/$file" ]; then
+    cp "$CODEX_HOME/$file" "$CODEX_HOME/$file.bak.$ts"
+  fi
+done
+```
+
+## Directory Layout
+
+Create the runtime directories:
+
+```bash
+CODEX_HOME="${CODEX_HOME:-$HOME/.codex}"
+
+mkdir -p "$CODEX_HOME/hooks" "$CODEX_HOME/agents" "$CODEX_HOME/task-state"
+chmod 700 "$CODEX_HOME/task-state"
+```
+
+## Create Or Patch From Templates
+
+Use the files in `assets/` as source templates:
+
+```text
+assets/AGENTS.md.template              -> $CODEX_HOME/AGENTS.md
+assets/config.toml.template            -> $CODEX_HOME/config.toml
+assets/hooks.json.template             -> $CODEX_HOME/hooks.json
+assets/hooks/session_start_context.py.template
+  -> $CODEX_HOME/hooks/session_start_context.py
+assets/hooks/user_prompt_context.py.template
+  -> $CODEX_HOME/hooks/user_prompt_context.py
+assets/agents/repo_mapper.toml.template
+  -> $CODEX_HOME/agents/repo_mapper.toml
+assets/agents/test_strategist.toml.template
+  -> $CODEX_HOME/agents/test_strategist.toml
+assets/agents/risk_reviewer.toml.template
+  -> $CODEX_HOME/agents/risk_reviewer.toml
+```
+
+Replace placeholders:
+
+- `{{CODEX_HOME}}` with the user's Codex home.
+- `{{SKILLS_HOME}}` with the user's installed skills directory.
+- `{{PROJECT_ROOT}}` with the user's trusted project root.
+
+If `$CODEX_HOME/AGENTS.md` is missing, create it from
+`assets/AGENTS.md.template`. If it exists, do not replace it. Append or update a
+small managed section for `config-codex`/`global-context-management` guidance
+and leave unrelated user rules untouched.
+
+Recommended managed block markers:
+
+```markdown
+<!-- BEGIN config-codex managed context -->
+...
+<!-- END config-codex managed context -->
+```
+
+If `$CODEX_HOME/config.toml` is missing, create it from
+`assets/config.toml.template` after replacing placeholders. If it exists, do not
+replace it. Parse it first, then add only missing settings:
+
+- `[features]` entries such as `hooks` and `multi_agent`.
+- `[agents]` limits and `[agents.<name>]` custom-agent references.
+- Missing MCP server tables.
+- Missing `[[skills.config]]` entries for skill folder paths.
+- Missing trusted project entries the user explicitly wants.
+
+Preserve existing user values, comments, profiles, project trust entries, MCP
+servers, app settings, and unrelated feature flags. If an existing value
+conflicts with the template, report the difference and ask before changing it.
+Do not silently relax approval or sandbox settings.
+
+## Secret Handling
+
+Do not put actual token values in `config.toml`.
+
+For Context7:
+
+```bash
+export CONTEXT7_API_KEY="<context7-api-key>"
+```
+
+For GitHub MCP:
+
+```bash
+export GITHUB_TOKEN="<github-token>"
+```
+
+Store those exports in the user's preferred local shell or secret-management
+setup. Do not commit them.
+
+## Validation
+
+Compile hooks:
+
+```bash
+python3 -m py_compile \
+  "$CODEX_HOME/hooks/session_start_context.py" \
+  "$CODEX_HOME/hooks/user_prompt_context.py"
+```
+
+Parse TOML:
+
+```bash
+python3 - <<'PY'
+import os
+import tomllib
+from pathlib import Path
+
+codex_home = Path(os.environ.get("CODEX_HOME", Path.home() / ".codex"))
+tomllib.loads((codex_home / "config.toml").read_text(encoding="utf-8"))
+print("config.toml is valid TOML")
+PY
+```
+
+Parse hooks JSON:
+
+```bash
+python3 - <<'PY'
+import json
+import os
+from pathlib import Path
+
+codex_home = Path(os.environ.get("CODEX_HOME", Path.home() / ".codex"))
+json.loads((codex_home / "hooks.json").read_text(encoding="utf-8"))
+print("hooks.json is valid JSON")
+PY
+```
+
+Check features:
+
+```bash
+codex features list | rg '^(hooks|multi_agent)\s'
+```
+
+Expected:
+
+```text
+hooks        stable  true
+multi_agent  stable  true
+```
+
+If needed:
+
+```bash
+codex features enable hooks
+codex features enable multi_agent
+```
+
+## Restart And Trust Hooks
+
+Codex CLI has no separate restart command. Exit:
+
+```text
+/quit
+```
+
+Then start a fresh session:
+
+```bash
+cd <PROJECT_ROOT>
+codex
+```
+
+Or:
+
+```bash
+codex --cd <PROJECT_ROOT>
+```
+
+For VS Code, run `Developer: Restart Extension Host` from the Command Palette.
+
+In the fresh session:
+
+```text
+/hooks
+```
+
+Review the two local hooks and trust them only when the paths point to the
+expected scripts under `$CODEX_HOME/hooks/`.
+
+## Runtime Probe
+
+After trusting hooks, run a non-mutating probe:
+
+```bash
+codex exec --ask-for-approval never --cd <PROJECT_ROOT> \
+  "Summarize active instruction sources, available skills/custom agents, and the injected durable task-state path. Do not edit files."
+```
+
+Expected evidence:
+
+- `global-context-management` is available.
+- `config-codex` is available.
+- `repo_mapper`, `test_strategist`, and `risk_reviewer` are available.
+- The injected task-state path is session-scoped under
+  `$CODEX_HOME/task-state/<workspace>-<hash>/<session-id>/current.md`.

--- a/skills/create-pr/README.md
+++ b/skills/create-pr/README.md
@@ -1,0 +1,57 @@
+# Create PR
+
+`create-pr` turns local work or named branches into reviewable GitHub pull
+requests. It is designed for branch-safe PR creation without hand-driving Git
+and GitHub steps.
+
+## What It Does
+
+- Creates or reuses feature branches.
+- Keeps PR branches conflict-free against the base branch when possible.
+- Opens or reuses GitHub pull requests.
+- Preserves explicit user-supplied PR titles and bodies.
+- Reports PR URLs, readiness, and merge order for multi-branch work.
+
+## Architecture
+
+```text
+Local git state
+  |
+  v
+Branch selection and base refresh
+  |
+  v
+Commit or reuse requested work
+  |
+  v
+Push branch
+  |
+  v
+Open or reuse GitHub PR
+  |
+  v
+Report PR number, URL, and blockers
+```
+
+## Workflow
+
+1. Inspect repository status, remotes, current branch, and base branch.
+2. Select or create the target branch.
+3. Commit requested local work when appropriate.
+4. Refresh against the base branch and handle safe conflicts.
+5. Push the branch.
+6. Open or reuse the PR with the requested title and body.
+7. Return PR details and remaining blockers.
+
+## Core Concepts
+
+- Do not leave new work on the default branch.
+- Do not guess when GitHub authentication, remotes, or branch ownership are
+  unclear.
+- Use draft PRs for incomplete work when that better matches readiness.
+- Preserve one PR per branch.
+
+## Files
+
+- `SKILL.md`: PR creation workflow, guardrails, and command guidance.
+- `agents/openai.yaml`: UI metadata and default prompt.

--- a/skills/github-workflows/README.md
+++ b/skills/github-workflows/README.md
@@ -1,0 +1,53 @@
+# GitHub Workflows
+
+`github-workflows` creates, reviews, and standardizes GitHub Actions workflows
+for repository automation.
+
+## What It Does
+
+- Designs PR and merge CI workflows.
+- Reviews permissions, triggers, concurrency, and checkout behavior.
+- Creates release, image, and chart publication workflows.
+- Keeps workflow filenames, service scope, docs, and scripts aligned.
+- Applies least-privilege defaults where practical.
+
+## Architecture
+
+```text
+Repository automation need
+  |
+  v
+Choose workflow pattern
+  |
+  v
+Render or patch workflow YAML
+  |
+  v
+Align scripts, docs, and changelog
+  |
+  v
+Validate syntax and workflow contracts
+```
+
+## Workflow
+
+1. Identify the workflow purpose and trigger model.
+2. Check existing workflow conventions in the repository.
+3. Apply the smallest workflow change that satisfies the objective.
+4. Align related scripts, documentation, and release notes.
+5. Validate YAML and GitHub Actions behavior with available local tools.
+
+## Core Concepts
+
+- Prefer service-scoped workflows over broad catch-all automation.
+- Use minimal permissions.
+- Avoid hardcoded service lists when a catalog or shared source of truth
+  already exists.
+- Keep bot-safe merge and publish behavior explicit.
+
+## Files
+
+- `SKILL.md`: workflow design and review guidance.
+- `assets/`: reusable workflow templates.
+- `references/`: workflow pattern guidance.
+- `agents/openai.yaml`: UI metadata.

--- a/skills/gitignore/README.md
+++ b/skills/gitignore/README.md
@@ -1,0 +1,47 @@
+# Gitignore
+
+`gitignore` creates or updates project `.gitignore` files with a reusable
+baseline and detected stack-specific additions.
+
+## What It Does
+
+- Adds safe macOS and VS Code defaults.
+- Detects common technology stacks such as Node, Python, Go, Rust, Java, and
+  Terraform.
+- Adds missing ignore rules without removing user-owned entries.
+- Keeps generated, local, cache, and secret-like files out of source control.
+
+## Architecture
+
+```text
+Project files
+  |
+  v
+Detect baseline and stack needs
+  |
+  v
+Patch .gitignore
+  |
+  v
+Review final rules for accidental overreach
+```
+
+## Workflow
+
+1. Inspect the repository layout and existing `.gitignore`.
+2. Add the reusable macOS and editor baseline if missing.
+3. Add stack-specific sections based on detected files.
+4. Preserve existing project-specific rules.
+5. Report the sections added or updated.
+
+## Core Concepts
+
+- Patch existing files rather than replacing them.
+- Do not ignore source files or checked-in templates.
+- Keep local secrets and generated caches out of the repository.
+
+## Files
+
+- `SKILL.md`: runtime workflow and output rules.
+- `assets/gitignore.macos-vscode.template`: reusable baseline template.
+- `agents/openai.yaml`: UI metadata.

--- a/skills/global-context-management/README.md
+++ b/skills/global-context-management/README.md
@@ -1,0 +1,227 @@
+# Global Context Management
+
+`global-context-management` is a reusable Codex skill plus optional local
+runtime setup for keeping long or complex coding sessions focused. It reduces
+context pollution by separating runtime policy, task-state persistence, and
+read-only exploration roles.
+
+## Design Goal
+
+The goal is not to make Codex read less important context. The goal is to make
+Codex keep noisy context out of the parent thread while preserving the facts
+that matter:
+
+- objective and constraints
+- current plan and decisions
+- relevant files and symbols
+- commands and validation status
+- risks and next action
+
+This skill is designed to be global and repo-independent. Public skill files
+stay generic. Machine-local hooks, task-state files, and custom agent config
+belong under `$CODEX_HOME`, which normally defaults to `$HOME/.codex`.
+
+## Architecture
+
+```text
+User prompt
+  |
+  v
+Global hooks inject workspace and task-state context
+  |
+  v
+global-context-management skill defines the task workflow
+  |
+  v
+Main agent owns planning, edits, validation, and final answer
+  |
+  +--> read-only repo_mapper, when useful
+  +--> read-only test_strategist, when useful
+  `--> read-only risk_reviewer, before finalizing risky work
+```
+
+### Hooks
+
+Hooks run before the model starts or before a user prompt is submitted. They
+provide durable context, not implementation logic.
+
+They should say, in effect:
+
+```text
+Here is the workspace root.
+Here is the durable task-state file.
+For complex work, use global-context-management.
+Keep the parent thread concise.
+```
+
+The hooks create a session-scoped task-state path such as:
+
+```text
+$CODEX_HOME/task-state/<workspace>-<hash>/<session-id>/current.md
+```
+
+They must not persist raw prompts, broad command output, stack traces, secrets,
+customer data, private URLs, or broad environment dumps.
+
+### Skill
+
+The skill is the runtime process contract. During a complex task it tells Codex
+how to work:
+
+```text
+Understand the task.
+Update task state.
+Use targeted reads.
+Delegate bounded read-only exploration when useful.
+Plan the smallest coherent change.
+Edit in focused patches.
+Validate narrowly first.
+Review risk before finalizing.
+Update task state and summarize.
+```
+
+`SKILL.md` stays concise because it is loaded into the model context when the
+skill is used. Detailed local setup lives in `references/local-setup.md`.
+
+### Subagents
+
+Subagents are optional read-only helpers. They are useful when exploration is
+large enough that it would pollute the parent thread.
+
+- `repo_mapper`: maps relevant files, symbols, flows, and conventions.
+- `test_strategist`: finds focused tests, fixtures, and validation order.
+- `risk_reviewer`: checks near-final work for correctness, regressions,
+  security, compatibility, edge cases, and missing tests.
+
+Subagents inspect, summarize, and report. They do not edit code. The main agent
+owns consolidation, implementation, final verification, and the final answer.
+
+## Workflow
+
+For a complex task, the intended flow is:
+
+1. Receive prompt and injected task-state context.
+2. Identify the objective, constraints, likely files, and validation path.
+3. Update the task-state file with the current plan.
+4. Use read-only subagents only when they reduce parent-thread noise.
+5. Implement the smallest coherent change in the main thread.
+6. Inspect the diff and run focused validation.
+7. Use a read-only risk review for non-trivial or risky changes.
+8. Address serious findings or record why they are out of scope.
+9. Update task state and return the final summary.
+
+## Your Mental Model
+
+This is the right mental model:
+
+```text
+The hook does this:
+
+Before Codex starts working:
+  "Here is the repo.
+   Here is the task-state file.
+   Use the global workflow for complex work."
+
+The Skill does this:
+
+During the task:
+  "Here is the exact process to follow."
+
+The subagents do this:
+
+When asked by the main agent:
+  "Inspect, summarize, and report.
+   Do not edit code."
+```
+
+One nuance: hooks do not force Codex to follow the workflow by themselves. They
+inject model-visible context. The best-effort automatic behavior comes from the
+combination of global AGENTS routing, hook-injected context, skill metadata, and
+the skill body.
+
+## File Responsibilities
+
+- `SKILL.md`: runtime instructions Codex follows during complex work.
+- `README.md`: human-facing architecture, design, workflow, and mental model.
+- `references/local-setup.md`: local installation and validation details.
+- `assets/`: templates for hooks, task state, and local custom-agent configs.
+- `agents/openai.yaml`: UI metadata and implicit invocation policy.
+
+## Validation
+
+Use static validation before claiming the skill is ready:
+
+```bash
+python3 align-skill/scripts/validate-skill-structure.py global-context-management
+python3 global-context-management/scripts/validate-local-templates.py
+markdownlint README.md CHANGELOG.md global-context-management/**/*.md
+git diff --check
+```
+
+Runtime hook activation is surface-dependent. Treat it as unverified until a
+fresh Codex session has loaded and trusted the hooks.
+
+## Enable And Trust Hooks
+
+After local setup, confirm the required Codex features are enabled:
+
+```bash
+codex features list | rg '^(hooks|multi_agent)\s'
+```
+
+Expected output should show both features enabled:
+
+```text
+hooks        stable  true
+multi_agent  stable  true
+```
+
+If either feature is disabled, enable it and restart Codex:
+
+```bash
+codex features enable hooks
+codex features enable multi_agent
+```
+
+Restart Codex so the updated config and hook files are loaded.
+
+For Codex CLI, there is no separate restart subcommand. Exit the current
+session:
+
+```text
+/quit
+```
+
+Then start Codex again from a shell in the target repo:
+
+```bash
+cd <path-to-target-repo>
+codex
+```
+
+Or start it from any directory by passing the target repo:
+
+```bash
+codex --cd <path-to-target-repo>
+```
+
+For the VS Code extension, run `Developer: Restart Extension Host` from the
+Command Palette, then open a new Codex chat for the target repo.
+
+In the fresh session, open the hook review UI:
+
+```text
+/hooks
+```
+
+Review the two configured hook commands. They should point to the local
+`$CODEX_HOME/hooks/session_start_context.py` and
+`$CODEX_HOME/hooks/user_prompt_context.py` scripts. Trust or enable those hooks
+from the `/hooks` UI only after confirming the paths are local and expected.
+
+After trusting the hooks, start another fresh session and confirm a complex
+prompt receives an injected durable task-state path under:
+
+```text
+$CODEX_HOME/task-state/<workspace>-<hash>/<session-id>/current.md
+```

--- a/skills/global-context-management/SKILL.md
+++ b/skills/global-context-management/SKILL.md
@@ -1,0 +1,119 @@
+---
+name: global-context-management
+description: Use automatically for complex Codex repository work, including implementation, debugging, refactoring, migration, architecture, reviews, tests, CI failures, and multi-file tasks. Keeps long sessions accurate by externalizing durable task state, limiting parent-thread noise, using bounded read-only subagents when useful, and reviewing risk before final answers.
+---
+
+# Global Context Management
+
+## Purpose
+
+Use this skill to keep long or complex Codex work focused and recoverable.
+The workflow keeps durable decisions outside the conversation, delegates noisy
+read-heavy investigation when useful, and keeps the parent thread centered on
+implementation and final judgment.
+
+## Use This Skill For
+
+- Multi-file implementation, refactoring, migration, debugging, or architecture
+  work.
+- CI failures, long logs, test failures, or unclear root-cause investigations.
+- Code review or risk review where many files or contracts may be relevant.
+- Tasks likely to run long enough to hit compaction or lose earlier decisions.
+
+For tiny single-file edits, apply only the lightweight parts: concise
+exploration, minimal task-state notes if already injected, focused validation,
+and a short final summary.
+
+## Non-Goals
+
+- Do not create repo-local task-state files unless the user explicitly asks or
+  no global state path is available.
+- Do not store raw prompts, secrets, command output, stack traces, customer
+  data, private URLs, or environment-specific values in task-state files.
+- Do not make subagents responsible for final decisions. The parent agent owns
+  consolidation, edits, verification, and the final answer.
+- Do not claim runtime hook or skill activation is proven unless it was
+  observed in the current Codex surface.
+
+## Task State
+
+Use the durable task-state path injected by global hooks. If no path is
+available, use `$CODEX_HOME/task-state/manual/current.md`, with
+`$CODEX_HOME` defaulting to `$HOME/.codex`.
+
+Keep task state concise:
+
+```text
+# Current Codex task state
+
+## Workspace
+## Objective
+## Constraints
+## Current plan
+## Decisions made
+## Relevant files and symbols
+## Commands run
+## Test status
+## Risks
+## Next action
+```
+
+Update task state after initial exploration, before implementation, after major
+edits, after validation, before a long pause or compaction, and before the
+final response.
+
+## Parent-Thread Discipline
+
+Keep the parent thread focused on:
+
+- user objective and constraints
+- current plan and decisions
+- files changed
+- verification status
+- risks and final answer
+
+Do not paste broad file listings, raw logs, repeated stack traces, abandoned
+approaches, broad environment dumps, or large copied documentation blocks
+unless the exact text is needed for correctness.
+
+## Subagent Delegation
+
+For complex tasks, use bounded read-only subagents when they materially help:
+
+- `repo_mapper`: map relevant files, symbols, execution paths, and conventions.
+- `test_strategist`: identify focused tests, fixtures, and validation order.
+- `risk_reviewer`: review near-final work for correctness, regressions,
+  security, compatibility, edge cases, and missing tests.
+
+Ask subagents for concise summaries only. Do not use multiple write-capable
+agents in the same workspace unless the user explicitly asks for worktrees or
+parallel implementation.
+
+## Workflow
+
+1. Understand the task and constraints.
+2. Create or update the global task-state file.
+3. Explore with targeted reads and read-only subagents when useful.
+4. Plan the smallest coherent implementation.
+5. Edit in focused patches using existing project conventions.
+6. Inspect the diff.
+7. Run narrow validation first, then broader checks when appropriate.
+8. Use `risk_reviewer` before finalizing non-trivial or risky changes.
+9. Update task state and return the final summary.
+
+## Local Setup
+
+For machine-level installation, read `references/local-setup.md`. Keep local
+runtime files under `$CODEX_HOME`; keep this skill public, generic, and free of
+personal paths or secrets. Use `scripts/validate-local-templates.py` for a
+local-only template smoke test when validating hook setup. For the human-facing
+design and architecture map, read `README.md`.
+
+## Output Contract
+
+For code changes, return:
+
+- summary
+- files changed
+- verification performed
+- remaining risks or follow-ups

--- a/skills/global-context-management/agents/openai.yaml
+++ b/skills/global-context-management/agents/openai.yaml
@@ -1,0 +1,6 @@
+interface:
+  display_name: "Global Context Management"
+  short_description: "Keep long Codex tasks focused and recoverable"
+  default_prompt: "Use $global-context-management to keep this complex Codex task focused: maintain durable task state, delegate bounded read-only exploration when useful, keep noisy output out of the parent thread, validate narrowly first, and review risk before the final answer."
+policy:
+  allow_implicit_invocation: true

--- a/skills/global-context-management/assets/hooks.json.template
+++ b/skills/global-context-management/assets/hooks.json.template
@@ -1,0 +1,28 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "startup|resume|clear",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 \"${CODEX_HOME:-$HOME/.codex}/hooks/session_start_context.py\"",
+            "timeout": 10,
+            "statusMessage": "Loading global context policy"
+          }
+        ]
+      }
+    ],
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 \"${CODEX_HOME:-$HOME/.codex}/hooks/user_prompt_context.py\"",
+            "timeout": 10
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/skills/global-context-management/assets/repo_mapper.toml.template
+++ b/skills/global-context-management/assets/repo_mapper.toml.template
@@ -1,0 +1,21 @@
+sandbox_mode = "read-only"
+model_reasoning_effort = "medium"
+developer_instructions = """
+Stay in exploration mode.
+
+Find the smallest useful set of files, symbols, tests, and flows relevant to
+the parent task.
+
+Prefer targeted search and targeted file reads over broad scans.
+
+Do not edit files.
+
+Return:
+- relevant entry points
+- key files and symbols
+- existing conventions
+- likely risks
+- recommended implementation boundaries
+
+Keep the summary concise and actionable.
+"""

--- a/skills/global-context-management/assets/risk_reviewer.toml.template
+++ b/skills/global-context-management/assets/risk_reviewer.toml.template
@@ -1,0 +1,27 @@
+sandbox_mode = "read-only"
+model_reasoning_effort = "high"
+developer_instructions = """
+Review like a senior owner.
+
+Prioritize real defects over style comments.
+
+Check:
+- correctness
+- regressions
+- security
+- concurrency
+- error handling
+- observability
+- compatibility
+- missing tests
+
+Do not edit files.
+
+Return only concrete findings with:
+- file and symbol
+- why it matters
+- how to reproduce or verify
+- suggested fix direction
+
+If no serious issue is found, say so directly.
+"""

--- a/skills/global-context-management/assets/session_start_context.py.template
+++ b/skills/global-context-management/assets/session_start_context.py.template
@@ -1,0 +1,149 @@
+#!/usr/bin/env python3
+"""Inject a global task-state path at Codex session start.
+
+This hook writes only a minimal task-state scaffold. It does not persist raw
+prompts, command output, stack traces, or secrets.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+from pathlib import Path
+import re
+import subprocess
+import sys
+
+
+STATE_TEMPLATE = """# Current Codex task state
+
+## Workspace
+
+- Root: `{root}`
+
+## Objective
+
+## Constraints
+
+## Current plan
+
+## Decisions made
+
+## Relevant files and symbols
+
+## Commands run
+
+## Test status
+
+## Risks
+
+## Next action
+"""
+
+
+def read_payload() -> dict:
+    try:
+        return json.load(sys.stdin)
+    except Exception:
+        return {}
+
+
+def resolve_root(cwd: str) -> str:
+    cwd = os.path.abspath(cwd)
+
+    try:
+        root = subprocess.check_output(
+            ["git", "-C", cwd, "rev-parse", "--show-toplevel"],
+            text=True,
+            stderr=subprocess.DEVNULL,
+        ).strip()
+    except Exception:
+        root = ""
+
+    return os.path.abspath(root or cwd)
+
+
+def safe_segment(value: str, fallback: str) -> str:
+    safe = re.sub(r"[^A-Za-z0-9._-]+", "-", value).strip("-")
+    return safe[:80] or fallback
+
+
+def chmod_private(path: Path, mode: int) -> None:
+    try:
+        path.chmod(mode)
+    except OSError:
+        pass
+
+
+def state_file_for_payload(root: str, payload: dict) -> Path:
+    codex_home = Path(os.environ.get("CODEX_HOME", Path.home() / ".codex"))
+    codex_home = codex_home.expanduser()
+
+    workspace_name = safe_segment(Path(root).name or "workspace", "workspace")
+    workspace_hash = hashlib.sha256(root.encode("utf-8")).hexdigest()[:12]
+    session_id = payload.get("session_id") or "manual"
+    session_segment = safe_segment(str(session_id), "manual")
+
+    state_dir = (
+        codex_home
+        / "task-state"
+        / f"{workspace_name}-{workspace_hash}"
+        / session_segment
+    )
+    state_dir.mkdir(parents=True, exist_ok=True)
+    chmod_private(codex_home / "task-state", 0o700)
+    chmod_private(state_dir.parent, 0o700)
+    chmod_private(state_dir, 0o700)
+
+    state_file = state_dir / "current.md"
+    if not state_file.exists():
+        state_file.write_text(STATE_TEMPLATE.format(root=root), encoding="utf-8")
+        chmod_private(state_file, 0o600)
+
+    return state_file
+
+
+def main() -> int:
+    payload = read_payload()
+    cwd = payload.get("cwd") or os.getcwd()
+    root = resolve_root(cwd)
+    state_file = state_file_for_payload(root, payload)
+
+    context = f"""Global context management is enabled.
+
+Workspace root: `{root}`
+Durable task-state file: `{state_file}`
+
+Use this task-state file for complex work instead of creating repo-local state
+files.
+
+For non-trivial planning, implementation, debugging, refactoring, migration,
+architecture, review, testing, CI failure, or multi-file work, apply the
+`global-context-management` skill.
+
+Use bounded read-only subagents when useful:
+- `repo_mapper` for code exploration
+- `test_strategist` for verification planning
+- `risk_reviewer` before finalizing risky or non-trivial changes
+
+Keep the parent thread concise and update the task-state file before
+implementation, after major edits, after tests, before compaction, and before
+the final response.
+"""
+
+    print(
+        json.dumps(
+            {
+                "hookSpecificOutput": {
+                    "hookEventName": "SessionStart",
+                    "additionalContext": context,
+                }
+            }
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/global-context-management/assets/task-state-template.md
+++ b/skills/global-context-management/assets/task-state-template.md
@@ -1,0 +1,21 @@
+# Current Codex task state
+
+## Workspace
+
+## Objective
+
+## Constraints
+
+## Current plan
+
+## Decisions made
+
+## Relevant files and symbols
+
+## Commands run
+
+## Test status
+
+## Risks
+
+## Next action

--- a/skills/global-context-management/assets/test_strategist.toml.template
+++ b/skills/global-context-management/assets/test_strategist.toml.template
@@ -1,0 +1,20 @@
+sandbox_mode = "read-only"
+model_reasoning_effort = "medium"
+developer_instructions = """
+Identify how to verify the requested change.
+
+Do not edit files.
+
+Find existing tests, fixtures, mocks, local commands, CI commands, and
+validation conventions.
+
+Prioritize fast targeted checks before broad suites.
+
+Return:
+- exact test files to inspect or update
+- exact commands to run
+- missing test coverage
+- risk-based verification order
+
+Keep the summary concise and actionable.
+"""

--- a/skills/global-context-management/assets/user_prompt_context.py.template
+++ b/skills/global-context-management/assets/user_prompt_context.py.template
@@ -1,0 +1,173 @@
+#!/usr/bin/env python3
+"""Inject global context-management guidance for complex prompts."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+from pathlib import Path
+import re
+import subprocess
+import sys
+
+
+COMPLEX_KEYWORDS = (
+    "implement",
+    "refactor",
+    "debug",
+    "fix",
+    "migrate",
+    "migration",
+    "architecture",
+    "design",
+    "test",
+    "tests",
+    "review",
+    "plan",
+    "investigate",
+    "ci",
+    "failing",
+    "failure",
+    "error",
+    "stack trace",
+    "multi-file",
+    "multiple files",
+    "performance",
+    "security",
+    "concurrency",
+    "race",
+    "deadlock",
+    "regression",
+    "root cause",
+    "root-cause",
+)
+
+STATE_TEMPLATE = """# Current Codex task state
+
+## Workspace
+
+- Root: `{root}`
+
+## Objective
+
+## Constraints
+
+## Current plan
+
+## Decisions made
+
+## Relevant files and symbols
+
+## Commands run
+
+## Test status
+
+## Risks
+
+## Next action
+"""
+
+
+def read_payload() -> dict:
+    try:
+        return json.load(sys.stdin)
+    except Exception:
+        return {}
+
+
+def looks_complex(prompt: str) -> bool:
+    lower = prompt.lower()
+    return len(prompt) >= 300 or any(keyword in lower for keyword in COMPLEX_KEYWORDS)
+
+
+def resolve_root(cwd: str) -> str:
+    cwd = os.path.abspath(cwd)
+
+    try:
+        root = subprocess.check_output(
+            ["git", "-C", cwd, "rev-parse", "--show-toplevel"],
+            text=True,
+            stderr=subprocess.DEVNULL,
+        ).strip()
+    except Exception:
+        root = ""
+
+    return os.path.abspath(root or cwd)
+
+
+def safe_segment(value: str, fallback: str) -> str:
+    safe = re.sub(r"[^A-Za-z0-9._-]+", "-", value).strip("-")
+    return safe[:80] or fallback
+
+
+def chmod_private(path: Path, mode: int) -> None:
+    try:
+        path.chmod(mode)
+    except OSError:
+        pass
+
+
+def state_file_for_payload(root: str, payload: dict) -> Path:
+    codex_home = Path(os.environ.get("CODEX_HOME", Path.home() / ".codex"))
+    codex_home = codex_home.expanduser()
+
+    workspace_name = safe_segment(Path(root).name or "workspace", "workspace")
+    workspace_hash = hashlib.sha256(root.encode("utf-8")).hexdigest()[:12]
+    session_id = payload.get("session_id") or "manual"
+    session_segment = safe_segment(str(session_id), "manual")
+
+    state_dir = (
+        codex_home
+        / "task-state"
+        / f"{workspace_name}-{workspace_hash}"
+        / session_segment
+    )
+    state_dir.mkdir(parents=True, exist_ok=True)
+    chmod_private(codex_home / "task-state", 0o700)
+    chmod_private(state_dir.parent, 0o700)
+    chmod_private(state_dir, 0o700)
+
+    state_file = state_dir / "current.md"
+    if not state_file.exists():
+        state_file.write_text(STATE_TEMPLATE.format(root=root), encoding="utf-8")
+        chmod_private(state_file, 0o600)
+
+    return state_file
+
+
+def main() -> int:
+    payload = read_payload()
+    prompt = payload.get("prompt") or ""
+    if not looks_complex(prompt):
+        return 0
+
+    cwd = payload.get("cwd") or os.getcwd()
+    root = resolve_root(cwd)
+    state_file = state_file_for_payload(root, payload)
+
+    context = f"""This prompt should use global context management.
+
+Durable task-state file: `{state_file}`
+
+Apply the `global-context-management` skill. Keep raw exploration output out of
+the parent context. Use `repo_mapper` and `test_strategist` for read-heavy
+exploration when useful. Use `risk_reviewer` before finalizing non-trivial code
+changes.
+"""
+
+    print(
+        json.dumps(
+            {
+                "hookSpecificOutput": {
+                    "hookEventName": "UserPromptSubmit",
+                    "additionalContext": context,
+                }
+            }
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/global-context-management/references/local-setup.md
+++ b/skills/global-context-management/references/local-setup.md
@@ -1,0 +1,141 @@
+# Local Setup
+
+This reference explains the local-only setup for `global-context-management`.
+Do not copy machine-specific paths, secrets, or task-state contents into a
+public repository.
+
+## Layout
+
+Use `$CODEX_HOME`, defaulting to `$HOME/.codex`:
+
+```text
+$CODEX_HOME/
+|-- AGENTS.md
+|-- config.toml
+|-- hooks.json
+|-- hooks/
+|   |-- session_start_context.py
+|   `-- user_prompt_context.py
+|-- agents/
+|   |-- repo_mapper.toml
+|   |-- test_strategist.toml
+|   `-- risk_reviewer.toml
+`-- task-state/
+```
+
+The source-controlled skill lives in a public skills repository. The runtime
+hooks, custom agent configs, and task-state files live only under
+`$CODEX_HOME`.
+
+Template files for `hooks.json`, hook scripts, custom agent config layers, and
+task-state structure are available in this skill's `assets/` directory. Copy
+or adapt them locally; do not commit the rendered `$CODEX_HOME` files.
+
+## Backup First
+
+Back up existing local Codex files before editing:
+
+```bash
+CODEX_HOME="${CODEX_HOME:-$HOME/.codex}"
+ts="$(date +%Y%m%d%H%M%S)"
+
+cp "$CODEX_HOME/AGENTS.md" "$CODEX_HOME/AGENTS.md.bak.$ts"
+cp "$CODEX_HOME/config.toml" "$CODEX_HOME/config.toml.bak.$ts"
+
+if [ -f "$CODEX_HOME/hooks.json" ]; then
+  cp "$CODEX_HOME/hooks.json" "$CODEX_HOME/hooks.json.bak.$ts"
+fi
+```
+
+## Minimal Global AGENTS.md Addition
+
+Append a compact context-management section to `$CODEX_HOME/AGENTS.md`.
+Keep detailed workflow instructions in this skill instead of expanding the
+global file.
+
+```markdown
+## Context Management
+
+- For non-trivial planning, implementation, debugging, refactoring, migration,
+  architecture, review, testing, CI failure, or multi-file coding tasks, use
+  the `global-context-management` skill.
+- Use the durable task-state path injected by global hooks. Do not create
+  repo-local task-state files unless explicitly requested.
+- Keep the parent thread focused on objective, constraints, decisions, current
+  plan, changed files, verification status, risks, and final answer.
+- Keep raw logs, broad file listings, abandoned attempts, secrets, customer
+  data, broad environment dumps, and large copied documentation blocks out of
+  the parent thread.
+- Use bounded read-only subagents for noisy exploration when useful, and use a
+  read-only risk review before finalizing non-trivial changes.
+```
+
+## Config Snippet
+
+Patch `$CODEX_HOME/config.toml`; do not replace the whole file. Use config
+layers for custom agents:
+
+```toml
+[features]
+hooks = true
+multi_agent = true
+
+[agents]
+max_threads = 4
+max_depth = 1
+
+[agents.repo_mapper]
+description = "Read-only codebase explorer for relevant files, symbols, execution paths, dependencies, and conventions."
+nickname_candidates = ["Mapper", "Pathfinder", "Scout"]
+config_file = "agents/repo_mapper.toml"
+
+[agents.test_strategist]
+description = "Read-only verification planner for tests, fixtures, CI commands, local commands, and validation gaps."
+nickname_candidates = ["Verifier", "Test Scout", "Checkmate"]
+config_file = "agents/test_strategist.toml"
+
+[agents.risk_reviewer]
+description = "Read-only reviewer focused on correctness, regressions, security, compatibility, edge cases, and missing tests."
+nickname_candidates = ["Reviewer", "Sentinel", "Auditor"]
+config_file = "agents/risk_reviewer.toml"
+```
+
+If an MCP server currently stores a secret directly in `config.toml`, move it
+to an environment variable and configure the server to use `env_vars`.
+
+## Hook Review
+
+After adding or changing hooks, restart Codex and use `/hooks` to review and
+trust the new non-managed hooks before relying on them.
+
+The provided `hooks.json` template resolves hook scripts through
+`${CODEX_HOME:-$HOME/.codex}`. If you use a non-default `CODEX_HOME`, confirm
+the `/hooks` UI shows commands pointing at that directory.
+
+## Validation
+
+Run:
+
+```bash
+python3 <path-to-skill>/scripts/validate-local-templates.py
+
+python3 -m py_compile \
+  "$CODEX_HOME/hooks/session_start_context.py" \
+  "$CODEX_HOME/hooks/user_prompt_context.py"
+
+python3 - <<'PY'
+import os
+import tomllib
+from pathlib import Path
+
+codex_home = Path(os.environ.get("CODEX_HOME", Path.home() / ".codex"))
+tomllib.loads((codex_home / "config.toml").read_text(encoding="utf-8"))
+print("config.toml is valid TOML")
+PY
+
+codex features list
+```
+
+Then run a non-mutating Codex probe from a test repository and confirm the
+injected task-state path appears. Treat runtime activation as unverified until
+observed in the target Codex surface.

--- a/skills/global-context-management/scripts/validate-local-templates.py
+++ b/skills/global-context-management/scripts/validate-local-templates.py
@@ -1,0 +1,200 @@
+#!/usr/bin/env python3
+"""Validate global-context-management local runtime templates.
+
+This check is local-only and uses disposable directories. It does not read or
+write the user's real Codex home.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+import re
+import shutil
+import stat
+import subprocess
+import sys
+import tempfile
+import tomllib
+
+
+ROOT_MARKERS = ("SKILL.md", "assets", "references")
+SENTINEL_MARKER = "PROMPT_CONTENT_SENTINEL_DO_NOT_PERSIST"
+
+
+def skill_dir() -> Path:
+    path = Path(__file__).resolve().parent.parent
+    missing = [marker for marker in ROOT_MARKERS if not (path / marker).exists()]
+    if missing:
+        raise AssertionError(f"cannot locate skill root from {path}: missing {missing}")
+    return path
+
+
+def parse_templates(root: Path) -> dict:
+    hooks_template = root / "assets" / "hooks.json.template"
+    hooks = json.loads(hooks_template.read_text(encoding="utf-8"))
+
+    for path in sorted((root / "assets").glob("*.toml.template")):
+        tomllib.loads(path.read_text(encoding="utf-8"))
+
+    for path in (
+        root / "assets" / "session_start_context.py.template",
+        root / "assets" / "user_prompt_context.py.template",
+    ):
+        compile(path.read_text(encoding="utf-8"), str(path), "exec")
+
+    return hooks
+
+
+def run_hook(script: Path, payload: dict, env: dict[str, str]) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(script)],
+        input=json.dumps(payload),
+        text=True,
+        capture_output=True,
+        check=True,
+        env=env,
+    )
+
+
+def extract_state_path(output: str) -> Path:
+    payload = json.loads(output)
+    context = payload["hookSpecificOutput"]["additionalContext"]
+    match = re.search(r"Durable task-state file: `([^`]+)`", context)
+    if not match:
+        raise AssertionError(f"state path missing from context: {context}")
+    return Path(match.group(1))
+
+
+def assert_private_file(path: Path) -> None:
+    mode = stat.S_IMODE(path.stat().st_mode)
+    if mode != 0o600:
+        raise AssertionError(f"{path} mode is {oct(mode)}, expected 0o600")
+
+
+def assert_no_prompt_leak(state_file: Path) -> None:
+    text = state_file.read_text(encoding="utf-8")
+    if SENTINEL_MARKER in text:
+        raise AssertionError("hook persisted prompt content into task state")
+
+
+def validate_direct_hooks(root: Path, codex_home: Path, home: Path) -> None:
+    hooks_dir = codex_home / "hooks"
+    hooks_dir.mkdir(parents=True)
+
+    session_script = hooks_dir / "session_start_context.py"
+    user_script = hooks_dir / "user_prompt_context.py"
+    shutil.copyfile(root / "assets" / "session_start_context.py.template", session_script)
+    shutil.copyfile(root / "assets" / "user_prompt_context.py.template", user_script)
+
+    env = {
+        **os.environ,
+        "CODEX_HOME": str(codex_home),
+        "HOME": str(home),
+    }
+    cwd = str(root)
+    session_payload = {
+        "session_id": "session one/with spaces",
+        "cwd": cwd,
+        "hook_event_name": "SessionStart",
+        "source": "startup",
+        "model": "test-model",
+    }
+    session_result = run_hook(session_script, session_payload, env)
+    state_file = extract_state_path(session_result.stdout)
+    if not state_file.exists():
+        raise AssertionError(f"state file was not created: {state_file}")
+    if not str(state_file).startswith(str(codex_home / "task-state") + os.sep):
+        raise AssertionError(f"state file is outside CODEX_HOME: {state_file}")
+    assert_private_file(state_file)
+
+    simple_payload = {
+        "session_id": "session one/with spaces",
+        "cwd": cwd,
+        "hook_event_name": "UserPromptSubmit",
+        "turn_id": "turn-simple",
+        "prompt": "hello",
+    }
+    simple_result = run_hook(user_script, simple_payload, env)
+    if simple_result.stdout:
+        raise AssertionError("simple prompt unexpectedly produced hook context")
+
+    complex_payload = {
+        "session_id": "session one/with spaces",
+        "cwd": cwd,
+        "hook_event_name": "UserPromptSubmit",
+        "turn_id": "turn-complex",
+        "prompt": (
+            "Please review and test hooks end to end. "
+            f"Do not persist {SENTINEL_MARKER} in task state."
+        ),
+    }
+    complex_result = run_hook(user_script, complex_payload, env)
+    context = json.loads(complex_result.stdout)["hookSpecificOutput"]["additionalContext"]
+    if "Apply the `global-context-management` skill" not in context:
+        raise AssertionError("complex prompt did not request the skill")
+    if SENTINEL_MARKER in context:
+        raise AssertionError("hook echoed prompt content into model context")
+    assert_no_prompt_leak(state_file)
+
+
+def validate_hooks_json_command(root: Path, hooks: dict, temp_dir: Path) -> None:
+    custom_home = temp_dir / "custom-codex-home"
+    normal_home = temp_dir / "normal-home"
+    hooks_dir = custom_home / "hooks"
+    hooks_dir.mkdir(parents=True)
+    normal_home.mkdir()
+    shutil.copyfile(
+        root / "assets" / "session_start_context.py.template",
+        hooks_dir / "session_start_context.py",
+    )
+
+    command = hooks["hooks"]["SessionStart"][0]["hooks"][0]["command"]
+    env = {
+        **os.environ,
+        "CODEX_HOME": str(custom_home),
+        "HOME": str(normal_home),
+    }
+    payload = {
+        "session_id": "mismatch",
+        "cwd": str(root),
+        "hook_event_name": "SessionStart",
+        "source": "startup",
+    }
+    result = subprocess.run(
+        command,
+        input=json.dumps(payload),
+        text=True,
+        capture_output=True,
+        shell=True,
+        check=True,
+        env=env,
+    )
+    state_file = extract_state_path(result.stdout)
+    if not str(state_file).startswith(str(custom_home / "task-state") + os.sep):
+        raise AssertionError(
+            "hooks.json command did not respect CODEX_HOME override: "
+            f"{state_file}"
+        )
+
+
+def main() -> int:
+    root = skill_dir()
+    hooks = parse_templates(root)
+
+    with tempfile.TemporaryDirectory(prefix="gcm-template-test-") as temp:
+        temp_dir = Path(temp)
+        validate_direct_hooks(
+            root=root,
+            codex_home=temp_dir / ".codex",
+            home=temp_dir / "home-default",
+        )
+        validate_hooks_json_command(root=root, hooks=hooks, temp_dir=temp_dir)
+
+    print("global-context-management local templates validated")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/helmchart/README.md
+++ b/skills/helmchart/README.md
@@ -1,0 +1,50 @@
+# Helm Chart
+
+`helmchart` reviews, hardens, refactors, creates, lints, and standardizes Helm
+charts.
+
+## What It Does
+
+- Reviews chart metadata, values, schemas, templates, notes, and README files.
+- Checks Kubernetes and Helm rendering behavior.
+- Improves values design, validation, security context, RBAC, and chart CI.
+- Uses focused Helm commands to validate actual rendered output.
+
+## Architecture
+
+```text
+Helm chart
+  |
+  +--> Chart.yaml
+  +--> values.yaml and values.schema.json
+  +--> templates/
+  +--> README and NOTES
+  `--> chart CI
+        |
+        v
+helmchart applies review, patch, and validation workflow
+```
+
+## Workflow
+
+1. Inspect chart structure and chart-owned files.
+2. Review values and template contracts.
+3. Patch only chart surfaces that are in scope.
+4. Run focused `helm lint` and `helm template` validation.
+5. Report rendered behavior, remaining risks, and follow-up checks.
+
+## Core Concepts
+
+- Validate Helm whitespace and conditional logic by rendering, not by visual
+  indentation alone.
+- Keep upstream-owned and chart-owned surfaces separate.
+- Avoid changing plain Kubernetes, Kustomize, Docker, or Terraform files unless
+  the task explicitly connects them to the chart.
+
+## Files
+
+- `SKILL.md`: chart workflow, validation commands, and guardrails.
+- `scripts/validate-chart.sh`: reusable chart validation helper.
+- `references/best-practices-checklist.md`: chart review checklist.
+- `evals/trigger-prompts.csv`: trigger examples.
+- `agents/openai.yaml`: UI metadata.

--- a/skills/linter/README.md
+++ b/skills/linter/README.md
@@ -1,0 +1,47 @@
+# Linter
+
+`linter` runs a fix-first linting workflow for shell scripts, Markdown, and
+Python files.
+
+## What It Does
+
+- Checks shell scripts with `bash -n` and `shellcheck`.
+- Checks Markdown with `markdownlint`.
+- Checks Python with `ruff`.
+- Applies safe automatic fixes before adding fallback config.
+- Reports commands run and remaining manual fixes.
+
+## Architecture
+
+```text
+Repository files
+  |
+  v
+Detect Shell, Markdown, and Python surfaces
+  |
+  v
+Run fix-first linting workflow
+  |
+  v
+Patch safe issues or report blockers
+```
+
+## Workflow
+
+1. Identify relevant file types.
+2. Run the narrowest useful lint checks.
+3. Apply safe automatic fixes when requested or appropriate.
+4. Add targeted fallback lint config only when needed.
+5. Re-run checks and report status.
+
+## Core Concepts
+
+- Prefer fixing files over weakening lint rules.
+- Keep fallback config narrow and justified.
+- Do not hide real syntax or formatting failures.
+
+## Files
+
+- `SKILL.md`: lint workflow and command policy.
+- `scripts/lint-repo.sh`: reusable lint helper.
+- `agents/openai.yaml`: UI metadata.

--- a/skills/nebius/README.md
+++ b/skills/nebius/README.md
@@ -1,0 +1,55 @@
+# Nebius
+
+`nebius` supports Nebius cloud automation with the Nebius SDK and related
+infrastructure workflows.
+
+## What It Does
+
+- Builds and reviews Nebius IAM, Object Storage, VPC, route, and quota
+  automation.
+- Helps design service accounts, access keys, Terraform state buckets, and
+  auth bootstrap flows.
+- Supports MK8s GPU compatibility, quota readiness, and operator decisions.
+- Documents observability endpoints and onboarding patterns.
+
+## Architecture
+
+```text
+Nebius task
+  |
+  v
+Select domain reference or helper
+  |
+  +--> IAM and auth
+  +--> VPC and routes
+  +--> quotas and capacity
+  +--> observability
+  `--> MK8s GPU readiness
+  |
+  v
+Implement, inspect, or validate with least exposure
+```
+
+## Workflow
+
+1. Identify the Nebius domain and safety level.
+2. Load only the relevant reference file or asset.
+3. Prefer SDK-supported behavior and documented API contracts.
+4. Avoid printing secrets or live sensitive identifiers.
+5. Run local or disposable validation when safe.
+6. Report cleanup, residual risk, and any unverified live behavior.
+
+## Core Concepts
+
+- Treat live cloud changes as high impact.
+- Use placeholders in public docs.
+- Prefer environment-driven or catalog-driven behavior over hardcoding.
+- Cleanup evidence matters when live resources are created.
+
+## Files
+
+- `SKILL.md`: Nebius workflow, guardrails, assets, and references.
+- `references/`: focused Nebius domain guidance.
+- `scripts/`: read-only inspection helpers.
+- `assets/`: reusable IAM, observability, and GPU examples.
+- `agents/openai.yaml`: UI metadata.

--- a/skills/onboard-nebius-cxcli/README.md
+++ b/skills/onboard-nebius-cxcli/README.md
@@ -1,0 +1,48 @@
+# Onboard Nebius CXCLI
+
+`onboard-nebius-cxcli` guides onboarding a Nebius Terraform module into
+`nebius-cxcli`.
+
+## What It Does
+
+- Decides whether onboarding can stay catalog-only or needs code-owned layers.
+- Aligns component sources, CLI settings, wizard behavior, validation,
+  deployment status, cluster handoffs, tests, and docs.
+- Keeps module onboarding tied to actual `nebius-cxcli` contracts.
+
+## Architecture
+
+```text
+Terraform module
+  |
+  v
+component_sources.yaml and component_cli_settings.yaml
+  |
+  +--> optional wizard/provider code
+  +--> optional validation profiles
+  +--> optional runtime validation
+  +--> optional status and handoff code
+  |
+  v
+tests, docs, and changelog alignment
+```
+
+## Workflow
+
+1. Inspect the module and existing component catalog patterns.
+2. Decide whether catalog-only onboarding is sufficient.
+3. Patch catalog entries and only the code-owned layers that are required.
+4. Update focused tests, docs, and changelog entries.
+5. Validate generated configs and affected CLI behavior.
+
+## Core Concepts
+
+- Prefer catalog-first onboarding.
+- Do not hardcode component behavior when catalog data can express it.
+- Keep generated artifacts, docs, and CLI contracts aligned.
+
+## Files
+
+- `SKILL.md`: onboarding workflow and guardrails.
+- `references/touchpoints.md`: detailed cxcli touchpoint map.
+- `agents/openai.yaml`: UI metadata.

--- a/skills/publish-helm/README.md
+++ b/skills/publish-helm/README.md
@@ -1,0 +1,45 @@
+# Publish Helm
+
+`publish-helm` generates a Nebius OCI Helm chart publication flow.
+
+## What It Does
+
+- Creates a chart-local `CHANGELOG.md`.
+- Creates a chart-local `publish-helm.sh`.
+- Registers the chart in a shared tag-driven GitHub Actions workflow.
+- Supports release prep and publication checks.
+- Includes public pull verification guidance where applicable.
+
+## Architecture
+
+```text
+Helm chart
+  |
+  +--> chart-local changelog
+  +--> publish-helm.sh helper
+  `--> shared helm-chart-publish workflow registration
+        |
+        v
+Tag-driven OCI chart publication
+```
+
+## Workflow
+
+1. Collect chart name, path, version, registry, and release tag pattern.
+2. Create or update chart-local release assets.
+3. Register the chart in the shared publish workflow.
+4. Validate script syntax, chart metadata, and workflow YAML.
+5. Report prep, publish, and verification commands.
+
+## Core Concepts
+
+- Keep chart release notes with the chart.
+- Separate release preparation from publication.
+- Avoid hardcoded per-chart workflow branches when shared registration is
+  available.
+
+## Files
+
+- `SKILL.md`: Helm publication workflow and guardrails.
+- `assets/`: changelog and publish helper templates.
+- `agents/openai.yaml`: UI metadata.

--- a/skills/publish-image/README.md
+++ b/skills/publish-image/README.md
@@ -1,0 +1,43 @@
+# Publish Image
+
+`publish-image` generates a container image publication workflow.
+
+## What It Does
+
+- Creates a project-local `CHANGELOG.md`.
+- Creates a `publish-image.sh` helper.
+- Creates a tag-driven GitHub Actions image publication workflow.
+- Supports manual dispatch controls and immutable tagging.
+
+## Architecture
+
+```text
+Containerized project
+  |
+  +--> changelog
+  +--> publish-image.sh
+  `--> image publish workflow
+        |
+        v
+Build, tag, and publish image
+```
+
+## Workflow
+
+1. Collect project name, image name, registry, Dockerfile path, and tag policy.
+2. Add release assets from templates.
+3. Wire workflow triggers and permissions.
+4. Validate shell, workflow YAML, and image metadata assumptions.
+5. Report publish commands and remaining registry prerequisites.
+
+## Core Concepts
+
+- Prefer immutable release tags.
+- Keep registry credentials out of source control.
+- Keep script behavior, workflow behavior, docs, and changelog aligned.
+
+## Files
+
+- `SKILL.md`: image publication workflow and guardrails.
+- `assets/`: changelog, shell helper, and workflow templates.
+- `agents/openai.yaml`: UI metadata.

--- a/skills/publish-release/README.md
+++ b/skills/publish-release/README.md
@@ -1,0 +1,45 @@
+# Publish Release
+
+`publish-release` generates a default application release publication flow with
+GitHub Releases.
+
+## What It Does
+
+- Creates a project-local `CHANGELOG.md`.
+- Creates a `publish-release.sh` helper.
+- Creates a tag-driven GitHub Release workflow.
+- Adds artifact and version verification where applicable.
+
+## Architecture
+
+```text
+Application project
+  |
+  +--> changelog
+  +--> publish-release.sh
+  `--> release publish workflow
+        |
+        v
+Tag-driven GitHub Release
+```
+
+## Workflow
+
+1. Collect project name, artifact paths, version source, and tag pattern.
+2. Add or update release assets from templates.
+3. Wire the GitHub Actions workflow.
+4. Validate shell syntax, workflow YAML, and artifact assumptions.
+5. Report release prep and publication steps.
+
+## Core Concepts
+
+- Prefer tag-driven GitHub Releases for default release automation.
+- Keep release metadata close to the project being released.
+- Use `release-generator` only when the user explicitly wants local manual
+  releases and no CI workflow.
+
+## Files
+
+- `SKILL.md`: application release workflow and guardrails.
+- `assets/`: changelog, shell helper, and workflow templates.
+- `agents/openai.yaml`: UI metadata.

--- a/skills/python-project/README.md
+++ b/skills/python-project/README.md
@@ -1,0 +1,50 @@
+# Python Project
+
+`python-project` scaffolds and hardens Python projects with reusable modern
+defaults.
+
+## What It Does
+
+- Creates or improves `pyproject.toml` based projects.
+- Uses `src/` layout, setuptools-scm, Ruff, pytest, Typer, and Pydantic where
+  appropriate.
+- Supports CLI tools, systemd services, APIs, UI apps, IaC automation, security
+  tooling, and AI/ML workflows.
+- Adds templates, tests, Makefile targets, and CI scaffolding when requested.
+
+## Architecture
+
+```text
+Python project request
+  |
+  v
+Choose project profile
+  |
+  +--> base package layout
+  +--> CLI or service/API templates
+  +--> tests and fixtures
+  +--> lint and CI config
+  `--> docs and release metadata
+```
+
+## Workflow
+
+1. Identify project type and risk profile.
+2. Inspect existing files before scaffolding.
+3. Add only the needed templates and dependencies.
+4. Align tests, linting, docs, and CI.
+5. Run focused Python validation.
+
+## Core Concepts
+
+- Prefer `pyproject.toml` and `src/` layout.
+- Keep compatibility shims minimal and justified.
+- Do not introduce dependencies without a clear project need.
+- Make generated examples executable where practical.
+
+## Files
+
+- `SKILL.md`: Python scaffolding workflow and guardrails.
+- `assets/`: project templates.
+- `references/`: profile-specific guidance.
+- `agents/openai.yaml`: UI metadata.

--- a/skills/release-generator/README.md
+++ b/skills/release-generator/README.md
@@ -1,0 +1,45 @@
+# Release Generator
+
+`release-generator` is the manual release-script fallback. Use it only when the
+user explicitly asks for local manual release publishing with no CI workflow.
+
+## What It Does
+
+- Generates or reviews a local `release.sh` script.
+- Supports preparing, publishing, verifying, and retagging manual releases.
+- Keeps tag format and release safety explicit.
+- Defers to `publish-release` for the default tag-driven CI workflow.
+
+## Architecture
+
+```text
+Explicit manual release request
+  |
+  v
+release.sh helper
+  |
+  +--> prepare
+  +--> publish
+  +--> verify
+  `--> retag safety
+```
+
+## Workflow
+
+1. Confirm the user wants manual local release publishing.
+2. Collect project name, artifacts, version source, and tag format.
+3. Generate or patch `release.sh`.
+4. Validate shell syntax and command safety.
+5. Report manual release steps and risks.
+
+## Core Concepts
+
+- Do not use this for default CI-backed releases.
+- Make destructive retagging explicit.
+- Keep release commands reproducible and auditable.
+
+## Files
+
+- `SKILL.md`: manual release workflow and routing rule.
+- `scripts/release.sh`: reference release helper.
+- `agents/openai.yaml`: UI metadata.

--- a/skills/review-pr/README.md
+++ b/skills/review-pr/README.md
@@ -1,0 +1,48 @@
+# Review PR
+
+`review-pr` reviews GitHub pull requests and safely moves them closer to
+merge-readiness when permissions allow.
+
+## What It Does
+
+- Reviews PRs by number, URL, or current branch.
+- Inspects base branch, checks, review state, conflicts, and open concerns.
+- Fixes safe issues on writable branches.
+- Resolves straightforward conflicts when safe.
+- Reports whether the PR is ready to merge and what blockers remain.
+
+## Architecture
+
+```text
+PR target
+  |
+  v
+Fetch GitHub and git state
+  |
+  v
+Review checks, diffs, conflicts, and comments
+  |
+  +--> apply safe fixes when writable
+  `--> report blockers when not writable or unsafe
+```
+
+## Workflow
+
+1. Resolve the PR target and base branch.
+2. Inspect working tree state and branch ownership.
+3. Review checks, comments, diff, and conflicts.
+4. Apply relevant sibling skills for concrete file types.
+5. Fix safe issues and rerun focused validation.
+6. Report readiness, remaining blockers, and merge guidance.
+
+## Core Concepts
+
+- Findings lead; summaries come after issues.
+- Do not rewrite externally owned branches without permission.
+- Preserve reviewer concerns as explicit blockers until resolved.
+- Prefer non-destructive updates for shared branches.
+
+## Files
+
+- `SKILL.md`: PR review and repair workflow.
+- `agents/openai.yaml`: UI metadata.

--- a/skills/shell-scripting/README.md
+++ b/skills/shell-scripting/README.md
@@ -1,0 +1,48 @@
+# Shell Scripting
+
+`shell-scripting` creates, refactors, and reviews Bash and shell automation.
+
+## What It Does
+
+- Builds strict, idempotent shell scripts.
+- Uses safe argument parsing and clear usage output.
+- Adds readable logging and color fallback where appropriate.
+- Validates scripts with syntax and lint checks.
+- Keeps shell behavior aligned with docs and examples.
+
+## Architecture
+
+```text
+Shell automation request
+  |
+  v
+Inspect existing script or requirements
+  |
+  v
+Apply Bash safety and UX conventions
+  |
+  v
+Validate with shell-focused checks
+```
+
+## Workflow
+
+1. Identify the target shell and portability requirements.
+2. Inspect existing scripts and calling docs.
+3. Patch or create the smallest script that satisfies the workflow.
+4. Add usage, logging, dry-run, and idempotency behavior when relevant.
+5. Run `bash -n` and `shellcheck` when available.
+
+## Core Concepts
+
+- Prefer strict mode and explicit error handling.
+- Quote variables and avoid unsafe word splitting.
+- Keep destructive actions guarded and visible.
+- Avoid clever shell when straightforward code is safer.
+
+## Files
+
+- `SKILL.md`: shell workflow, practices, and output style.
+- `assets/script-template.sh`: reusable script template.
+- `references/best-practices.md`: detailed shell guidance.
+- `agents/openai.yaml`: UI metadata.

--- a/skills/terraform/README.md
+++ b/skills/terraform/README.md
@@ -1,0 +1,47 @@
+# Terraform
+
+`terraform` generates and hardens Terraform modules and infrastructure
+repositories.
+
+## What It Does
+
+- Scaffolds module and multi-environment Terraform layouts.
+- Reviews state, backend, provider, variable, output, and validation design.
+- Adds examples, documentation, CI checks, and security guardrails.
+- Keeps generated Terraform idiomatic and maintainable.
+
+## Architecture
+
+```text
+Terraform request
+  |
+  v
+Choose layout profile
+  |
+  +--> reusable module
+  +--> environment repository
+  `--> examples and tests
+        |
+        v
+Validation, docs, and CI alignment
+```
+
+## Workflow
+
+1. Identify whether the target is a module or environment repo.
+2. Inspect existing Terraform files and provider constraints.
+3. Add or patch layout, variables, outputs, examples, and docs.
+4. Run `terraform fmt` and `terraform validate` when available.
+5. Report any skipped plan/apply steps and required credentials.
+
+## Core Concepts
+
+- Prefer explicit variables, outputs, and validation blocks.
+- Keep state/backend guidance clear and environment-specific.
+- Do not run apply-like operations without explicit confirmation.
+- Avoid hardcoded provider or environment values in reusable modules.
+
+## Files
+
+- `SKILL.md`: Terraform structure, workflow, and guardrails.
+- `agents/openai.yaml`: UI metadata.


### PR DESCRIPTION
## Summary
- add the `config-codex` skill for public-safe local Codex runtime setup templates
- add the `global-context-management` skill with durable task-state hooks, custom-agent templates, and validation helper
- add skill-local README files across reusable skills and wire the new skills into `skills/README.md` and `skills/CHANGELOG.md`

## Validation
- `git diff --cached --check`
- `git diff --check origin/main...HEAD`
- staged conflict-marker and public secret/path scans
- `markdownlint` on staged Markdown files
- Ruby YAML parse for `skills/*/agents/openai.yaml`
- `python3 skills/global-context-management/scripts/validate-local-templates.py`
- `python3 -m py_compile skills/global-context-management/scripts/validate-local-templates.py`
- config-codex JSON/TOML parse and hook-template compile smoke test
