### PR TITLE
Prepare Soperator chart release 4.0.2-ps.1

### DIFF
--- a/helm-charts/soperator/CHANGELOG.md
+++ b/helm-charts/soperator/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this chart are tracked here.
 
 ## [Unreleased]
 
+## [soperator-chart-v4.0.2-ps.1] - 2026-06-12
+
 - Bumped Soperator upstream release to 4.0.2 and Helm chart package to
   4.0.2-ps.1.
 - Made the upstream sync workflow and `publish-helm.sh --prep` seed a fallback


### PR DESCRIPTION
## Summary
- Move Soperator chart 4.0.2 release notes from Unreleased into soperator-chart-v4.0.2-ps.1
- Keep the release prep branch based on PR #148 / current main

## Validation
- bash -n helm-charts/soperator/publish-helm.sh
- python3 -m json.tool .github/helm-chart-publish.json
- helm lint helm-charts/soperator --strict --with-subcharts
- helm template smoke helm-charts/soperator --namespace soperator >/dev/null
- git diff --check