### PR TITLE
Add Grafana MCP skill and cxcli chart controls

### DIFF
--- a/services/nebius-cxcli/CHANGELOG.md
+++ b/services/nebius-cxcli/CHANGELOG.md
@@ -6,6 +6,22 @@ All notable changes to this project are tracked here. This changelog follows
 
 ## [Unreleased]
 
+- Removed confusing version-label wording from `upgrade` help and docs while
+  preserving the documented supported upgrade scope.
+- Added create/component-add Helm chart version overrides for app charts:
+  `component_sources.yaml` remains the default version source, interactive
+  `create` and `component add` prompt for `apps.charts[].version` before the
+  longer app config phase, and non-interactive `create` plus `component add`
+  accept `--app-version <app-id>=<chart-version>`. `component add` also accepts
+  `--app-namespace` and `--app-releasename` for app rows added by that
+  operation. With source validation enabled, cxcli resolves requested
+  non-catalog chart versions before writing `config.yaml`, so a published
+  rollback/test package such as `soperator=4.0.1-ps.2` can be selected
+  explicitly while unknown versions fail fast.
+- Aligned Soperator-created SFS defaults in the `create` wizard: after the
+  operator enters the MK8s cluster name, generated jail/controller/accounting
+  SFS filesystem `name` and `mount_tag` defaults use `<cluster-name>-<role>`
+  instead of the initial `mk8s` placeholder or role-only mount tags.
 - Tightened destructive/create-path guardrails and local credential writes:
   MK8s live resource-name preflight now trusts only typed Nebius `NOT_FOUND`
   status, Soperator node-group cleanup no longer swallows arbitrary errors

--- a/services/nebius-cxcli/README.md
+++ b/services/nebius-cxcli/README.md
@@ -105,8 +105,9 @@ nebius-cxcli bootstrap-ci <config.yaml>
 - In the interactive `create` wizard, the entered MK8s `cluster.cluster_name`
   becomes the target `instance_id` before app defaults are previewed. Rendered
   Terraform/Flux artifacts use that target identity, not
-  `client_info.client_name`; Terraform module labels may still replace hyphens
-  with underscores for HCL syntax.
+  `client_info.client_name`; Soperator-created SFS filesystem `name` and
+  `mount_tag` defaults also use `<cluster-name>-<role>`. Terraform module labels
+  may still replace hyphens with underscores for HCL syntax.
 - Authored `config.yaml` does not use `apps.charts[].target_ref`; any internal generated `target_ref` is derived from and must equal the same target `instance_id`.
 - Terraform outputs consumed by app bindings, deploy, or bootstrap behavior are stable interfaces. Renaming or changing one is a breaking contract change.
 - Generated-bundle commands recreate ignored Terraform tfvars from the generated manifest before Terraform runs. Use `nebius-cxcli terraform plan <generated>`, `nebius-cxcli terraform apply <generated>`, or `nebius-cxcli deploy <config.yaml>` from a fresh checkout.
@@ -404,7 +405,7 @@ Field guide:
   - `ui.selectable`: optional selector metadata. Omit it for normal persistent app chart sources. Set it to `false` only for cataloged chart sources that cxcli owns through another runtime flow.
   - `usage.lifecycle`: optional chart lifecycle metadata. Omit it for normal persistent app chart sources. `transient` marks a reusable Helm source for a cxcli-owned runtime flow; transient charts must also set `ui.enabled: false` and `ui.selectable: false`.
   - `usage.config.ref`: required with `usage.lifecycle: transient`. It points to the customer-facing config field that activates the runtime flow, for example `deploy.targets[].validations.mk8s_gpu.nccl`.
-  - `release.namespace`, `release.name`: default Helm namespace and release name used during `create`.
+  - `release.namespace`, `release.name`: default Helm namespace and release name used during `create` and `component add`.
   - `release.timeout`: optional Flux `HelmRelease.spec.timeout` duration such as `10m` or `12m30s`. When omitted, the chart inherits `cli.flux.release_timeout`.
   - `release.install_after`: app prerequisite list. cxcli auto-selects the
     listed app components when this app is selected and renders Flux
@@ -527,7 +528,10 @@ Bundled infra component alignment:
   choices rather than a raw nested object prompt.
 - `sfs` uses `wizard_profile: sfs` because its name, size, filesystem type,
   block size, mount tag, and deletion-protection (`forbid_deletion`) defaults
-  should be visible and editable instead of blank optional prompts.
+  should be visible and editable instead of blank optional prompts. When
+  Soperator materializes the multi-filesystem SFS map, the generated `name` and
+  `mount_tag` defaults use the target cluster name plus role, such as
+  `<cluster-name>-accounting`.
 - `soperator` uses `wizard_profile: soperator` because its app wizard is a
   concise policy surface over `install_mode`, NodeSet profile, partition
   profile, topology profile, role mapping, and optional child-chart gates rather
@@ -987,7 +991,7 @@ Source requirements enforced by `validate-sources`:
     chart can exceed Kubernetes' 1 MiB Helm release Secret limit when Helm
     stores release state in-cluster.
   - App `defaults` seed `values.*` when missing.
-  - `release.namespace` and `release.name` are the default Helm namespace and release name used by `create`.
+  - `release.namespace` and `release.name` are the default Helm namespace and release name used by `create` and `component add`.
 
 Resolution precedence:
 
@@ -1162,10 +1166,23 @@ When enabled charts are deployed, the CLI reads the rendered Terraform output `c
 
 For app source entries, `release.namespace` and `release.name` are defaults:
 
-- interactive create wizard prompts them for enabled apps
-- non-interactive create can override with:
+- interactive `create` and `component add` wizards prompt them for selected app
+  rows
+- non-interactive `create` and `component add` can override added/selected app
+  rows with:
   - `--app-namespace <app-id>=<namespace>`
   - `--app-releasename <app-id>=<release-name>`
+  - `--app-version <app-id>=<chart-version>`
+
+App chart versions default to the active `component_sources.yaml` pin. During
+interactive `create` and `component add`, each selected app chart prompts for
+`apps.charts[].version` immediately after the default preview and before the
+full app-config yes/no prompt; pressing Enter keeps the pin, and typing a
+different version records that value in `apps.charts[].version` even when the
+rest of the app config is skipped. In non-interactive mode, `--app-version`
+provides the same override for app rows added by the command. With source
+validation enabled, cxcli validates requested non-catalog chart versions against
+the resolved Helm/OCI source before writing `config.yaml`.
 
 Runtime config shape:
 
@@ -1230,6 +1247,13 @@ Wizard field behavior:
 - Interactive `create` and `component add` offer all discoverable required and optional component fields for newly selected components.
 - When no `--app` values are provided, interactive `create` opens app chart selection only after an MK8s target is selected. Explicit app selections still run normal target validation, so Helm charts cannot be added by `create` without a managed MK8s target. Existing external Nebius MK8s targets are registered later with `nebius-cxcli ext-soperator onboard <config.yaml-or-deployments-root>`.
 - Infra component field phases default to `y`; app chart field phases default to `n`, because chart overrides are usually optional and Helm/chart defaults still apply unless you choose to edit them.
+- App chart version prompts keep the active `component_sources.yaml` pin as the
+  default and run before the full app field phase in `create` and
+  `component add`. Operators can type a known published chart version, then
+  answer `n` to the longer app config prompt when no other app overrides are
+  needed, or pass `--app-version <app-id>=<chart-version>` in non-interactive
+  mode. With source validation enabled, cxcli fails before writing `config.yaml`
+  if that requested version cannot be resolved.
 - Optional-wizard controls are consistent across component selection, component phase prompts, and field prompts: `q` backs up to the previous step so you can revise an earlier answer, while `qq` stops the wizard immediately and saves the current config state. Interactive TTY list and checkbox prompts bind those controls directly to the keys instead of showing Back/Quit as selectable rows. When a field has a constrained choice list, the TTY wizard shows only selectable values, plus an explicit skip row for optional unset fields; the non-TTY fallback accepts only a listed index or exact value. Manual free text is reserved for fields without resolved choices, except required VPC network/subnet fields which fail fast when live lookup is unavailable.
 - Interactive component selection prints one resolved infra/apps summary after dependency resolution finishes. During field input, the wizard context is a one-line Rich-colored `Wizard context: Current: <scope> / <component-or-target-feature>` marker, so long app lists are not repeated before every prompt. Fields under `deploy.targets[]`, such as native MysteryBox ESO sync, are labeled as deploy-target context rather than ordinary MK8s Terraform inputs.
 - Interactive `component add` uses that target-aware summary as the component report and does not repeat final `Added infra/apps components` lines after writing `config.yaml`; non-interactive adds still print compact added-component summaries for categories that actually changed because they do not run the wizard summary.
@@ -3004,7 +3028,7 @@ Underlying MK8s infrastructure upgrade commands are also different:
 ## Upgrade
 
 `nebius-cxcli upgrade` is the day-2 lifecycle surface for version and component
-changes that need cxcli safety gates before live reconciliation. V1 implements
+changes that need cxcli safety gates before live reconciliation. It supports
 Kubernetes version upgrades for Terraform-managed MK8s clusters, combined MK8s
 node-template upgrades for Kubernetes version, OS, and Nebius-image GPU stack,
 OS image upgrades for Terraform-managed MK8s node groups and generic VM
@@ -3086,7 +3110,7 @@ and `deploy`, `terraform apply`, or `flux apply` as appropriate.
 
 ### Kubernetes Version Upgrade
 
-The implemented V1 command can run as a guided wizard from only `config.yaml`:
+The command can run as a guided wizard from only `config.yaml`:
 
 ```bash
 nebius-cxcli upgrade k8s-version <config.yaml>
@@ -3865,7 +3889,7 @@ nebius-cxcli auth --project-config /path/to/config.yaml --validate-profile
   - `component list/add/remove`: pass the project `config.yaml` with `--config <config.yaml>` so component selectors can be written first.
   - `grafana`: no positional path; use `--export-dashboard <grafana-base-or-folder-url>` or `--dashboard-json <path>` and optional `--component-sources` with `--attach`.
   - `component`, `validate`, `validate-dashboards`, `quota-check`, `quota-request`, `render`, `deploy`, `soperator`, `upgrade`, `bootstrap-ci`, `wireguard`, `ssh-jumphost`, `destroy`, `email`: operate on the project `config.yaml`.
-  - `upgrade k8s-version`: pass `config.yaml` alone in an interactive terminal to choose the managed MK8s target, version, and options through the wizard; pass an explicit `infra:mk8s@<target>` selector plus `--to-version <major.minor>` for automation. V1 supports Terraform-managed MK8s targets only.
+  - `upgrade k8s-version`: pass `config.yaml` alone in an interactive terminal to choose the managed MK8s target, version, and options through the wizard; pass an explicit `infra:mk8s@<target>` selector plus `--to-version <major.minor>` for automation. Supports Terraform-managed MK8s targets only.
   - `upgrade os-image`: pass `config.yaml` alone in an interactive terminal to choose an upgradeable `infra:mk8s@<target>` or `infra:vm@<target>` component through the wizard; pass an explicit selector plus `--to-os <os>` for automation. MK8s selectors update node template OS values and can use `--node-group <source-key-or-live-name>` to narrow the rolling update to one group. VM selectors update generic `infra:vm` `inputs.source_image_family`.
   - `validate-generated`: pass `generated/`, one of its subdirectories, or a file under that tree.
   - `terraform *`: pass the project `generated/` directory or a path under `generated/infra/`.
@@ -3898,6 +3922,11 @@ nebius-cxcli auth --project-config /path/to/config.yaml --validate-profile
     generic NCCL path off; enable Soperator ActiveChecks only for
     benchmark/diagnostic clusters or maintenance windows.
   - Interactive mode prompts for infra first and can complete an infra-only add without selecting any app. It asks for app selection only when no infra was selected or when you explicitly choose to add apps too, then confirms the final selection, auto-resolves app chart dependencies plus `release.install_after` prerequisites, and runs the field wizard only for the newly added components. Auto-enabled app rows created by that field wizard are target-scoped to the newly selected target, so adding `mk8s@cluster2` to a config that already has `cluster1` shows and prompts only the new rows such as `grafana@cluster2`. If apps are selected without an enabled MK8s target, cxcli warns immediately and sends the operator back to select `infra:mk8s` or remove the app selection.
+  - Newly added app charts prompt for `apps.charts[].version` before the longer
+    app config phase. Press Enter to keep the pinned `component_sources.yaml`
+    version, or type a known chart package version. Non-interactive
+    `component add` accepts `--app-namespace`, `--app-releasename`, and
+    `--app-version` for app rows added by that operation.
   - When that wizard reaches per-component field phases, infra components
     default to `y` and app charts default to `n`. Answering `n` for a newly
     added infra component cancels that pending add instead of writing an
@@ -3976,6 +4005,13 @@ nebius-cxcli auth --project-config /path/to/config.yaml --validate-profile
     and `--app n8n,gateway-helm --app cert-manager` select multiple infra and
     app components in one create run. App chart dependencies can still add
     required chart rows automatically.
+  - App chart rows use the active `component_sources.yaml` version pin by
+    default. In `create` and `component add`, use
+    `--app-version soperator=4.0.1-ps.2`, or type the version at the
+    interactive app chart version prompt before the full app config phase, when
+    you intentionally want a different published chart package. With source
+    validation enabled, cxcli checks that requested version before writing
+    `config.yaml`.
   - Interactive `create` offers app chart selection only after the infra
     selection includes an MK8s target. To configure Soperator interactively,
     select `infra:mk8s` first and then `apps:soperator`; non-interactive
@@ -4121,13 +4157,13 @@ nebius-cxcli auth --project-config /path/to/config.yaml --validate-profile
 Common command flags:
 
 - `component add`:
-  `--no-interactive`, `--network-id`, `--subnet-id`, `--network-ref`,
-  `--subnet-ref`,
+  `--no-interactive`, `--app-namespace`, `--app-releasename`, `--app-version`,
+  `--network-id`, `--subnet-id`, `--network-ref`, `--subnet-ref`,
   `--validate-sources/--no-validate-sources`
 - `component remove`:
   `--no-interactive`
 - `create`:
-  `--client-name`, `--tenant-id`, `--project-id`, `--region-id`, `--email`, `--infra`, `--app`, `--app-namespace`, `--app-releasename`, `--network-id`, `--subnet-id`, `--network-ref`, `--subnet-ref`, `--validate-sources/--no-validate-sources`, `--validate-config/--no-validate-config`, `--no-interactive`, `--force`
+  `--client-name`, `--tenant-id`, `--project-id`, `--region-id`, `--email`, `--infra`, `--app`, `--app-namespace`, `--app-releasename`, `--app-version`, `--network-id`, `--subnet-id`, `--network-ref`, `--subnet-ref`, `--validate-sources/--no-validate-sources`, `--validate-config/--no-validate-config`, `--no-interactive`, `--force`
 - `bootstrap-ci`:
   `--auth-bootstrap/--no-auth-bootstrap`, `--github-repo`, `--github-token-env`, `--cli-ref`
 - `grafana`: `--export-dashboard`, `--dashboard-json`, `--output-dir`, `--folder-uid`, `--dashboard-uid`, `--overwrite`, `--attach`, `--component-sources`, `--dashboard-folder`, `--datasource`, `--token-env`, `--username`, `--password-env`

--- a/services/nebius-cxcli/component_cli_settings.yaml
+++ b/services/nebius-cxcli/component_cli_settings.yaml
@@ -735,19 +735,19 @@ components:
                     name: "{target}-jail"
                     size_gib: 1024
                     block_size_kib: 4
-                    mount_tag: jail
+                    mount_tag: "{target}-jail"
                     forbid_deletion: false
                   controller-spool:
                     name: "{target}-controller-spool"
                     size_gib: 128
                     block_size_kib: 4
-                    mount_tag: controller-spool
+                    mount_tag: "{target}-controller-spool"
                     forbid_deletion: false
                   accounting:
                     name: "{target}-accounting"
                     size_gib: 128
                     block_size_kib: 4
-                    mount_tag: accounting
+                    mount_tag: "{target}-accounting"
                     forbid_deletion: false
               chart:
                 topology_profiles:

--- a/services/nebius-cxcli/docs/design.md
+++ b/services/nebius-cxcli/docs/design.md
@@ -53,7 +53,7 @@ Core principles:
 - `config.yaml` is the canonical render/reset contract.
 - `generated/` is the deploy contract for customer repositories.
 - Project-level workflow commands use `config.yaml` as the CLI entrypoint.
-- `upgrade` is a day-2 lifecycle command group. V1 implements Kubernetes
+- `upgrade` is a day-2 lifecycle command group. It supports Kubernetes
   version, combined node-template, OS image, focused MK8s node-layer, and
   target-scoped Helm chart upgrades as separate subcommands instead of folding
   unrelated layers into one mixed operation. In interactive terminals, commands
@@ -223,8 +223,9 @@ Sections:
 - During interactive `create`, scalar-named infra targets such as MK8s are
   aligned to the entered resource name before the app wizard section starts.
   That means app prompt labels, skipped-default previews, derived
-  `target_ref`, and Soperator `values.clusterName` all use the entered cluster
-  target name instead of the initial placeholder or `client_info.client_name`.
+  `target_ref`, Soperator `values.clusterName`, and Soperator-created SFS
+  filesystem `name`/`mount_tag` defaults all use the entered cluster target name
+  instead of the initial placeholder or `client_info.client_name`.
 - dependency-backed wizard fields are gated by the selected upstream component or context: for example GPU validation waits for MK8s GPU, VM journald log fields wait for the VM observability context, provider-backed choices wait for their declared `depends_on` value, and native MysteryBox ESO sync waits for both MK8s and the Terraform `mysterybox` component
 - the bundled MK8s profile suppresses raw parent prompts for the typed
   `inputs.cluster` and `inputs.node_groups` objects; the wizard asks for the
@@ -288,7 +289,9 @@ Sections:
   Soperator has already materialized a multi-filesystem SFS map, the wizard
   skips the single-filesystem prompts and exposes the generated jail,
   controller-spool, and accounting entries through guided `name`, `size_gib`,
-  `block_size_kib`, `mount_tag`, and `forbid_deletion` prompts. Standalone SFS
+  `block_size_kib`, `mount_tag`, and `forbid_deletion` prompts. Soperator SFS
+  `name` and `mount_tag` defaults use `<cluster-name>-<role>` so the visible
+  Nebius filesystem identity and mount tag stay target-scoped. Standalone SFS
   prompts default to `name=sfs`, `size_gib=1024`, `type=NETWORK_SSD`,
   `block_size_kib=4`, and `forbid_deletion=false`.
 - `status` is the canonical Nebius status-polling contract for infra components; if polling is needed, `status.kind` must be declared explicitly
@@ -1287,18 +1290,20 @@ The Soperator app wizard hides raw parent chart values by default and exposes a
 small guided surface instead: nodeset profile, partition profile, topology
 profile, and top-level optional-service gates. Before every app chart field
 phase, cxcli prints up to four concise lines of the defaults that answering `n`
-will keep. For Soperator, that preview prioritizes release/profile basics,
-cluster/partition defaults, and SFS-derived jail/controller-spool/accounting
-sizes. SFS remains the physical filesystem capacity owner; the Soperator app row
-mirrors those values into Helm `values.volume.*`, `values.sfs.filesystems.*`,
-and chart-managed MariaDB storage because the chart renders storage objects and
+will keep, then prompts for the chart version separately so operators can change
+only the package version without entering the longer app config phase. For
+Soperator, that preview prioritizes release/profile basics, cluster/partition
+defaults, and SFS-derived jail/controller-spool/accounting sizes. SFS remains
+the physical filesystem capacity owner; the Soperator app row mirrors those
+values into Helm `values.volume.*`, `values.sfs.filesystems.*`, and
+chart-managed MariaDB storage because the chart renders storage objects and
 mounts.
 If the operator answers `n` to the app field phase, cxcli keeps the catalog
-production defaults: five-role GPU layout (`system`, `controller`, `login`,
-`accounting`, and GPU `worker`), SFS jail/controller-spool/accounting
-filesystems, Slurm accounting, SlurmDBD, and chart-managed MariaDB enabled
-with storage bound to the accounting SFS-backed `slurm-local-pv` class, one
-node in each generated role group by default, with
+production chart config defaults: five-role GPU layout (`system`, `controller`,
+`login`, `accounting`, and GPU `worker`), SFS jail/controller-spool/accounting
+filesystems, Slurm accounting, SlurmDBD, and chart-managed MariaDB enabled with
+storage bound to the accounting SFS-backed `slurm-local-pv` class, one node in
+each generated role group by default, with
 ActiveChecks, checks controller, Soperator DCGM job mapping, notifier, backup,
 QoS reconcile, SSSD, and the NodeConfigurator rebooter disabled. Exact
 descendant wizard entries can still prompt under `values.*`; broad chart
@@ -1719,7 +1724,7 @@ Instance self-containment:
 - Config-based commands resolve sources from the active `component_sources.yaml` resolution path.
 - Canonical project path shape is `<deployments-root>/<tenant-folder>/<project-folder>/config.yaml`.
 - `create` still takes `tenant_id` / `project_id` as the project identity inputs. Folder names are resolved from the validated Nebius names only after ID validation succeeds, and runtime identity continues to come from `config.yaml`.
-- App chart defaults (`release.namespace`, `release.name`) can be edited in wizard mode or overridden in non-interactive mode with `--app-namespace` and `--app-releasename`.
+- App chart defaults (`release.namespace`, `release.name`) can be edited in wizard mode or overridden in non-interactive `create` and `component add` with `--app-namespace` and `--app-releasename`.
 - App chart `release.timeout` is optional catalog metadata for Flux `HelmRelease.spec.timeout`; when omitted, the chart inherits `cli.flux.release_timeout`. That keeps a global default in the catalog while still allowing per-chart overrides without hardcoding chart-specific logic in the deploy loop.
 - `deploy.targets[].observability.*` is the canonical customer-facing MK8s observability contract, and `deploy.observability.vm.*` remains the VM observability contract. cxcli renders those deploy settings into infra labels and app chart values during render/deploy, keeping `config.yaml` organized under `infra`, `apps`, and `deploy`.
 
@@ -2767,6 +2772,16 @@ Canonical model is dynamic:
 - `infra.components[]`: `id`, `instance_id`, `enabled`, `inputs`
 - `apps.charts[]`: `id`, `instance_id`, `group`, `enabled`, `repo`, `version`, `namespace`, `release-name`, `values`
 - Enabled `apps.charts[]` rows require at least one enabled MK8s target, and each app row `instance_id` must match one enabled target cluster `instance_id`.
+- App chart versions default to the active `component_sources.yaml` pin.
+  Interactive `create` and `component add` prompt for the row `version`
+  immediately after each selected app's default preview and before the full app
+  field phase, so an operator can set a published chart version while still
+  skipping the longer app config prompt. Non-interactive `create` and
+  `component add` accept
+  `--app-version <app-id>=<chart-version>` for explicit published-version
+  overrides. With source validation enabled, cxcli validates non-catalog
+  requested versions against the resolved Helm/OCI chart source before writing
+  `config.yaml`.
 - Source catalogs use `release.name`; project `config.yaml` uses `release-name`. Alias keys are intentionally unsupported.
 - Static nested component blocks are not accepted.
 
@@ -2792,7 +2807,7 @@ The command boundary is intentional:
 - Unless `--tenant-id` / `--project-id` were passed explicitly, interactive `create` starts those identity prompts blank instead of prefilling values from an existing project under the deployments root.
 - After `create` writes the resulting `config.yaml`, it runs the internal warning-only post-create validation by default; `--no-validate-config` is the explicit escape hatch.
 - `component add`/`component remove` are the day-2 config-editing commands for an already existing `config.yaml`. They take that file with `--config <config.yaml>` so component selectors can be written first.
-- Live Helm chart defaults remain implicit in the chart and are not persisted into `config.yaml`; the wizard may surface them as prompt defaults, but only explicit chart overrides are written.
+- Live Helm chart defaults remain implicit in the chart and are not persisted into `config.yaml`; the wizard may surface them as prompt defaults, but only explicit chart overrides are written. Chart version defaults are the exception already present in each app row: `create` and `component add` seed the active catalog pin into `apps.charts[].version`, prompt for that version before the longer app config phase, and replace the pin only when the operator explicitly requests another version.
 - CLI help should label positional targets explicitly as `DEPLOYMENTS_ROOT`, `CONFIG_YAML`,
   `GENERATED_PATH`, or `COMPONENT_SOURCES_YAML` so operators can tell the expected path type
   from the first `--help` screen.
@@ -2834,6 +2849,11 @@ The command boundary is intentional:
 - Auto-resolves app chart dependencies from chart metadata and app
   `release.install_after` prerequisites before persisting the updated selection.
 - Runs the field wizard only for newly added components; existing component values remain untouched.
+- Newly added app charts prompt for `apps.charts[].version` before the longer
+  app config phase. Non-interactive `component add` accepts `--app-namespace`,
+  `--app-releasename`, and `--app-version` for app rows added by that operation;
+  requested non-catalog versions are validated before `config.yaml` is written
+  when source validation is enabled.
 - The field wizard offers all discoverable required and optional fields for each newly added component, keeping module/chart defaults virtual unless the operator overrides them.
 - In interactive `component add`, answering `n` at a newly added infra
   component's `Configure '<component>' component fields now?` phase cancels

--- a/services/nebius-cxcli/src/nebius_cxcli/cli.py
+++ b/services/nebius-cxcli/src/nebius_cxcli/cli.py
@@ -24011,7 +24011,7 @@ def _run_component_field_wizard(
                     module_dependency_expander = _expand_module_dependency_prompts
             elif entry.scope == "apps":
                 # App wizard prompts are Helm values-driven.
-                for key in ("version", "namespace", "release-name"):
+                for key in ("namespace", "release-name"):
                     full_path = component_path + (key,)
                     if full_path in pre_prompted_app_paths:
                         continue
@@ -25441,6 +25441,7 @@ def _validate_enabled_chart_sources(
     *,
     chart_meta_cache: _ChartMetaCache | None = None,
     candidate_app_ids: set[str] | None = None,
+    candidate_app_identities: set[tuple[str, str]] | None = None,
 ) -> list[str]:
     issues: list[str] = []
     payload = to_plain_data(config)
@@ -25450,9 +25451,16 @@ def _validate_enabled_chart_sources(
 
     for chart_row in _dynamic_enabled_app_chart_rows(payload):
         chart_id = str(chart_row["id"])
-        if candidate_app_ids is not None and chart_id not in candidate_app_ids:
-            continue
         instance_id = str(chart_row["instance_id"])
+        if candidate_app_identities is not None:
+            normalized_identity = (
+                normalize_component_token(chart_id),
+                normalize_component_token(instance_id),
+            )
+            if normalized_identity not in candidate_app_identities:
+                continue
+        elif candidate_app_ids is not None and chart_id not in candidate_app_ids:
+            continue
         chart_repo = str(chart_row.get("repo", "")).strip()
         chart_version = str(chart_row.get("version", "")).strip()
         entry = app_entry_by_id.get(chart_id)
@@ -25477,7 +25485,8 @@ def _validate_enabled_chart_sources(
         for issue in issues_for_chart:
             issue_text = (
                 f"version '{chart_version}' {issue}"
-                if candidate_app_ids is not None and chart_version
+                if (candidate_app_ids is not None or candidate_app_identities is not None)
+                and chart_version
                 else issue
             )
             issues.append(
@@ -25505,19 +25514,52 @@ def _app_chart_ids_with_non_catalog_versions(
     return changed
 
 
+def _app_chart_identities_with_non_catalog_versions(
+    *,
+    payload: dict[str, Any],
+    app_entries: tuple[ComponentEntry, ...],
+) -> set[tuple[str, str]]:
+    entry_by_id = {entry.id: entry for entry in app_entries}
+    changed: set[tuple[str, str]] = set()
+    for chart_row in _dynamic_enabled_app_chart_rows(payload):
+        chart_id = str(chart_row["id"])
+        chart_version = str(chart_row.get("version", "")).strip()
+        if not chart_version:
+            continue
+        entry = entry_by_id.get(chart_id)
+        catalog_version = str(entry.version or "").strip() if entry is not None else ""
+        if not catalog_version or chart_version != catalog_version:
+            changed.add(
+                (
+                    normalize_component_token(chart_id),
+                    normalize_component_token(str(chart_row["instance_id"])),
+                )
+            )
+    return changed
+
+
 def _validate_requested_app_chart_versions_or_raise(
     *,
     payload: dict[str, Any],
-    candidate_app_ids: set[str],
+    candidate_app_ids: set[str] | None = None,
+    candidate_app_identities: set[tuple[str, str]] | None = None,
 ) -> None:
-    candidate_ids = {normalize_component_token(item) for item in candidate_app_ids if item}
-    if not candidate_ids:
+    candidate_ids = {
+        normalize_component_token(item) for item in candidate_app_ids or set() if item
+    }
+    candidate_identities = {
+        (normalize_component_token(chart_id), normalize_component_token(instance_id))
+        for chart_id, instance_id in candidate_app_identities or set()
+        if chart_id and instance_id
+    }
+    if not candidate_ids and not candidate_identities:
         return
     chart_meta_cache: _ChartMetaCache = {}
     issues = _validate_enabled_chart_sources(
         payload,
         chart_meta_cache=chart_meta_cache,
-        candidate_app_ids=candidate_ids,
+        candidate_app_ids=candidate_ids or None,
+        candidate_app_identities=candidate_identities or None,
     )
     if issues:
         raise RuntimeError(
@@ -37474,17 +37516,21 @@ def component_add_command(
                 already_validated_app_ids=source_validated_app_ids,
                 candidate_app_ids=final_app_ids_to_validate,
             )
-            requested_version_app_ids = set(app_version_overrides)
-            requested_version_app_ids.update(
-                _app_chart_ids_with_non_catalog_versions(
+            requested_version_app_identities = {
+                identity
+                for identity in newly_enabled_app_identities
+                if identity[0] in set(app_version_overrides)
+            }
+            requested_version_app_identities.update(
+                _app_chart_identities_with_non_catalog_versions(
                     payload=next_payload,
                     app_entries=app_entries,
                 )
-                & newly_enabled_app_ids
+                & newly_enabled_app_identities
             )
             _validate_requested_app_chart_versions_or_raise(
                 payload=next_payload,
-                candidate_app_ids=requested_version_app_ids,
+                candidate_app_identities=requested_version_app_identities,
             )
 
         wrote_config = _write_runtime_payload_config(config_path.resolve(), next_payload)

--- a/services/nebius-cxcli/src/nebius_cxcli/cli.py
+++ b/services/nebius-cxcli/src/nebius_cxcli/cli.py
@@ -1481,7 +1481,7 @@ soperator_app = typer.Typer(
 )
 upgrade_app = typer.Typer(
     help=(
-        "Run day-2 lifecycle upgrades from config.yaml. V1 implements MK8s "
+        "Run day-2 lifecycle upgrades from config.yaml. Supports MK8s "
         "Kubernetes version, combined node-template, OS-image, node-layer, and "
         "target-scoped Helm chart upgrades with dry-run planning and guardrails."
     ),
@@ -1973,12 +1973,12 @@ def _prompt_upgrade_helm_chart_target_selector_if_needed(
     return _parse_helm_chart_upgrade_selector(selector)
 
 
-def _validate_helm_chart_version_value(value: str) -> str:
+def _validate_helm_chart_version_value(value: str, *, option_name: str = "--to-version") -> str:
     raw = _non_empty_text(value)
     if not raw:
-        raise ValueError("--to-version must not be empty.")
+        raise ValueError(f"{option_name} must not be empty.")
     if any(char.isspace() for char in raw):
-        raise ValueError("--to-version must not contain whitespace.")
+        raise ValueError(f"{option_name} must not contain whitespace.")
     return raw
 
 
@@ -7983,6 +7983,7 @@ def _dependency_seed_payload(
     app_entries: tuple[ComponentEntry, ...],
     existing_payload: dict[str, Any] | None,
     merge_existing: bool,
+    app_version_overrides: dict[str, str] | None = None,
 ) -> dict[str, Any] | None:
     if not selected_apps:
         return None
@@ -8014,6 +8015,13 @@ def _dependency_seed_payload(
         infra_entries=infra_entries,
         app_entries=app_entries,
     )
+    _apply_app_release_overrides(
+        payload=parsed_seed_payload,
+        selected_apps=selected_apps,
+        namespace_overrides={},
+        release_name_overrides={},
+        version_overrides=app_version_overrides or {},
+    )
     return parsed_seed_payload
 
 
@@ -8030,6 +8038,7 @@ def _starter_component_payload(
     app_entries: tuple[ComponentEntry, ...],
     app_namespace_overrides: dict[str, str] | None = None,
     app_releasename_overrides: dict[str, str] | None = None,
+    app_version_overrides: dict[str, str] | None = None,
 ) -> dict[str, Any]:
     starter_yaml = starter_config_yaml(
         client_name=client_name,
@@ -8057,6 +8066,7 @@ def _starter_component_payload(
         selected_apps=selected_apps,
         namespace_overrides=app_namespace_overrides or {},
         release_name_overrides=app_releasename_overrides or {},
+        version_overrides=app_version_overrides or {},
     )
     materialize_shared_defaults(
         payload=starter_payload,
@@ -8931,10 +8941,13 @@ def _apply_app_release_overrides(
     *,
     payload: dict[str, Any],
     selected_apps: set[str],
+    selected_app_identities: set[tuple[str, str]] | None = None,
     namespace_overrides: dict[str, str],
     release_name_overrides: dict[str, str],
+    version_overrides: dict[str, str] | None = None,
 ) -> None:
-    if not namespace_overrides and not release_name_overrides:
+    chart_version_overrides = version_overrides or {}
+    if not namespace_overrides and not release_name_overrides and not chart_version_overrides:
         return
     apps_node = payload.get("apps")
     if not isinstance(apps_node, dict):
@@ -8943,32 +8956,59 @@ def _apply_app_release_overrides(
     if not isinstance(charts, list):
         raise RuntimeError("Generated payload is missing apps.charts list.")
 
-    by_id: dict[str, dict[str, Any]] = {}
+    selected_app_ids = {normalize_component_token(item) for item in selected_apps if item}
+    selected_identities = (
+        {
+            (normalize_component_token(chart_id), normalize_component_token(instance_id))
+            for chart_id, instance_id in selected_app_identities
+            if chart_id and instance_id
+        }
+        if selected_app_identities is not None
+        else None
+    )
+    by_id: dict[str, list[dict[str, Any]]] = {}
     for item in charts:
         if not isinstance(item, dict):
             continue
-        chart_id = str(item.get("id", "")).strip().lower()
-        if chart_id:
-            by_id[chart_id] = item
+        chart_id = normalize_component_token(item.get("id"))
+        if not chart_id or chart_id not in selected_app_ids:
+            continue
+        if selected_identities is not None and (
+            chart_id,
+            component_instance_id(item),
+        ) not in selected_identities:
+            continue
+        by_id.setdefault(chart_id, []).append(item)
 
-    target_ids = set(namespace_overrides) | set(release_name_overrides)
+    target_ids = set(namespace_overrides) | set(release_name_overrides) | set(chart_version_overrides)
     for chart_id in sorted(target_ids):
-        if chart_id not in selected_apps:
+        chart_id = normalize_component_token(chart_id)
+        if chart_id not in selected_app_ids:
             raise RuntimeError(
                 f"Override target apps component '{chart_id}' is not enabled. "
-                "Enable it with --app first."
+                "Select it in this command first."
             )
-        row = by_id.get(chart_id)
-        if row is None:
+        rows = by_id.get(chart_id, [])
+        if not rows:
             raise RuntimeError(
                 f"Override target apps component '{chart_id}' was not found in apps.charts."
             )
-        namespace = namespace_overrides.get(chart_id)
-        if namespace is not None:
-            row["namespace"] = namespace
-        release_name = release_name_overrides.get(chart_id)
-        if release_name is not None:
-            row["release-name"] = release_name
+        for row in rows:
+            namespace = namespace_overrides.get(chart_id)
+            if namespace is not None:
+                row["namespace"] = namespace
+            release_name = release_name_overrides.get(chart_id)
+            if release_name is not None:
+                row["release-name"] = release_name
+            chart_version = chart_version_overrides.get(chart_id)
+            if chart_version is not None:
+                try:
+                    row["version"] = _validate_helm_chart_version_value(
+                        chart_version,
+                        option_name="--app-version",
+                    )
+                except ValueError as exc:
+                    raise RuntimeError(str(exc)) from exc
 
 
 def _resolve_component_ids_from_tokens(
@@ -14780,17 +14820,97 @@ def _materialize_soperator_sfs_profile(
     profile: Mapping[str, Any],
     target_ref: str,
 ) -> dict[str, Any]:
-    sfs_profile = _profile_mapping(profile, "sfs")
-    profile_filesystems = _profile_mapping(sfs_profile, "filesystems")
-    rendered_filesystems = {
-        key: _render_soperator_profile_value(value, target_ref=target_ref)
-        for key, value in profile_filesystems.items()
-    }
+    rendered_filesystems = _render_soperator_sfs_profile_filesystems(
+        profile=profile,
+        target_ref=target_ref,
+    )
     filesystems = inputs.setdefault("filesystems", {})
     if isinstance(filesystems, dict):
         _merge_missing_mapping(filesystems, rendered_filesystems)
         return copy.deepcopy(filesystems)
     return {}
+
+
+def _render_soperator_sfs_profile_filesystems(
+    *,
+    profile: Mapping[str, Any],
+    target_ref: str,
+) -> dict[str, Any]:
+    sfs_profile = _profile_mapping(profile, "sfs")
+    profile_filesystems = _profile_mapping(sfs_profile, "filesystems")
+    return {
+        key: _render_soperator_profile_value(value, target_ref=target_ref)
+        for key, value in profile_filesystems.items()
+    }
+
+
+def _soperator_sfs_rows_for_target(
+    payload: Mapping[str, Any],
+    *,
+    target_ref: str,
+) -> list[dict[str, Any]]:
+    infra_rows = _scope_rows(payload, scope="infra")
+    enabled_sfs_rows = [
+        row
+        for row in infra_rows
+        if isinstance(row, dict)
+        and bool(row.get("enabled", False))
+        and component_type_id(row) == "sfs"
+    ]
+    exact_rows = [row for row in enabled_sfs_rows if component_instance_id(row) == target_ref]
+    if exact_rows:
+        return exact_rows
+    soperator_targets = _soperator_app_target_refs(payload)
+    if len(enabled_sfs_rows) == 1 and len(soperator_targets) == 1 and target_ref in soperator_targets:
+        return enabled_sfs_rows
+    return []
+
+
+def _retarget_soperator_sfs_profile_defaults(
+    payload: dict[str, Any],
+    *,
+    target_renames: Mapping[str, str],
+) -> bool:
+    if not target_renames:
+        return False
+    profile_by_target = _soperator_profile_by_target(payload)
+    changed = False
+    for old_target_ref, new_target_ref in target_renames.items():
+        profile = profile_by_target.get(new_target_ref, {})
+        if not profile:
+            continue
+        old_filesystems = _render_soperator_sfs_profile_filesystems(
+            profile=profile,
+            target_ref=old_target_ref,
+        )
+        new_filesystems = _render_soperator_sfs_profile_filesystems(
+            profile=profile,
+            target_ref=new_target_ref,
+        )
+        for row in _soperator_sfs_rows_for_target(payload, target_ref=new_target_ref):
+            inputs = row.get("inputs")
+            if not isinstance(inputs, dict):
+                continue
+            filesystems = inputs.get("filesystems")
+            if not isinstance(filesystems, dict):
+                continue
+            for filesystem_key, new_spec in new_filesystems.items():
+                current_spec = filesystems.get(filesystem_key)
+                old_spec = old_filesystems.get(filesystem_key)
+                if not isinstance(current_spec, dict) or not isinstance(old_spec, Mapping):
+                    continue
+                if not isinstance(new_spec, Mapping):
+                    continue
+                for field_name in ("name", "mount_tag"):
+                    old_value = str(old_spec.get(field_name, "") or "").strip()
+                    new_value = str(new_spec.get(field_name, "") or "").strip()
+                    current_value = str(current_spec.get(field_name, "") or "").strip()
+                    if not new_value:
+                        continue
+                    if not current_value or current_value == old_value:
+                        current_spec[field_name] = new_value
+                        changed = True
+    return changed
 
 
 def _materialize_soperator_partition_profile(
@@ -21455,6 +21575,7 @@ def _run_component_field_wizard(
     provider_lookup: ProviderOptionLookup | None = None,
     skip_soperator_profile_prompt: bool = False,
     align_infra_resource_names_before_apps: bool = False,
+    prompt_app_version_before_app_config: bool = False,
     skipped_components: set[tuple[ComponentScope, str, str]] | None = None,
 ) -> tuple[str, bool]:
     payload = yaml.safe_load(config_yaml) or {}
@@ -21641,6 +21762,7 @@ def _run_component_field_wizard(
                 selected_infra.remove(old)
                 selected_infra.add(new)
         _materialize_single_target_app_bindings(payload)
+        _retarget_soperator_sfs_profile_defaults(payload, target_renames=renames)
         _materialize_soperator_component_defaults(payload)
 
     def _ensure_target_scoped_auto_app_rows(auto_enabled_app_ids: Sequence[str]) -> None:
@@ -23430,6 +23552,7 @@ def _run_component_field_wizard(
             if entry.scope == "infra"
             else _dynamic_app_chart_path(payload, entry.id, instance_id=instance_id)
         )
+        pre_prompted_app_paths: set[PayloadPath] = set()
         _print_wizard_component_selection_context(
             current_label=component_label,
             current_scope=entry.scope,
@@ -23442,6 +23565,32 @@ def _run_component_field_wizard(
                 component_node if isinstance(component_node, Mapping) else None,
                 entry=entry,
             )
+            if prompt_app_version_before_app_config and component_path is not None:
+                version_path = component_path + ("version",)
+                current_version = (
+                    _get_payload_value(payload, version_path)
+                    if _payload_path_exists(payload, version_path)
+                    else entry.version or ""
+                )
+                version_label = _format_payload_path(version_path)
+                updated_version, should_stop = _prompt_scalar_override(
+                    version_label,
+                    current_version,
+                )
+                if should_stop:
+                    return _WizardComponentOutcome.QUIT
+                if _wizard_backtrack_requested(updated_version):
+                    return _WizardComponentOutcome.BACK
+                if _payload_path_exists(payload, version_path):
+                    _set_payload_value(payload, version_path, updated_version)
+                else:
+                    _set_payload_value_creating_containers(
+                        payload,
+                        version_path,
+                        updated_version,
+                    )
+                _print_wizard_selected_field(version_label, updated_version)
+                pre_prompted_app_paths.add(version_path)
         decision = _wizard_continue_phase(
             f"Configure '{component_label}' component fields now?",
             default=entry.scope == "infra",
@@ -23862,8 +24011,10 @@ def _run_component_field_wizard(
                     module_dependency_expander = _expand_module_dependency_prompts
             elif entry.scope == "apps":
                 # App wizard prompts are Helm values-driven.
-                for key in ("namespace", "release-name"):
+                for key in ("version", "namespace", "release-name"):
                     full_path = component_path + (key,)
+                    if full_path in pre_prompted_app_paths:
+                        continue
                     if full_path in bound_prompt_paths:
                         continue
                     label = _format_payload_path(full_path)
@@ -23912,6 +24063,8 @@ def _run_component_field_wizard(
                         seen_prompt_labels.add(label)
                         prompt_paths.append(full_path)
                 for full_path in declared_prompt_paths:
+                    if full_path in pre_prompted_app_paths:
+                        continue
                     if full_path in bound_prompt_paths:
                         continue
                     label = _format_payload_path(full_path)
@@ -24586,6 +24739,7 @@ def _run_component_field_wizard(
                 if _confirm_exit_from_first_step():
                     return _wizard_payload_yaml(), False
                 continue
+            _align_infra_resource_names_for_app_section()
             infra_index += 1
             if infra_index < len(infra_components):
                 continue
@@ -25286,6 +25440,7 @@ def _validate_enabled_chart_sources(
     config: Any,
     *,
     chart_meta_cache: _ChartMetaCache | None = None,
+    candidate_app_ids: set[str] | None = None,
 ) -> list[str]:
     issues: list[str] = []
     payload = to_plain_data(config)
@@ -25295,6 +25450,8 @@ def _validate_enabled_chart_sources(
 
     for chart_row in _dynamic_enabled_app_chart_rows(payload):
         chart_id = str(chart_row["id"])
+        if candidate_app_ids is not None and chart_id not in candidate_app_ids:
+            continue
         instance_id = str(chart_row["instance_id"])
         chart_repo = str(chart_row.get("repo", "")).strip()
         chart_version = str(chart_row.get("version", "")).strip()
@@ -25318,10 +25475,54 @@ def _validate_enabled_chart_sources(
                 chart_meta_cache=chart_meta_cache,
             )
         for issue in issues_for_chart:
+            issue_text = (
+                f"version '{chart_version}' {issue}"
+                if candidate_app_ids is not None and chart_version
+                else issue
+            )
             issues.append(
-                f"{_component_instance_path_label('apps', chart_id, instance_id)} {issue}"
+                f"{_component_instance_path_label('apps', chart_id, instance_id)} {issue_text}"
             )
     return issues
+
+
+def _app_chart_ids_with_non_catalog_versions(
+    *,
+    payload: dict[str, Any],
+    app_entries: tuple[ComponentEntry, ...],
+) -> set[str]:
+    entry_by_id = {entry.id: entry for entry in app_entries}
+    changed: set[str] = set()
+    for chart_row in _dynamic_enabled_app_chart_rows(payload):
+        chart_id = str(chart_row["id"])
+        chart_version = str(chart_row.get("version", "")).strip()
+        if not chart_version:
+            continue
+        entry = entry_by_id.get(chart_id)
+        catalog_version = str(entry.version or "").strip() if entry is not None else ""
+        if not catalog_version or chart_version != catalog_version:
+            changed.add(chart_id)
+    return changed
+
+
+def _validate_requested_app_chart_versions_or_raise(
+    *,
+    payload: dict[str, Any],
+    candidate_app_ids: set[str],
+) -> None:
+    candidate_ids = {normalize_component_token(item) for item in candidate_app_ids if item}
+    if not candidate_ids:
+        return
+    chart_meta_cache: _ChartMetaCache = {}
+    issues = _validate_enabled_chart_sources(
+        payload,
+        chart_meta_cache=chart_meta_cache,
+        candidate_app_ids=candidate_ids,
+    )
+    if issues:
+        raise RuntimeError(
+            "Requested app chart version validation failed:\n  - " + "\n  - ".join(issues)
+        )
 
 
 _SEMVER_TAG_PATTERN = re.compile(r"^v?\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)?$")
@@ -35289,6 +35490,18 @@ def create_command(
             ),
         ),
     ] = None,
+    app_version_opt: Annotated[
+        list[str] | None,
+        typer.Option(
+            "--app-version",
+            help=(
+                "Override app chart version with '<app-id>=<chart-version>' "
+                "(repeatable or comma-separated). Defaults come from component_sources.yaml; "
+                "with source validation enabled, the requested chart version must resolve before "
+                "create writes config.yaml."
+            ),
+        ),
+    ] = None,
     network_ids_opt: Annotated[
         list[str] | None,
         typer.Option(
@@ -35613,6 +35826,10 @@ def create_command(
             raw_values=app_releasename_opt,
             option_name="--app-releasename",
         )
+        app_version_overrides = _parse_component_value_overrides(
+            raw_values=app_version_opt,
+            option_name="--app-version",
+        )
         soperator_install_mode: str | None = None
         soperator_profile: str | None = None
         if interactive_mode and optional_wizard_mode and _SOPERATOR_APP_ID in selected_apps_raw:
@@ -35679,6 +35896,7 @@ def create_command(
             app_entries=app_entries,
             existing_payload=None,
             merge_existing=False,
+            app_version_overrides=app_version_overrides,
         )
 
         dependency_resolution_started = time.monotonic()
@@ -35726,6 +35944,7 @@ def create_command(
             app_entries=app_entries,
             app_namespace_overrides=app_namespace_overrides,
             app_releasename_overrides=app_releasename_overrides,
+            app_version_overrides=app_version_overrides,
         )
         if soperator_install_mode is not None:
             _apply_soperator_install_mode_to_payload(
@@ -35798,6 +36017,7 @@ def create_command(
             if soperator_profile is not None:
                 field_wizard_kwargs["skip_soperator_profile_prompt"] = True
             field_wizard_kwargs["align_infra_resource_names_before_apps"] = True
+            field_wizard_kwargs["prompt_app_version_before_app_config"] = True
             config_yaml_override, wizard_completed = _run_component_field_wizard(
                 config_yaml=yaml.safe_dump(final_payload, sort_keys=False),
                 selected_infra=selected_infra,
@@ -35880,6 +36100,7 @@ def create_command(
                 app_entries=app_entries,
                 app_namespace_overrides=app_namespace_overrides,
                 app_releasename_overrides=app_releasename_overrides,
+                app_version_overrides=app_version_overrides,
             )
             _ensure_payload_contains_component_rows(
                 payload=final_payload,
@@ -35919,6 +36140,7 @@ def create_command(
                 app_entries=app_entries,
                 app_namespace_overrides=app_namespace_overrides,
                 app_releasename_overrides=app_releasename_overrides,
+                app_version_overrides=app_version_overrides,
             )
             _ensure_payload_contains_component_rows(
                 payload=final_payload,
@@ -35982,6 +36204,17 @@ def create_command(
                 payload=final_payload,
                 app_entries=app_entries,
                 already_validated_app_ids=source_validated_app_ids,
+            )
+            requested_version_app_ids = set(app_version_overrides)
+            requested_version_app_ids.update(
+                _app_chart_ids_with_non_catalog_versions(
+                    payload=final_payload,
+                    app_entries=app_entries,
+                )
+            )
+            _validate_requested_app_chart_versions_or_raise(
+                payload=final_payload,
+                candidate_app_ids=requested_version_app_ids,
             )
         selected_infra = _enabled_ids_from_runtime_payload(
             payload=final_payload,
@@ -36249,6 +36482,38 @@ def component_add_command(
             help="Disable interactive selection and field prompts.",
         ),
     ] = False,
+    app_namespace_opt: Annotated[
+        list[str] | None,
+        typer.Option(
+            "--app-namespace",
+            help=(
+                "Override added app namespace with '<app-id>=<namespace>' "
+                "(repeatable or comma-separated). Applies to app rows added by this operation."
+            ),
+        ),
+    ] = None,
+    app_releasename_opt: Annotated[
+        list[str] | None,
+        typer.Option(
+            "--app-releasename",
+            help=(
+                "Override added app release name with '<app-id>=<release-name>' "
+                "(repeatable or comma-separated). Applies to app rows added by this operation."
+            ),
+        ),
+    ] = None,
+    app_version_opt: Annotated[
+        list[str] | None,
+        typer.Option(
+            "--app-version",
+            help=(
+                "Override added app chart version with '<app-id>=<chart-version>' "
+                "(repeatable or comma-separated). Defaults come from component_sources.yaml; "
+                "with source validation enabled, the requested chart version must resolve before "
+                "component add writes config.yaml."
+            ),
+        ),
+    ] = None,
     network_ids_opt: Annotated[
         list[str] | None,
         typer.Option(
@@ -36312,6 +36577,9 @@ def component_add_command(
 
       --config <config.yaml>
       --no-interactive
+      --app-namespace <app-id>=<namespace>
+      --app-releasename <app-id>=<release-name>
+      --app-version <app-id>=<chart-version>
       --network-id <id-or-scoped-id>
       --subnet-id <id-or-scoped-id>
       --network-ref <ref-or-scoped-ref>
@@ -36353,6 +36621,18 @@ def component_add_command(
         interactive_mode = not no_interactive
         client_name, tenant_id, project_id, region_id, email = _identity_values_from_payload(
             payload
+        )
+        app_namespace_overrides = _parse_component_value_overrides(
+            raw_values=app_namespace_opt,
+            option_name="--app-namespace",
+        )
+        app_releasename_overrides = _parse_component_value_overrides(
+            raw_values=app_releasename_opt,
+            option_name="--app-releasename",
+        )
+        app_version_overrides = _parse_component_value_overrides(
+            raw_values=app_version_opt,
+            option_name="--app-version",
         )
         provider_lookup = ProviderOptionLookup()
         provider_scope_validated = False
@@ -36554,6 +36834,7 @@ def component_add_command(
             app_entries=app_entries,
             existing_payload=payload,
             merge_existing=True,
+            app_version_overrides=app_version_overrides,
         )
         dependency_resolution_started = time.monotonic()
         app_chart_dependency_payload = dependency_seed_payload if requested_apps_types else None
@@ -36836,6 +37117,7 @@ def component_add_command(
             field_wizard_kwargs: dict[str, Any] = {}
             if soperator_profile is not None:
                 field_wizard_kwargs["skip_soperator_profile_prompt"] = True
+            field_wizard_kwargs["prompt_app_version_before_app_config"] = True
             skipped_components: set[tuple[ComponentScope, str, str]] = set()
             config_yaml_override, wizard_completed = _run_component_field_wizard(
                 config_yaml=config_yaml_override,
@@ -37160,6 +37442,27 @@ def component_add_command(
             app_entries=app_entries,
         )
         _refresh_soperator_onboarding_fingerprints(next_payload)
+        newly_enabled_app_identities = {
+            (
+                component_type_id(row),
+                component_instance_id(row),
+            )
+            for row in _dynamic_enabled_app_chart_rows(next_payload)
+            if (
+                component_type_id(row),
+                component_instance_id(row),
+            )
+            not in initially_enabled_app_rows
+        }
+        newly_enabled_app_ids = {app_id for app_id, _instance_id in newly_enabled_app_identities}
+        _apply_app_release_overrides(
+            payload=next_payload,
+            selected_apps=newly_enabled_app_ids,
+            selected_app_identities=newly_enabled_app_identities,
+            namespace_overrides=app_namespace_overrides,
+            release_name_overrides=app_releasename_overrides,
+            version_overrides=app_version_overrides,
+        )
         if validate_sources:
             final_app_ids_to_validate = _enabled_app_ids_for_new_rows(
                 payload=next_payload,
@@ -37170,6 +37473,18 @@ def component_add_command(
                 app_entries=app_entries,
                 already_validated_app_ids=source_validated_app_ids,
                 candidate_app_ids=final_app_ids_to_validate,
+            )
+            requested_version_app_ids = set(app_version_overrides)
+            requested_version_app_ids.update(
+                _app_chart_ids_with_non_catalog_versions(
+                    payload=next_payload,
+                    app_entries=app_entries,
+                )
+                & newly_enabled_app_ids
+            )
+            _validate_requested_app_chart_versions_or_raise(
+                payload=next_payload,
+                candidate_app_ids=requested_version_app_ids,
             )
 
         wrote_config = _write_runtime_payload_config(config_path.resolve(), next_payload)

--- a/services/nebius-cxcli/tests/test_cli.py
+++ b/services/nebius-cxcli/tests/test_cli.py
@@ -7966,7 +7966,7 @@ def test_create_field_wizard_uses_entered_cluster_name_for_app_defaults(
     cli_module._apply_soperator_profile_to_payload(payload, profile="nebius-cpu-v1")
     cli_module._materialize_soperator_component_defaults(payload)
 
-    decisions = iter([True, False, False, False])
+    decisions = iter([True, True, False, False])
     monkeypatch.setattr(
         cli_module,
         "_wizard_continue_phase",
@@ -7979,18 +7979,9 @@ def test_create_field_wizard_uses_entered_cluster_name_for_app_defaults(
         lambda **_kwargs: (set(), ()),
     )
 
-    def _prompt_scalar_override(path_label, current, **_kwargs):  # type: ignore[no-untyped-def]
-        if path_label.endswith(".inputs.cluster.cluster_name"):
-            return "soperator-cluster1", False
-        if path_label.endswith(".inputs.cluster.network_id"):
-            return "vpcnetwork-1", False
-        if path_label.endswith(".inputs.cluster.subnet_id"):
-            return "vpcsubnet-1", False
-        if path_label.endswith(".inputs.cluster.k8s_version"):
-            return "1.33", False
-        return current, False
-
     previewed_app_targets: list[tuple[str, str, str]] = []
+    sfs_name_prompt_defaults: dict[str, str] = {}
+    sfs_mount_tag_prompt_defaults: dict[str, str] = {}
 
     def _capture_app_defaults_preview(component_node, *, entry):  # type: ignore[no-untyped-def]
         if not isinstance(component_node, dict):
@@ -8004,6 +7995,21 @@ def test_create_field_wizard_uses_entered_cluster_name_for_app_defaults(
                 str(cluster_name),
             )
         )
+
+    def _prompt_scalar_override(path_label, current, **_kwargs):  # type: ignore[no-untyped-def]
+        if path_label.endswith(".inputs.cluster.cluster_name"):
+            return "soperator-cluster1", False
+        if path_label.endswith(".inputs.cluster.network_id"):
+            return "vpcnetwork-1", False
+        if path_label.endswith(".inputs.cluster.subnet_id"):
+            return "vpcsubnet-1", False
+        if path_label.endswith(".inputs.cluster.k8s_version"):
+            return "1.33", False
+        if ".inputs.filesystems." in path_label and path_label.endswith(".name"):
+            sfs_name_prompt_defaults[path_label] = str(current)
+        if ".inputs.filesystems." in path_label and path_label.endswith(".mount_tag"):
+            sfs_mount_tag_prompt_defaults[path_label] = str(current)
+        return current, False
 
     monkeypatch.setattr(cli_module, "_prompt_scalar_override", _prompt_scalar_override)
     monkeypatch.setattr(
@@ -8019,6 +8025,7 @@ def test_create_field_wizard_uses_entered_cluster_name_for_app_defaults(
         infra_entries=infra_entries,
         app_entries=app_entries,
         align_infra_resource_names_before_apps=True,
+        prompt_app_version_before_app_config=True,
     )
 
     assert completed is True
@@ -8037,6 +8044,25 @@ def test_create_field_wizard_uses_entered_cluster_name_for_app_defaults(
     assert charts["cert-manager"]["instance_id"] == "soperator-cluster1"
     assert ("soperator", "soperator-cluster1", "soperator-cluster1") in previewed_app_targets
     assert all(target != "mk8s" for _app_id, target, _cluster_name in previewed_app_targets)
+
+    sfs = next(row for row in updated["infra"]["components"] if row["id"] == "sfs")
+    sfs_filesystems = sfs["inputs"]["filesystems"]
+    assert sfs_filesystems["jail"]["name"] == "soperator-cluster1-jail"
+    assert sfs_filesystems["controller-spool"]["name"] == (
+        "soperator-cluster1-controller-spool"
+    )
+    assert sfs_filesystems["accounting"]["name"] == "soperator-cluster1-accounting"
+    assert sfs_filesystems["jail"]["mount_tag"] == "soperator-cluster1-jail"
+    assert sfs_filesystems["controller-spool"]["mount_tag"] == (
+        "soperator-cluster1-controller-spool"
+    )
+    assert sfs_filesystems["accounting"]["mount_tag"] == "soperator-cluster1-accounting"
+    assert sfs_name_prompt_defaults[
+        "infra.components[1].inputs.filesystems.accounting.name"
+    ] == "soperator-cluster1-accounting"
+    assert sfs_mount_tag_prompt_defaults[
+        "infra.components[1].inputs.filesystems.accounting.mount_tag"
+    ] == "soperator-cluster1-accounting"
 
 
 def test_create_auto_enables_observability_agent_when_wizard_turns_on_observability(
@@ -9191,6 +9217,241 @@ def test_create_app_namespace_and_releasename_overrides(tmp_path: Path) -> None:
     assert isinstance(n8n_row, dict)
     assert n8n_row.get("namespace") == "automation"
     assert n8n_row.get("release-name") == "workflow-core"
+
+
+def test_create_app_version_override_replaces_catalog_pin(tmp_path: Path) -> None:
+    deployments_root = tmp_path / "deployments"
+    deployments_root.mkdir(parents=True, exist_ok=True)
+
+    result = _create_non_interactive(
+        deployments_root,
+        "--infra",
+        "mk8s",
+        "--app",
+        "soperator",
+        "--app-version",
+        "soperator=4.0.1-ps.2",
+        "--no-validate-config",
+    )
+    assert result.exit_code == 0, result.output
+
+    payload = yaml.safe_load(_project_config_path(deployments_root).read_text(encoding="utf-8"))
+    soperator_row = next(
+        row
+        for row in payload["apps"]["charts"]
+        if isinstance(row, dict) and row.get("id") == "soperator"
+    )
+    assert soperator_row["version"] == "4.0.1-ps.2"
+
+
+def test_create_app_version_override_validates_requested_chart_before_write(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    deployments_root = tmp_path / "deployments"
+    deployments_root.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setattr(cli_module, "_validate_component_sources_or_raise", lambda **_kwargs: None)
+
+    def _chart_issues(
+        *,
+        chart_name: str,
+        chart_repo: str,
+        chart_version: str,
+        chart_meta_cache=None,
+    ) -> tuple[str, ...]:
+        _ = chart_name, chart_repo, chart_meta_cache
+        if chart_version == "9.9.9-ps.9":
+            return ("could not be resolved by helm (soperator): not found",)
+        return ()
+
+    monkeypatch.setattr(cli_module, "_resolve_helm_chart_validation_issues", _chart_issues)
+
+    result = runner.invoke(
+        app,
+        [
+            "create",
+            str(deployments_root),
+            "--no-interactive",
+            "--client-name",
+            "client-a",
+            "--tenant-id",
+            "tenant-123",
+            "--project-id",
+            "project-456",
+            "--validate-sources",
+            "--no-validate-config",
+            "--infra",
+            "mk8s",
+            "--app",
+            "soperator",
+            "--app-version",
+            "soperator=9.9.9-ps.9",
+        ],
+    )
+
+    assert result.exit_code == 1, result.output
+    assert "Requested app chart version validation failed" in result.output
+    assert "apps.charts[soperator@mk8s]" in result.output
+    assert "9.9.9-ps.9" in result.output
+    assert not _project_config_path(deployments_root).exists()
+
+
+def test_app_field_wizard_prompts_for_chart_version(monkeypatch: pytest.MonkeyPatch) -> None:
+    app_entry = cli_module.ComponentEntry(
+        id="soperator",
+        scope="apps",
+        config_path="apps.charts.soperator",
+        description="Soperator",
+        chart_name="soperator",
+        version="4.0.2-ps.1",
+        default_namespace="soperator",
+        default_release_name="soperator",
+    )
+    payload = {
+        "version": "v1",
+        "infra": {"components": []},
+        "apps": {
+            "charts": [
+                {
+                    "id": "soperator",
+                    "instance_id": "soperator",
+                    "enabled": True,
+                    "repo": "oci://example.invalid/charts/soperator",
+                    "version": "4.0.2-ps.1",
+                    "namespace": "soperator",
+                    "release-name": "soperator",
+                    "values": {},
+                }
+            ]
+        },
+    }
+    prompted_paths: list[str] = []
+
+    monkeypatch.setattr(cli_module, "_wizard_continue_phase", lambda *_args, **_kwargs: True)
+
+    def _prompt_scalar(path_label: str, current: object, **_kwargs) -> tuple[object, bool]:
+        prompted_paths.append(path_label)
+        if path_label.endswith(".version"):
+            return "4.0.1-ps.2", False
+        return current, False
+
+    monkeypatch.setattr(cli_module, "_prompt_scalar_override", _prompt_scalar)
+
+    updated_yaml, completed = cli_module._run_component_field_wizard(
+        config_yaml=yaml.safe_dump(payload, sort_keys=False),
+        selected_infra=set(),
+        selected_apps={"soperator"},
+        infra_entries=(),
+        app_entries=(app_entry,),
+        prompt_app_version_before_app_config=True,
+    )
+
+    updated = yaml.safe_load(updated_yaml)
+    assert completed is True
+    assert "apps.charts[0].version" in prompted_paths
+    assert updated["apps"]["charts"][0]["version"] == "4.0.1-ps.2"
+
+
+def test_app_wizard_prompts_for_chart_version_before_full_app_config(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    app_entry = cli_module.ComponentEntry(
+        id="soperator",
+        scope="apps",
+        config_path="apps.charts.soperator",
+        description="Soperator",
+        chart_name="soperator",
+        version="4.0.2-ps.1",
+        default_namespace="soperator",
+        default_release_name="soperator",
+    )
+    payload = {
+        "version": "v1",
+        "infra": {"components": []},
+        "apps": {
+            "charts": [
+                {
+                    "id": "soperator",
+                    "instance_id": "soperator",
+                    "enabled": True,
+                    "repo": "oci://example.invalid/charts/soperator",
+                    "version": "4.0.2-ps.1",
+                    "namespace": "soperator",
+                    "release-name": "soperator",
+                    "values": {},
+                }
+            ]
+        },
+    }
+    prompted_paths: list[str] = []
+
+    monkeypatch.setattr(cli_module, "_wizard_continue_phase", lambda *_args, **_kwargs: False)
+
+    def _prompt_scalar(path_label: str, current: object, **_kwargs) -> tuple[object, bool]:
+        prompted_paths.append(path_label)
+        if path_label.endswith(".version"):
+            return "4.0.1-ps.2", False
+        return current, False
+
+    monkeypatch.setattr(cli_module, "_prompt_scalar_override", _prompt_scalar)
+
+    updated_yaml, completed = cli_module._run_component_field_wizard(
+        config_yaml=yaml.safe_dump(payload, sort_keys=False),
+        selected_infra=set(),
+        selected_apps={"soperator"},
+        infra_entries=(),
+        app_entries=(app_entry,),
+        prompt_app_version_before_app_config=True,
+    )
+
+    updated = yaml.safe_load(updated_yaml)
+    assert completed is True
+    assert prompted_paths == ["apps.charts[0].version"]
+    assert updated["apps"]["charts"][0]["version"] == "4.0.1-ps.2"
+
+
+def test_changed_app_chart_version_detection_uses_exact_helm_version() -> None:
+    app_entry = cli_module.ComponentEntry(
+        id="soperator",
+        scope="apps",
+        config_path="apps.charts.soperator",
+        description="Soperator",
+        chart_name="soperator",
+        version="4.0.2-ps.1",
+        default_namespace="soperator",
+        default_release_name="soperator",
+    )
+    payload = {
+        "infra": {
+            "components": [
+                {
+                    "id": "mk8s",
+                    "instance_id": "mk8s",
+                    "enabled": True,
+                    "inputs": {},
+                }
+            ]
+        },
+        "apps": {
+            "charts": [
+                {
+                    "id": "soperator",
+                    "instance_id": "mk8s",
+                    "enabled": True,
+                    "repo": "oci://example.invalid/charts/soperator",
+                    "version": "v4.0.2-ps.1",
+                    "namespace": "soperator",
+                    "release-name": "soperator",
+                    "values": {},
+                }
+            ]
+        },
+    }
+
+    assert cli_module._app_chart_ids_with_non_catalog_versions(
+        payload=payload,
+        app_entries=(app_entry,),
+    ) == {"soperator"}
 
 
 def test_create_rejects_enabled_app_without_mk8s_target(tmp_path: Path) -> None:
@@ -11532,6 +11793,189 @@ def test_component_add_noninteractive_adds_app_chart_and_preserves_existing_valu
     assert gateway_refreshed["namespace"] == "edge"
     assert gateway_refreshed["release-name"] == "edge-gateway"
     assert n8n_row["enabled"] is True
+
+
+def test_component_add_app_release_overrides_apply_to_added_chart(tmp_path: Path) -> None:
+    deployments_root = tmp_path / "deployments"
+    deployments_root.mkdir(parents=True, exist_ok=True)
+
+    created = _create_non_interactive(
+        deployments_root,
+        "--infra",
+        "mk8s",
+        "--app",
+        "none",
+    )
+    assert created.exit_code == 0, created.output
+
+    config_path = _project_config_path(deployments_root)
+    result = _component_add(
+        config_path,
+        "n8n",
+        "--no-interactive",
+        "--app-namespace",
+        "n8n=automation",
+        "--app-releasename",
+        "n8n=workflow-core",
+        "--app-version",
+        "n8n=1.2.3-test.1",
+    )
+
+    assert result.exit_code == 0, result.output
+    payload = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+    charts = payload.get("apps", {}).get("charts", [])
+    assert isinstance(charts, list)
+    n8n_row = next(
+        row for row in charts if isinstance(row, dict) and row.get("id") == "n8n"
+    )
+    assert n8n_row["namespace"] == "automation"
+    assert n8n_row["release-name"] == "workflow-core"
+    assert n8n_row["version"] == "1.2.3-test.1"
+
+
+def test_component_add_app_release_overrides_apply_to_each_added_target(
+    tmp_path: Path,
+) -> None:
+    deployments_root = tmp_path / "deployments"
+    deployments_root.mkdir(parents=True, exist_ok=True)
+
+    created = _create_non_interactive(
+        deployments_root,
+        "--infra",
+        "mk8s",
+        "--app",
+        "none",
+    )
+    assert created.exit_code == 0, created.output
+
+    config_path = _project_config_path(deployments_root)
+    add_cluster = _component_add(config_path, "mk8s@mk8s-2", "--no-interactive")
+    assert add_cluster.exit_code == 0, add_cluster.output
+
+    result = _component_add(
+        config_path,
+        "n8n@mk8s",
+        "n8n@mk8s-2",
+        "--no-interactive",
+        "--app-version",
+        "n8n=1.2.3-test.1",
+    )
+
+    assert result.exit_code == 0, result.output
+    payload = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+    charts = payload.get("apps", {}).get("charts", [])
+    assert isinstance(charts, list)
+    n8n_rows = [
+        row for row in charts if isinstance(row, dict) and row.get("id") == "n8n"
+    ]
+    assert {
+        (row.get("instance_id"), row.get("version")) for row in n8n_rows
+    } == {
+        ("mk8s", "1.2.3-test.1"),
+        ("mk8s-2", "1.2.3-test.1"),
+    }
+
+
+def test_component_add_app_version_override_validates_requested_chart_before_write(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    deployments_root = tmp_path / "deployments"
+    deployments_root.mkdir(parents=True, exist_ok=True)
+
+    created = _create_non_interactive(
+        deployments_root,
+        "--infra",
+        "mk8s",
+        "--app",
+        "none",
+    )
+    assert created.exit_code == 0, created.output
+
+    monkeypatch.setattr(cli_module, "_validate_component_sources_or_raise", lambda **_kwargs: None)
+
+    def _chart_issues(
+        *,
+        chart_name: str,
+        chart_repo: str,
+        chart_version: str,
+        chart_meta_cache=None,
+    ) -> tuple[str, ...]:
+        _ = chart_name, chart_repo, chart_meta_cache
+        if chart_version == "9.9.9-test.9":
+            return ("could not be resolved by helm (n8n): not found",)
+        return ()
+
+    monkeypatch.setattr(cli_module, "_resolve_helm_chart_validation_issues", _chart_issues)
+
+    config_path = _project_config_path(deployments_root)
+    original_config = config_path.read_text(encoding="utf-8")
+    result = runner.invoke(
+        app,
+        [
+            "component",
+            "add",
+            "n8n",
+            "--config",
+            str(config_path),
+            "--no-interactive",
+            "--validate-sources",
+            "--app-version",
+            "n8n=9.9.9-test.9",
+        ],
+    )
+
+    assert result.exit_code == 1, result.output
+    assert "Requested app chart version validation failed" in result.output
+    assert "apps.charts[n8n@mk8s]" in result.output
+    assert "9.9.9-test.9" in result.output
+    assert config_path.read_text(encoding="utf-8") == original_config
+
+
+def test_component_add_wizard_prompts_for_chart_version_before_full_app_config(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    deployments_root = tmp_path / "deployments"
+    deployments_root.mkdir(parents=True, exist_ok=True)
+
+    created = _create_non_interactive(
+        deployments_root,
+        "--infra",
+        "mk8s",
+        "--app",
+        "none",
+    )
+    assert created.exit_code == 0, created.output
+
+    def _wizard_phase(label: str, *, default: bool = True, allow_back: bool = False) -> bool:
+        _ = default, allow_back
+        return label == "Add selected components to config.yaml now?"
+
+    monkeypatch.setattr(cli_module, "_wizard_continue_phase", _wizard_phase)
+
+    prompted_paths: list[str] = []
+
+    def _prompt_scalar(path_label: str, current: object, **_kwargs) -> tuple[object, bool]:
+        prompted_paths.append(path_label)
+        if path_label.endswith(".version"):
+            return "1.2.3-test.1", False
+        return current, False
+
+    monkeypatch.setattr(cli_module, "_prompt_scalar_override", _prompt_scalar)
+
+    config_path = _project_config_path(deployments_root)
+    result = _component_add(config_path, "n8n")
+
+    assert result.exit_code == 0, result.output
+    assert prompted_paths == ["apps.charts[0].version"]
+    payload = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+    charts = payload.get("apps", {}).get("charts", [])
+    assert isinstance(charts, list)
+    n8n_row = next(
+        row for row in charts if isinstance(row, dict) and row.get("id") == "n8n"
+    )
+    assert n8n_row["version"] == "1.2.3-test.1"
 
 
 def test_component_add_reuses_noninteractive_scope_validation_for_existing_config(

--- a/services/nebius-cxcli/tests/test_cli.py
+++ b/services/nebius-cxcli/tests/test_cli.py
@@ -11724,7 +11724,7 @@ def test_component_add_mysterybox_interactive_preserves_existing_mk8s_target(
     result = _component_add(
         config_path,
         "mysterybox",
-        input_text="y\ny\n\n" + json.dumps(secrets) + "\n\n",
+        input_text="y\ny\n\n" + json.dumps(secrets) + "\n\n\n",
     )
 
     assert result.exit_code == 0, result.output

--- a/services/nebius-cxcli/tests/test_cli_command_coverage.py
+++ b/services/nebius-cxcli/tests/test_cli_command_coverage.py
@@ -17765,6 +17765,8 @@ def test_help_text_aligns_render_and_apply_surfaces() -> None:
     assert "copy-paste commands" in deploy_help
     assert "important generated paths" in deploy_help
     assert "day-2 lifecycle upgrades from config.yaml" in upgrade_help
+    legacy_scope_label = "V" + "1"
+    assert legacy_scope_label not in upgrade_help
     assert "k8s-version" in upgrade_help
     assert "node-template" in upgrade_help
     assert "os-image" in upgrade_help
@@ -18203,6 +18205,8 @@ def test_command_help_usage_labels_positional_target_types() -> None:
     assert "Validate infra sources first" in normalized_create_help
     assert "selected app chart sources" in normalized_create_help
     assert "auto-enabled app dependencies" in normalized_create_help
+    assert "--app-version" in normalized_create_help
+    assert "Override app chart version" in normalized_create_help
     assert "list [OPTIONS]" in component_list_help
     assert "--config CONFIG_YAML" in normalized_component_list_help
     assert "nebius-cxcli component list --config <config.yaml>" in normalized_component_list_help
@@ -18260,6 +18264,11 @@ def test_command_help_usage_labels_positional_target_types() -> None:
     assert "Validate infra sources first" in normalized_component_add_help
     assert "app chart sources selected" in normalized_component_add_help
     assert "auto-enabled by this add" in normalized_component_add_help
+    assert "--app-namespace" in normalized_component_add_help
+    assert "--app-releasename" in normalized_component_add_help
+    assert "--app-version" in normalized_component_add_help
+    assert "Override added app chart version" in normalized_component_add_help
+    assert "requested chart version must resolve before" in normalized_component_add_help
     assert "component add" in normalized_component_add_help
     assert (
         "Add source-defined components to an existing project config.yaml"
@@ -20614,7 +20623,7 @@ def test_soperator_selection_seeds_required_infra_and_defaults() -> None:
     sfs_inputs = payload["infra"]["components"][1]["inputs"]
     assert sfs_inputs["filesystems"]["jail"]["name"] == "cluster1-jail"
     assert sfs_inputs["filesystems"]["jail"]["block_size_kib"] == 4
-    assert sfs_inputs["filesystems"]["accounting"]["mount_tag"] == "accounting"
+    assert sfs_inputs["filesystems"]["accounting"]["mount_tag"] == "cluster1-accounting"
     for filesystem_key in ("jail", "controller-spool", "accounting"):
         filesystem = sfs_inputs["filesystems"][filesystem_key]
         assert filesystem["block_size_kib"] == 4
@@ -20637,12 +20646,12 @@ def test_soperator_selection_seeds_required_infra_and_defaults() -> None:
         },
     }
     assert soperator_values["slurmNodes"]["login"]["sshRootPublicKeys"] == []
-    assert soperator_values["sfs"]["filesystems"]["jail"]["mount_tag"] == "jail"
+    assert soperator_values["sfs"]["filesystems"]["jail"]["mount_tag"] == "cluster1-jail"
     assert soperator_values["volume"]["jail"]["size"] == "1024Gi"
     assert soperator_values["volume"]["accounting"]["enabled"] is True
     assert soperator_values["volume"]["accounting"]["size"] == "128Gi"
     assert soperator_values["volume"]["controllerSpool"]["filestoreDeviceName"] == (
-        "controller-spool"
+        "cluster1-controller-spool"
     )
     assert soperator_values["nodeGroupMapping"]["worker"] == ["worker"]
 
@@ -20738,21 +20747,21 @@ def test_soperator_profiles_share_complete_sfs_filesystem_defaults() -> None:
             "name": "{target}-jail",
             "size_gib": 1024,
             "block_size_kib": 4,
-            "mount_tag": "jail",
+            "mount_tag": "{target}-jail",
             "forbid_deletion": False,
         }
         assert filesystems["controller-spool"] == {
             "name": "{target}-controller-spool",
             "size_gib": 128,
             "block_size_kib": 4,
-            "mount_tag": "controller-spool",
+            "mount_tag": "{target}-controller-spool",
             "forbid_deletion": False,
         }
         assert filesystems["accounting"] == {
             "name": "{target}-accounting",
             "size_gib": 128,
             "block_size_kib": 4,
-            "mount_tag": "accounting",
+            "mount_tag": "{target}-accounting",
             "forbid_deletion": False,
         }
 

--- a/services/nebius-cxcli/tests/test_docs_alignment.py
+++ b/services/nebius-cxcli/tests/test_docs_alignment.py
@@ -32,12 +32,14 @@ def test_design_architecture_summary_matches_upgrade_surface() -> None:
     architecture_flat = _squash(architecture)
     design_flat = _squash(design)
 
-    assert "V1 implements Kubernetes version, combined node-template, OS image" in (
+    assert "It supports Kubernetes version, combined node-template, OS image" in (
         architecture_flat
     )
     assert "focused MK8s node-layer, and target-scoped Helm chart upgrades" in (
         architecture_flat
     )
+    legacy_scope_label = "V" + "1"
+    assert legacy_scope_label not in architecture_flat
     assert "separate subcommands instead of folding unrelated layers" in architecture_flat
     assert "later GPU stack, platform, hardware preset, and app/chart upgrades" not in (
         architecture_flat
@@ -77,6 +79,14 @@ def test_readme_documents_redacted_guided_create_prefill_example() -> None:
         and "--app cert-manager" in readme
     )
     assert "App chart dependencies can still add required chart rows automatically." in flat
+    assert (
+        "`release.namespace`, `release.name`: default Helm namespace and release name "
+        "used during `create` and `component add`."
+    ) in readme
+    assert (
+        "`release.namespace` and `release.name` are the default Helm namespace and "
+        "release name used by `create` and `component add`."
+    ) in readme
     assert re.search(r"\btenant-[a-z0-9]{16,}\b", readme) is None
     assert re.search(r"\bproject-[a-z0-9]{16,}\b", readme) is None
 
@@ -180,10 +190,16 @@ def test_readme_supporting_commands_include_current_quota_and_target_flags() -> 
     common_flags = supporting.split("Common command flags:", maxsplit=1)[1]
     common_flags_flat = _squash(common_flags)
     assert (
+        "- `component add`: `--no-interactive`, `--app-namespace`, "
+        "`--app-releasename`, `--app-version`, `--network-id`, `--subnet-id`, "
+        "`--network-ref`, `--subnet-ref`, "
+        "`--validate-sources/--no-validate-sources`"
+    ) in common_flags_flat
+    assert (
         "- `create`:\n  `--client-name`, `--tenant-id`, `--project-id`, `--region-id`, "
         "`--email`, `--infra`, `--app`, `--app-namespace`, `--app-releasename`, "
-        "`--network-id`, `--subnet-id`, `--network-ref`, `--subnet-ref`, "
-        "`--validate-sources/--no-validate-sources`, "
+        "`--app-version`, `--network-id`, `--subnet-id`, `--network-ref`, "
+        "`--subnet-ref`, `--validate-sources/--no-validate-sources`, "
         "`--validate-config/--no-validate-config`, `--no-interactive`, `--force`"
     ) in common_flags
     assert (

--- a/skills/CHANGELOG.md
+++ b/skills/CHANGELOG.md
@@ -42,6 +42,10 @@ All notable changes to the reusable Codex skills are tracked here.
   parent-thread discipline, bounded read-only subagents, local-only hook
   templates, final risk review guidance, a local-only template validation
   helper, and a skill-local design README.
+- Added the `install-grafana-mcp-for-nebius` Codex skill for installing the
+  official Grafana MCP server, wiring it into Codex, refreshing a
+  Nebius-managed Grafana token file, discovering Grafana datasources, and
+  keeping external Grafana static-key setup guarded and optional.
 - Added skill-local `README.md` files across reusable skills so each skill
   folder has human-facing architecture, workflow, core concept, and file
   responsibility documentation.
@@ -61,6 +65,21 @@ All notable changes to the reusable Codex skills are tracked here.
   read-only information gathering: it reports from existing files only and does
   not edit, format, build, test, install, generate coverage, or stage files.
   Its helper also disables Git optional locks for Git inspection commands.
+- Expanded `install-grafana-mcp-for-nebius` with a Nebius-managed Grafana
+  token-refresh wrapper, Codex registration examples that launch the wrapper,
+  and clearer tenant/project input guidance. The default path now avoids
+  Nebius static-key and service-account setup unless the user explicitly asks
+  to connect external Grafana to Nebius read endpoints.
+- Hardened `install-grafana-mcp-for-nebius` for repeated laptop runs with an
+  idempotent setup contract, check/apply local-config helper, managed shell
+  defaults, check-before-add Codex MCP registration, and no duplicate
+  static-key issuance unless rotation is explicitly requested.
+- Aligned `install-grafana-mcp-for-nebius` with the current Grafana MCP docs
+  and the latest released/Homebrew binary behavior: the wrapper now prefers
+  token-file auth when supported, falls back to startup-only inline token auth
+  for released binaries that lack token-file support, and the config helper now
+  reports mismatched existing Codex MCP servers instead of silently reusing
+  them.
 - Minimized the global AGENTS template to durable always-on policy, moved
   detailed workflow guidance back to skills, preserved the explicit `$align`
   post-edit rule, and shortened high-impact skill descriptions so implicit

--- a/skills/README.md
+++ b/skills/README.md
@@ -24,6 +24,8 @@ For skill-specific release notes, see [CHANGELOG.md](CHANGELOG.md).
 - Global context management for long Codex tasks: `global-context-management`
 - Stack-aware `.gitignore` generation and cleanup: `gitignore`
 - Helm chart hardening and validation: `helmchart`
+- Grafana MCP setup for Nebius Observability in Codex:
+  `install-grafana-mcp-for-nebius`
 - Shell, Markdown, and Python linting: `linter`
 - Nebius cloud automation, quota, and MK8s GPU workflows: `nebius`
 - Nebius cxcli component onboarding: `onboard-nebius-cxcli`
@@ -185,6 +187,14 @@ VS Code defaults, then extends it for the detected stack.
 
 `helmchart` applies Helm chart best practices across metadata, values,
 templates, schema, and validation.
+
+### `install-grafana-mcp-for-nebius`
+
+`install-grafana-mcp-for-nebius` installs and configures the official Grafana
+MCP server for Codex, refreshes the Nebius-managed Grafana token file, keeps
+external Grafana service-account/static-key setup out of the default path, and
+guides agents through idempotent Codex MCP registration, datasource discovery,
+Prometheus, Loki, trace-tool checks, and read-only validation.
 
 ### `linter`
 

--- a/skills/install-grafana-mcp-for-nebius/README.md
+++ b/skills/install-grafana-mcp-for-nebius/README.md
@@ -1,0 +1,68 @@
+# Install Grafana MCP for Nebius
+
+This skill guides Codex through installing the official Grafana MCP server,
+wiring it into Codex, and connecting it to Nebius-managed Grafana at
+`https://grafana.nebius.dev/` so Codex can query metrics and logs through
+Grafana datasources.
+
+## Design
+
+The skill keeps a strict boundary between four credentials and token surfaces:
+
+- Nebius IAM access token: a 12-hour token refreshed by the local Nebius CLI
+  and used by MCP for Nebius-managed Grafana at `https://grafana.nebius.dev/`.
+  The wrapper prefers token-file auth when the installed `mcp-grafana` supports
+  it, and falls back to startup-only inline token auth for released binaries
+  that do not.
+- Grafana service-account token: used only for generic Grafana, Grafana Cloud,
+  or another external Grafana instance.
+- Nebius Observability static key: used only when configuring an external
+  Grafana datasource to call Nebius public read endpoints directly.
+- Nebius CLI identity: used by the wrapper to refresh the Nebius IAM token.
+
+The most important correction is that `GRAFANA_URL` must be a Grafana base URL,
+not a Nebius Prometheus, Loki, or Tempo read URL. Installing the
+`mcp-grafana` binary alone also does not make Codex discover it; Codex needs an
+MCP server entry in `~/.codex/config.toml` or a `codex mcp add` registration.
+The default Nebius-managed Grafana path does not create Nebius service
+accounts or static keys.
+
+The local setup is idempotent by design. Re-running the skill should check the
+existing `mcp-grafana` binary, managed shell-startup block, token file, and
+`grafana-nebius` Codex MCP entry before changing anything. Matching state is
+reused, missing state is created, and mismatched existing MCP config is
+reported for an explicit replacement decision instead of being duplicated.
+
+## Workflow
+
+Use the skill when a user wants Codex to set up `mcp-grafana` on macOS or
+Linux, register it in Codex, and connect it to Nebius metrics, logs, or traces.
+The runtime instructions install the official binary, configure the Nebius IAM
+token refresh wrapper, register the MCP server with Codex, discover Grafana
+datasources, and run safe read-only validation. Static-key and datasource setup
+is explicitly optional for external Grafana only.
+
+Live Nebius IAM changes and static-key issuance are intentionally outside the
+default path. The skill documents an idempotent external-Grafana pattern, but
+it does not run it unless the user explicitly asks for that setup.
+
+## Files
+
+- `SKILL.md`: runtime trigger, workflow, guardrails, and output contract.
+- `references/setup-guide.md`: detailed vendor-backed commands, endpoint
+  table, Codex config snippets, and troubleshooting notes.
+- `scripts/ensure-local-config.sh`: check/apply helper for idempotent local
+  shell defaults and Codex MCP registration.
+- `scripts/run-nebius-grafana-mcp.sh`: local wrapper that refreshes a Nebius
+  IAM token into `GRAFANA_TOKEN_FILE`, maps it to the supported Grafana MCP
+  auth environment, and starts `mcp-grafana` read-only by default.
+- `scripts/test-run-nebius-grafana-mcp.sh`: local fake-command smoke test for
+  wrapper token export modes and token-file permissions.
+- `agents/openai.yaml`: UI metadata for the skill.
+
+## Vendor Evidence
+
+The setup guide links to the official Grafana MCP docs, Grafana provisioning
+docs, and Nebius Observability/IAM docs that support the commands and endpoint
+values. Re-check those sources before changing command syntax, auth headers,
+or endpoint URLs.

--- a/skills/install-grafana-mcp-for-nebius/SKILL.md
+++ b/skills/install-grafana-mcp-for-nebius/SKILL.md
@@ -1,0 +1,166 @@
+---
+name: install-grafana-mcp-for-nebius
+description: "Install and configure the official Grafana MCP server for Codex against Nebius-managed Grafana. Use when Codex needs to set up mcp-grafana on macOS or Linux, wire Codex MCP config, refresh Nebius-managed Grafana IAM token files, query metrics/logs through Grafana Prometheus/Loki datasources, check whether trace tools are available, or troubleshoot Grafana MCP access to Nebius observability data. Only use Nebius static-key/data-source setup when the user explicitly asks to connect external Grafana to Nebius read endpoints."
+---
+
+# Install Grafana MCP for Nebius
+
+## Purpose
+
+Set up the official Grafana MCP server so Codex can inspect
+`https://grafana.nebius.dev/` and query Nebius Observability data through
+datasources that are already available in that Grafana instance.
+
+## Core Model
+
+- Installing `mcp-grafana` is not enough for Codex to discover it. Codex needs
+  a configured `[mcp_servers.*]` entry or `codex mcp add`.
+- Do not point `GRAFANA_URL` at a Nebius read endpoint. It must be the Grafana
+  base URL.
+- `mcp-grafana` talks to Grafana. It can query Prometheus and Loki through
+  Grafana datasources, but it is not a Nebius public-read-endpoint client.
+- For Nebius-managed Grafana at `https://grafana.nebius.dev/`, use a refreshed
+  Nebius IAM access token in `GRAFANA_TOKEN_FILE`. Prefer
+  `GRAFANA_SERVICE_ACCOUNT_TOKEN_FILE` when the installed `mcp-grafana` binary
+  supports it, because the server can reread rotated tokens. For released
+  binaries that only support `GRAFANA_SERVICE_ACCOUNT_TOKEN`, the wrapper must
+  export the refreshed token inline at startup; restart Codex before the
+  12-hour Nebius token expires.
+- For generic Grafana or Grafana Cloud, use a Grafana service-account token.
+  Grafana token metadata can show expiration, but the token value cannot be
+  recovered later; create a new token if the old value is missing or expired.
+- Nebius service accounts and static keys are not part of the default
+  Nebius-managed Grafana MCP path. They are only needed when configuring an
+  external Grafana instance to call Nebius public read endpoints directly.
+
+## Before You Act
+
+- Re-check current official Grafana and Nebius docs before changing commands,
+  endpoints, auth headers, or config snippets.
+- Use `references/setup-guide.md` when you need the detailed workflow,
+  endpoint table, command examples, or troubleshooting notes.
+- Confirm the user wants live changes before editing `~/.codex/config.toml`,
+  editing shell startup files, running Nebius IAM writes, issuing static keys,
+  or changing Grafana data sources.
+- Never print, persist, commit, or paste real Grafana tokens, Nebius access
+  tokens, Nebius static keys, private endpoints, or customer data. Use
+  placeholders for tenant and project IDs in repo files.
+
+## Idempotency Contract
+
+- Treat this as an ensure workflow. Re-running the skill must inspect the
+  laptop first, reuse matching state, and create only missing state.
+- Check `command -v mcp-grafana` before installing. Do not reinstall when the
+  binary is already present and responds to `mcp-grafana --help`.
+- Check `codex mcp get <server-name>` before registering Codex MCP config. If
+  the server exists and matches the desired wrapper-based command, read-only
+  args, and expected env keys, leave it in place. If it exists but points
+  somewhere else, report the mismatch and update only after the user confirms
+  replacement.
+- Use a managed shell-startup block for non-secret defaults. Replace that block
+  when values change; do not append duplicate `GRAFANA_URL` or
+  `GRAFANA_TOKEN_FILE` exports.
+- The token refresh wrapper is safe to run repeatedly: it writes a fresh token
+  to a temporary file, atomically replaces `GRAFANA_TOKEN_FILE`, and keeps mode
+  `0600`.
+- For the optional external Grafana flow, look up the service account, group,
+  membership, and existing datasource state before creating anything. Do not
+  issue another Nebius static key unless the user explicitly asks for rotation.
+
+## Workflow
+
+1. Identify the target OS, Codex surface, and whether the user wants the
+   default Nebius-managed Grafana path or an external Grafana data-source
+   setup. For the default path, do not ask for `TENANT_ID`; ask for
+   `PROJECT_ID` only when the user wants project-scoped metric/log/trace query
+   help.
+2. Ensure `mcp-grafana` is installed using the official binary path for macOS
+   or Linux. Prefer Homebrew only when Homebrew is already available; otherwise
+   use the official release binary or Go install path.
+3. For Nebius-managed Grafana, ensure non-secret shell defaults and run
+   `scripts/run-nebius-grafana-mcp.sh`. Use
+   `scripts/ensure-local-config.sh --check` first; use `--apply` only when the
+   user wants local config changes. The wrapper refreshes
+   `nebius iam get-access-token` into `GRAFANA_TOKEN_FILE`, maps it to
+   `GRAFANA_SERVICE_ACCOUNT_TOKEN_FILE` when supported, falls back to
+   startup-only `GRAFANA_SERVICE_ACCOUNT_TOKEN` for released binaries that lack
+   token-file support, and starts `mcp-grafana --disable-write` unless
+   different args are supplied.
+4. Ensure Codex MCP config exists with the wrapper for Nebius-managed Grafana.
+   Never embed token values in config. Do not call `codex mcp add` blindly when
+   `codex mcp get <server-name>` already succeeds.
+5. Validate locally with `mcp-grafana --help`, `codex mcp list`, and
+   `codex mcp get <server-name>`.
+6. Validate live access by listing Grafana datasources first. If Prometheus or
+   Loki datasources are present, run a small PromQL or LogQL query through
+   Grafana MCP. For traces, first list available MCP tools and do not promise
+   direct Tempo querying unless `tempo_*` proxied tools or an equivalent
+   supported panel-query path is available.
+7. Use the external Grafana static-key flow only when the user explicitly asks
+   to configure self-hosted Grafana or Grafana Cloud to call Nebius read
+   endpoints directly.
+
+## Optional External Grafana Static-Key Flow
+
+Use this flow only when the user explicitly wants to connect an external
+Grafana instance to Nebius public read endpoints. It is not needed for the
+default `https://grafana.nebius.dev/` MCP path.
+
+- Treat `TENANT_ID`, `PROJECT_ID`, `SA_NAME`, and `GROUP_NAME` as inputs for
+  external Grafana Nebius IAM/static-key/data-source setup.
+- Default `GROUP_NAME` to the tenant `viewers` group because Nebius
+  Observability docs require at least the tenant `viewer` role.
+- First look up the service account and group. Create missing resources only
+  when the user explicitly asked for live cloud changes and the tenant/project
+  were confirmed.
+- If the default `viewers` group is unavailable or the user wants a dedicated
+  group, create a custom group and access permit only after confirming the
+  desired scope. Tenant-scoped viewer access is the documented baseline for
+  Observability; narrower project-scoped groups must be verified with
+  Grafana "Save and test" before claiming they work.
+- Check existing group membership before creating it. Treat "already exists"
+  or an already-listed member as success.
+- Issue a Nebius `OBSERVABILITY` static key only after the service account and
+  group membership are ready, then put that static key in the external Grafana
+  datasource HTTP header. Reuse an existing valid key from the user's secret
+  store when available; issue a new static key only for first setup or explicit
+  rotation. Do not pass the Nebius static key to `mcp-grafana`.
+
+## Trace Tool Caveat
+
+Nebius docs verify a Tempo data source URL for viewing traces in Grafana.
+Grafana MCP docs verify trace-specific MCP tools only through proxied Tempo MCP
+tools when the Tempo backend exposes that MCP server. Do not claim direct
+Nebius trace querying through `mcp-grafana` until the configured server lists
+usable `tempo_*` proxied tools, or until a current Nebius doc explicitly says
+its Tempo endpoint supports the Grafana Tempo MCP proxy path.
+
+## Validation
+
+Run safe static and local checks first:
+
+```bash
+mcp-grafana --help
+install-grafana-mcp-for-nebius/scripts/ensure-local-config.sh --check
+install-grafana-mcp-for-nebius/scripts/run-nebius-grafana-mcp.sh --print-config
+install-grafana-mcp-for-nebius/scripts/test-run-nebius-grafana-mcp.sh
+install-grafana-mcp-for-nebius/scripts/run-nebius-grafana-mcp.sh --refresh-token-only
+codex mcp list
+codex mcp get <server-name>
+```
+
+Live validation should list Grafana datasources first, then run a small
+PromQL/LogQL query only through a datasource available in the target Grafana.
+
+## Output Contract
+
+Report:
+
+- Grafana and Nebius docs checked.
+- Install and config commands run.
+- Whether setup reused existing state or created/updated anything.
+- Whether Codex config edits and token-file refresh were run.
+- Whether Nebius IAM writes, static-key issuance, or Grafana data-source
+  changes were intentionally skipped because they are external-Grafana-only.
+- Which Grafana datasources and MCP tools were available.
+- Whether MCP access was validated, and what remains unverified.

--- a/skills/install-grafana-mcp-for-nebius/agents/openai.yaml
+++ b/skills/install-grafana-mcp-for-nebius/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Install Grafana MCP for Nebius"
+  short_description: "Install Grafana MCP for Nebius observability"
+  default_prompt: "Use $install-grafana-mcp-for-nebius to install Grafana MCP for Codex, refresh the Nebius-managed Grafana token file, and query available Grafana datasources."

--- a/skills/install-grafana-mcp-for-nebius/references/setup-guide.md
+++ b/skills/install-grafana-mcp-for-nebius/references/setup-guide.md
@@ -1,0 +1,593 @@
+# Setup Guide
+
+Use this reference when executing `$install-grafana-mcp-for-nebius` and you
+need exact commands, endpoint values, or troubleshooting details.
+
+## Official Sources
+
+- Grafana MCP install binary:
+  <https://grafana.com/docs/grafana/latest/developer-resources/mcp/set-up/install-the-binary/>
+- Grafana MCP authentication:
+  <https://grafana.com/docs/grafana/latest/developer-resources/mcp/configure/authentication/>
+- Grafana MCP upstream repository, including token-file rotation behavior:
+  <https://github.com/grafana/mcp-grafana>
+- Grafana MCP Codex client:
+  <https://grafana.com/docs/grafana/latest/developer-resources/mcp/clients/codex/>
+- Grafana MCP tool controls:
+  <https://grafana.com/docs/grafana/latest/developer-resources/mcp/configure/enable-and-disable-tools/>
+- Grafana MCP Prometheus and Loki guides:
+  <https://grafana.com/docs/grafana/latest/developer-resources/mcp/guides/query-metrics-with-prometheus/>
+  and
+  <https://grafana.com/docs/grafana/latest/developer-resources/mcp/guides/query-logs-with-loki/>
+- Grafana MCP proxied tools:
+  <https://grafana.com/docs/grafana/latest/developer-resources/mcp/configure/proxied-tools/>
+- Optional external Grafana data source provisioning and custom HTTP headers:
+  <https://grafana.com/docs/grafana/latest/administration/provisioning/>
+- Grafana service accounts and service account HTTP API:
+  <https://grafana.com/docs/grafana/latest/administration/service-accounts/>
+  and
+  <https://grafana.com/docs/grafana/latest/developer-resources/api-reference/http-api/api-legacy/serviceaccount/>
+- Nebius access tokens and API bearer authentication:
+  <https://docs.nebius.com/iam/authorization/access-tokens>
+  and
+  <https://docs.nebius.com/grpc-api/auth>
+- Optional external Grafana connection to Nebius metrics:
+  <https://docs.nebius.com/observability/metrics/grafana>
+- Optional external Grafana connection to Nebius logs:
+  <https://docs.nebius.com/observability/logs/grafana>
+- Optional external Grafana connection to Nebius traces:
+  <https://docs.nebius.com/observability/traces/grafana>
+- Optional Nebius static keys for external tools:
+  <https://docs.nebius.com/iam/authorization/static-keys>
+- Optional Nebius service accounts and groups for static-key setup:
+  <https://docs.nebius.com/iam/service-accounts/manage>,
+  <https://docs.nebius.com/iam/authorization/groups/members>,
+  <https://docs.nebius.com/iam/authorization/groups/manage>, and
+  <https://docs.nebius.com/iam/authorization/roles>
+
+## Inputs
+
+Collect these values for the default Nebius-managed Grafana MCP path:
+
+```bash
+export MCP_SERVER_NAME="grafana-nebius"
+export GRAFANA_URL="https://grafana.nebius.dev/"
+export GRAFANA_TOKEN_FILE="$HOME/.config/grafana-mcp/token"
+export NEBIUS_GRAFANA_TOKEN_REFRESH_SECONDS="36000"
+```
+
+Use placeholders in docs and examples. Never write real values into a repo.
+
+Ask for `PROJECT_ID` when the user wants project-scoped metric/log/trace query
+help, label filtering, or resource-specific prompts. Do not ask for
+`TENANT_ID` in the default path. A basic Nebius-managed Grafana API login check
+does not need tenant or project values when the local Nebius CLI identity
+already has access.
+
+Collect these only for the optional external-Grafana data-source path:
+
+```bash
+export TENANT_ID="<tenant_ID>"
+export PROJECT_ID="<project_ID>"
+export SA_NAME="grafana-external-observability"
+export GROUP_NAME="viewers"
+```
+
+## Auth Mode Decision
+
+Choose one MCP authentication path before editing config:
+
+| Target Grafana | Token source for MCP | Refresh behavior |
+| --- | --- | --- |
+| Nebius-managed Grafana at `https://grafana.nebius.dev/` | Nebius IAM access token from `nebius iam get-access-token`, written to `GRAFANA_TOKEN_FILE`. The wrapper exposes it as `GRAFANA_SERVICE_ACCOUNT_TOKEN_FILE` when the installed binary supports token-file auth, otherwise as startup-only `GRAFANA_SERVICE_ACCOUNT_TOKEN`. | Token-file-capable builds refresh before the 12-hour Nebius token lifetime ends. Inline-only released builds require a Codex restart before token expiry. |
+| Generic self-hosted Grafana or Grafana Cloud | Grafana service-account token, preferably stored in `GRAFANA_SERVICE_ACCOUNT_TOKEN_FILE` when the installed binary supports token-file auth. Use `GRAFANA_SERVICE_ACCOUNT_TOKEN` for released binaries that lack token-file support. | Rotate by creating a new Grafana service-account token; existing token values cannot be read back |
+| External Grafana data source calling Nebius read endpoints | Nebius Observability static key in the data source HTTP header | Static key lifecycle is separate from the MCP token and is not used by MCP |
+
+`GRAFANA_URL` is always the Grafana base URL. Do not use a Nebius Prometheus,
+Loki, or Tempo read endpoint as `GRAFANA_URL`.
+
+For the default Nebius-managed Grafana path, do not create Nebius service
+accounts or issue static keys. `mcp-grafana` queries Grafana, and Grafana
+already owns the datasource connection details.
+
+## Idempotent Setup Contract
+
+Treat local setup as an ensure workflow:
+
+1. Inspect the laptop.
+2. Reuse matching state.
+3. Create only missing state.
+4. Report mismatched existing state before replacing it.
+
+Use the helper in check mode before making changes:
+
+```bash
+./install-grafana-mcp-for-nebius/scripts/ensure-local-config.sh --check
+```
+
+When the user has explicitly approved local config changes, apply the same
+ensure logic:
+
+```bash
+./install-grafana-mcp-for-nebius/scripts/ensure-local-config.sh --apply
+```
+
+The helper is intentionally conservative:
+
+- It does not install `mcp-grafana`; it reports whether the binary is already
+  present.
+- It updates only a managed shell-startup block and exact matching legacy
+  `GRAFANA_URL` or `GRAFANA_TOKEN_FILE` exports.
+- It adds the Codex MCP server only when `codex mcp get "$MCP_SERVER_NAME"`
+  cannot find it.
+- It does not remove or replace an existing Codex MCP server. If an existing
+  server uses the wrong command or environment, inspect it and replace it only
+  after the user confirms.
+
+## Shell Defaults
+
+When the user asks to persist local shell defaults, write only non-secret
+values to `~/.zshrc` and keep them in this managed block:
+
+```bash
+# >>> grafana-mcp-for-nebius >>>
+export GRAFANA_URL="https://grafana.nebius.dev/"
+export GRAFANA_TOKEN_FILE="$HOME/.config/grafana-mcp/token"
+# <<< grafana-mcp-for-nebius <<<
+```
+
+If the block already exists, replace the block instead of appending another
+one. If old standalone exports already exist with the same desired values,
+normalize them into the managed block. If standalone exports exist with
+different values, stop and ask whether the user wants to preserve a custom
+setup or replace it.
+
+Do not put `GRAFANA_SERVICE_ACCOUNT_TOKEN`, Nebius access tokens, or Nebius
+static keys in `.zshrc`. The wrapper maps `GRAFANA_TOKEN_FILE` to the
+authentication environment supported by the installed `mcp-grafana` binary.
+
+## Install `mcp-grafana`
+
+Check before installing:
+
+```bash
+command -v mcp-grafana
+mcp-grafana --help
+```
+
+If the binary is already present and `mcp-grafana --help` works, do not
+reinstall it.
+
+macOS or Linux with Homebrew:
+
+```bash
+brew install mcp-grafana
+mcp-grafana --help
+```
+
+Linux without Homebrew:
+
+- Download the official release archive for the platform and place the
+  extracted `mcp-grafana` binary in a directory on `PATH`; or
+- build from source with Go:
+
+```bash
+GOBIN="$HOME/go/bin" go install github.com/grafana/mcp-grafana/cmd/mcp-grafana@latest
+export PATH="$HOME/go/bin:$PATH"
+mcp-grafana --help
+```
+
+## Nebius-Managed Grafana Token Refresh
+
+For `https://grafana.nebius.dev/`, prefer the bundled wrapper:
+
+```bash
+./install-grafana-mcp-for-nebius/scripts/run-nebius-grafana-mcp.sh --print-config
+./install-grafana-mcp-for-nebius/scripts/run-nebius-grafana-mcp.sh --refresh-token-only
+```
+
+The wrapper:
+
+- requires `nebius` and `mcp-grafana` on `PATH`;
+- refreshes `nebius iam get-access-token` into `GRAFANA_TOKEN_FILE`;
+- writes the token file with mode `0600` and does not print the token;
+- prefers `GRAFANA_SERVICE_ACCOUNT_TOKEN_FILE="$GRAFANA_TOKEN_FILE"` when the
+  installed `mcp-grafana` binary advertises token-file support;
+- falls back to `GRAFANA_SERVICE_ACCOUNT_TOKEN` for released binaries that only
+  support inline tokens, replacing any inherited inline token with the
+  refreshed Nebius token;
+- refreshes periodically while `mcp-grafana` runs only when token-file support
+  is available; inline fallback users must restart Codex before the Nebius
+  token expires; and
+- starts `mcp-grafana --disable-write` by default.
+
+If a non-default Nebius CLI profile is needed:
+
+```bash
+export NEBIUS_PROFILE="<profile_name>"
+```
+
+Because Nebius access tokens are valid for 12 hours, keep the refresh interval
+below that lifetime. The default is 10 hours.
+
+## Query Through Nebius-Managed Grafana
+
+After Codex is restarted with the `grafana-nebius` MCP server enabled, the
+first runtime step is datasource discovery:
+
+```text
+Use grafana-nebius to list Grafana datasources and identify Prometheus, Loki,
+and Tempo datasources available for my Nebius project.
+```
+
+Then query only through discovered datasources:
+
+```text
+Use grafana-nebius to run a small PromQL query against the Nebius Prometheus
+datasource for project <project_ID>.
+```
+
+```text
+Use grafana-nebius to run a small LogQL query against the Nebius Loki
+datasource for project <project_ID>.
+```
+
+Grafana MCP has documented Prometheus and Loki query tools. For traces, first
+list available MCP tools and inspect the discovered Tempo datasource. Do not
+promise direct TraceQL or `tempo_*` tools unless the configured server actually
+exposes them.
+
+## External Grafana Only: Nebius Service Account Flow
+
+Nebius Observability docs require a service account for observability services
+and a tenant group with at least the `viewer` role.
+
+Use this section only when configuring self-hosted Grafana or Grafana Cloud to
+call Nebius public read endpoints directly. Skip it for
+`https://grafana.nebius.dev/`.
+
+Read-only discovery:
+
+```bash
+nebius iam service-account get-by-name \
+  --name "$SA_NAME" \
+  --format json
+
+nebius iam group get-by-name \
+  --name "$GROUP_NAME" \
+  --parent-id "$TENANT_ID" \
+  --format json
+```
+
+If the service account does not exist and the user has explicitly approved live
+Nebius IAM changes, create it in the current Nebius CLI project context:
+
+```bash
+export SA_ID="$(nebius iam service-account create \
+  --name "$SA_NAME" \
+  --format json | jq -r '.metadata.id')"
+```
+
+If the service account already exists:
+
+```bash
+export SA_ID="$(nebius iam service-account get-by-name \
+  --name "$SA_NAME" \
+  --format json | jq -r '.metadata.id')"
+```
+
+Resolve the group:
+
+```bash
+export GROUP_ID="$(nebius iam group get-by-name \
+  --name "$GROUP_NAME" \
+  --parent-id "$TENANT_ID" \
+  --format json | jq -r '.metadata.id')"
+```
+
+Check membership before writing:
+
+```bash
+nebius iam group-membership list-members \
+  --parent-id "$GROUP_ID" \
+  --format json | jq -e --arg sa_id "$SA_ID" \
+  '.items[]? | select(.metadata.id == $sa_id or .id == $sa_id)'
+```
+
+If membership is missing and live IAM changes are approved:
+
+```bash
+nebius iam group-membership create \
+  --parent-id "$GROUP_ID" \
+  --member-id "$SA_ID"
+```
+
+### Custom Group Option
+
+Prefer the default tenant `viewers` group unless the user asks for a dedicated
+group. If a custom group is needed, create it only after confirming tenant or
+project scope:
+
+```bash
+export GROUP_ID="$(nebius iam group create \
+  --parent-id "$TENANT_ID" \
+  --name "$GROUP_NAME" \
+  --format json | jq -r '.metadata.id')"
+
+nebius iam access-permit create \
+  --parent-id "$GROUP_ID" \
+  --resource-id "$TENANT_ID" \
+  --role viewer
+```
+
+Nebius docs show tenant-level `viewer` as the Observability prerequisite. If a
+project-scoped custom group is used instead, validate each Grafana data source
+with "Save and test" before presenting the setup as complete.
+
+## External Grafana Only: Issue Nebius Static Key
+
+Issue a static key only after the service account and group membership are
+ready:
+
+```bash
+nebius iam static-key issue \
+  --name "<name_for_the_key>" \
+  --account-service-account-id "$SA_ID" \
+  --service=OBSERVABILITY
+```
+
+Copy only the `token` value into the target secret store or a one-time local
+shell variable. Do not echo the token in logs or write it into repo files.
+
+Static keys are service-specific and cannot grant more access than the service
+account has through its groups.
+
+Do not pass this static key to `mcp-grafana`. It belongs only in the external
+Grafana datasource HTTP header.
+
+## External Grafana Only: Nebius Read Endpoints
+
+Configure these as Grafana data sources:
+
+| Signal | Grafana data source | URL |
+| --- | --- | --- |
+| Metrics | Prometheus | `https://read.monitoring.api.nebius.cloud/projects/<project_ID>/service-provider/prometheus` |
+| Logs | Loki | `https://read.logging.api.nebius.cloud/projects/<project_ID>` |
+| Traces | Tempo | `https://read.tracing.api.nebius.cloud/projects/<project_ID>/tempo` |
+
+Use a custom HTTP header named `Authorization` for the Nebius static key.
+Current Nebius docs explicitly show `Bearer <static_token>` for Tempo. The
+metrics and logs Grafana pages say to use the static key value, while other
+Nebius logging docs use bearer-token fields. For a provisioned setup, start
+with:
+
+```text
+Authorization: Bearer <static_token>
+```
+
+If Prometheus or Loki "Save and test" fails with an authentication error,
+retry the exact Nebius page wording for that data source by using the raw
+static key as the header value, then record which form passed.
+
+Grafana provisioning can keep the header value in `secureJsonData`:
+
+```yaml
+apiVersion: 1
+
+datasources:
+  - name: Nebius Metrics
+    type: prometheus
+    access: proxy
+    url: https://read.monitoring.api.nebius.cloud/projects/<project_ID>/service-provider/prometheus
+    jsonData:
+      httpHeaderName1: Authorization
+    secureJsonData:
+      httpHeaderValue1: Bearer ${NEBIUS_OBSERVABILITY_STATIC_TOKEN}
+
+  - name: Nebius Logs
+    type: loki
+    access: proxy
+    url: https://read.logging.api.nebius.cloud/projects/<project_ID>
+    jsonData:
+      httpHeaderName1: Authorization
+    secureJsonData:
+      httpHeaderValue1: Bearer ${NEBIUS_OBSERVABILITY_STATIC_TOKEN}
+
+  - name: Nebius Traces
+    type: tempo
+    access: proxy
+    url: https://read.tracing.api.nebius.cloud/projects/<project_ID>/tempo
+    jsonData:
+      httpHeaderName1: Authorization
+    secureJsonData:
+      httpHeaderValue1: Bearer ${NEBIUS_OBSERVABILITY_STATIC_TOKEN}
+```
+
+Use this YAML only as a shape. Place it in the Grafana provisioning location
+for the target deployment, and keep `NEBIUS_OBSERVABILITY_STATIC_TOKEN` outside
+the repo.
+
+## MCP Token Sources
+
+`mcp-grafana` sends bearer authentication to the Grafana API. Current Grafana
+docs support both `GRAFANA_SERVICE_ACCOUNT_TOKEN` and
+`GRAFANA_SERVICE_ACCOUNT_TOKEN_FILE`, and prefer the file form because the
+server can read the file fresh on every request and pick up rotations without
+restart. The latest released/Homebrew `mcp-grafana` may lag those docs; when an
+installed binary does not advertise token-file support, use inline
+`GRAFANA_SERVICE_ACCOUNT_TOKEN` and restart Codex before the 12-hour Nebius
+token expires.
+
+### Nebius-Managed Grafana
+
+For `https://grafana.nebius.dev/`, use the wrapper to put a refreshed Nebius
+IAM access token in `GRAFANA_TOKEN_FILE`. Do not try to recover an existing
+Grafana service-account token value. Nebius access tokens are renewable through
+the local Nebius CLI and expire after 12 hours. Run `--print-config` to see
+whether the local binary will use token-file mode or inline-env fallback.
+
+Read-only API probe shape:
+
+```bash
+python3 - <<'PY'
+import subprocess
+import urllib.request
+
+token = subprocess.check_output(
+    ["nebius", "iam", "get-access-token"], text=True
+).strip()
+request = urllib.request.Request(
+    "https://grafana.nebius.dev/api/health",
+    headers={"Authorization": f"Bearer {token}"},
+)
+with urllib.request.urlopen(request, timeout=20) as response:
+    print(response.status)
+PY
+```
+
+Never print the token. Use a throwaway token file for wrapper tests when you do
+not want to touch the default user token file:
+
+```bash
+tmp_token_file="$(mktemp)"
+GRAFANA_TOKEN_FILE="$tmp_token_file" \
+  ./install-grafana-mcp-for-nebius/scripts/run-nebius-grafana-mcp.sh \
+  --refresh-token-only
+rm -f "$tmp_token_file"
+```
+
+### Generic or External Grafana
+
+For self-hosted Grafana, Grafana Cloud, or any external Grafana instance,
+create a Grafana service-account token with the minimum RBAC needed for the
+enabled MCP tools. For read-only observability queries, the service account
+needs enough Grafana RBAC to read and query the relevant data sources, such as
+`datasources:read` and `datasources:query` for Prometheus and Loki data source
+UIDs. Dashboard read tools require dashboard/folder read scopes. Keep write
+tools disabled unless the user wants mutations.
+
+Grafana service-account tokens can have no expiration by default, or an
+expiration if one was set. The HTTP API can create new tokens and expose token
+metadata such as expiration status, but it does not recover an old token value.
+If the token file is missing or the token is expired, create a new token and
+replace the file.
+
+Store the generic Grafana token outside the repo:
+
+```bash
+mkdir -p "$(dirname "$GRAFANA_TOKEN_FILE")"
+printf '%s' '<grafana_service_account_token>' > "$GRAFANA_TOKEN_FILE"
+chmod 600 "$GRAFANA_TOKEN_FILE"
+```
+
+## Register MCP in Codex
+
+Preferred Nebius-managed Grafana registration uses the wrapper as the MCP
+server command. First inspect existing state:
+
+```bash
+export MCP_SERVER_NAME="grafana-nebius"
+codex mcp get "$MCP_SERVER_NAME"
+```
+
+If the server exists and points to the desired wrapper command, leave it in
+place. If it exists but points to a different command or token source, do not
+add a second server with the same purpose. Ask before replacing it:
+
+```bash
+codex mcp remove "$MCP_SERVER_NAME"
+```
+
+Then re-add it with the desired wrapper command.
+
+If the server is missing, resolve the script path from the installed skill
+folder and add it:
+
+```bash
+export GRAFANA_URL="https://grafana.nebius.dev/"
+export GRAFANA_TOKEN_FILE="$HOME/.config/grafana-mcp/token"
+export WRAPPER_PATH="<path_to_skill>/scripts/run-nebius-grafana-mcp.sh"
+
+codex mcp add "$MCP_SERVER_NAME" \
+  --env GRAFANA_URL="$GRAFANA_URL" \
+  --env GRAFANA_TOKEN_FILE="$GRAFANA_TOKEN_FILE" \
+  -- "$WRAPPER_PATH" --disable-write
+```
+
+Generic Grafana read-only registration for token-file-capable builds:
+
+```bash
+codex mcp add "$MCP_SERVER_NAME" \
+  --env GRAFANA_URL="$GRAFANA_URL" \
+  --env GRAFANA_SERVICE_ACCOUNT_TOKEN_FILE="$GRAFANA_TOKEN_FILE" \
+  -- mcp-grafana --disable-write
+```
+
+Inline token registration is supported by Grafana docs. Use it when the
+installed binary lacks token-file support; otherwise prefer the token-file
+shape above:
+
+```bash
+codex mcp add "$MCP_SERVER_NAME" \
+  --env GRAFANA_URL="$GRAFANA_URL" \
+  --env GRAFANA_SERVICE_ACCOUNT_TOKEN="<grafana_service_account_token>" \
+  -- mcp-grafana --disable-write
+```
+
+Manual TOML shape:
+
+```toml
+[mcp_servers.grafana-nebius]
+command = "<path_to_skill>/scripts/run-nebius-grafana-mcp.sh"
+args = ["--disable-write"]
+env = { GRAFANA_URL = "https://grafana.nebius.dev/", GRAFANA_TOKEN_FILE = "/path/to/token" }
+startup_timeout_ms = 20000
+tool_timeout_ms = 120000
+```
+
+Codex uses `mcp_servers` with an underscore. Restart Codex after changing the
+config.
+
+## Validation Prompts
+
+After local checks pass and Codex is restarted, ask for safe read-only checks:
+
+```text
+Use the grafana-nebius MCP server to list Grafana data sources.
+```
+
+```text
+Use the Grafana MCP server to run a small PromQL query against a discovered Nebius Prometheus datasource.
+```
+
+```text
+Use the Grafana MCP server to run a small LogQL query against a discovered Nebius Loki datasource.
+```
+
+For traces, first list available MCP tools. Do not promise `tempo_*` tools
+unless they appear. Grafana MCP loads Tempo-specific tools only when proxied
+Tempo MCP support is available through the configured Tempo data source.
+
+## Common Failure Modes
+
+- `server not found`: verify `mcp-grafana` is on `PATH` for the Codex process.
+- Installed but not listed: binary installation does not register an MCP server
+  with Codex; run `codex mcp add` or add `[mcp_servers.<name>]` manually.
+- Codex config ignored: verify `~/.codex/config.toml` TOML syntax and the
+  `mcp_servers` key.
+- Nebius-managed Grafana auth failure: refresh the local Nebius CLI login,
+  rerun the wrapper, and verify `GRAFANA_TOKEN_FILE` is readable by the Codex
+  process.
+- Generic Grafana auth failure: verify `GRAFANA_URL` is the Grafana base URL
+  and the token file contains a Grafana service-account token, not a Nebius
+  static key.
+- Missing Nebius project data: verify the local Nebius identity has access to
+  the project and that the target Grafana datasource actually contains the
+  requested project's data.
+- External Grafana data source auth failure: validate the Nebius service
+  account group membership, static-key service `OBSERVABILITY`, and whether the
+  data source expects `Bearer <static_token>` or the raw static key.
+- Prometheus/Loki tools missing: verify those categories were not disabled.
+- Write tools exposed unexpectedly: add `--disable-write` and restart Codex.
+- Trace tools missing: treat as expected until the Tempo datasource exposes
+  proxied Tempo MCP tools.

--- a/skills/install-grafana-mcp-for-nebius/scripts/ensure-local-config.sh
+++ b/skills/install-grafana-mcp-for-nebius/scripts/ensure-local-config.sh
@@ -1,0 +1,323 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage: ensure-local-config.sh [--check] [--apply] [options]
+
+Idempotently checks or applies the local Codex/Grafana MCP wiring for
+Nebius-managed Grafana. The default is --check and does not modify files.
+
+Options:
+  --check                 Inspect only. This is the default.
+  --apply                 Update the managed shell block and add a missing
+                          Codex MCP server. Existing MCP servers are not
+                          removed or replaced.
+  --mcp-server-name NAME  Codex MCP server name. Default: grafana-nebius.
+  --grafana-url URL       Grafana base URL. Default: https://grafana.nebius.dev/
+  --token-file PATH       Token file path. Default:
+                          $HOME/.config/grafana-mcp/token.
+  --shell-file PATH       Shell startup file. Default: $HOME/.zshrc.
+  --wrapper-path PATH     Wrapper script path. Default: this skill's wrapper.
+  --skip-shell            Do not inspect or update the shell startup file.
+  --skip-codex            Do not inspect or update Codex MCP config.
+  -h, --help              Show this help.
+EOF
+}
+
+mode="check"
+skip_shell="false"
+skip_codex="false"
+mcp_server_name="${MCP_SERVER_NAME:-grafana-nebius}"
+grafana_url="${GRAFANA_URL:-https://grafana.nebius.dev/}"
+grafana_token_file="${GRAFANA_TOKEN_FILE:-${HOME}/.config/grafana-mcp/token}"
+shell_file="${SHELL_FILE:-${HOME}/.zshrc}"
+script_dir="$(CDPATH='' cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+wrapper_path="${WRAPPER_PATH:-${script_dir}/run-nebius-grafana-mcp.sh}"
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --check)
+      mode="check"
+      ;;
+    --apply)
+      mode="apply"
+      ;;
+    --mcp-server-name)
+      shift
+      mcp_server_name="${1:?missing value for --mcp-server-name}"
+      ;;
+    --grafana-url)
+      shift
+      grafana_url="${1:?missing value for --grafana-url}"
+      ;;
+    --token-file)
+      shift
+      grafana_token_file="${1:?missing value for --token-file}"
+      ;;
+    --shell-file)
+      shift
+      shell_file="${1:?missing value for --shell-file}"
+      ;;
+    --wrapper-path)
+      shift
+      wrapper_path="${1:?missing value for --wrapper-path}"
+      ;;
+    --skip-shell)
+      skip_shell="true"
+      ;;
+    --skip-codex)
+      skip_codex="true"
+      ;;
+    -h | --help)
+      usage
+      exit 0
+      ;;
+    *)
+      printf 'error: unknown argument: %s\n' "$1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+  shift
+done
+
+managed_start="# >>> grafana-mcp-for-nebius >>>"
+managed_end="# <<< grafana-mcp-for-nebius <<<"
+shell_token_file="$grafana_token_file"
+
+if [[ "$shell_token_file" == "${HOME}/"* ]]; then
+  shell_token_file="\$HOME/${shell_token_file#"${HOME}/"}"
+fi
+
+desired_url_line="export GRAFANA_URL=\"${grafana_url}\""
+desired_token_line="export GRAFANA_TOKEN_FILE=\"${shell_token_file}\""
+
+build_shell_block() {
+  printf '%s\n' "$managed_start"
+  printf '%s\n' "$desired_url_line"
+  printf '%s\n' "$desired_token_line"
+  printf '%s\n' "$managed_end"
+}
+
+info() {
+  printf '%s\n' "$*"
+}
+
+warn() {
+  printf 'warning: %s\n' "$*" >&2
+}
+
+check_conflicting_shell_exports() {
+  local conflicts
+  local line_number
+  local variable_name
+
+  if [ ! -f "$shell_file" ]; then
+    return 0
+  fi
+
+  conflicts="$(
+    awk \
+      -v start="$managed_start" \
+      -v end="$managed_end" \
+      -v desired_url="$desired_url_line" \
+      -v desired_token="$desired_token_line" '
+        $0 == start {
+          in_block = 1
+          next
+        }
+        in_block {
+          if ($0 == end) {
+            in_block = 0
+          }
+          next
+        }
+        $0 ~ /^export GRAFANA_URL=/ && $0 != desired_url {
+          print FNR ":GRAFANA_URL"
+        }
+        $0 ~ /^export GRAFANA_TOKEN_FILE=/ && $0 != desired_token {
+          print FNR ":GRAFANA_TOKEN_FILE"
+        }
+      ' "$shell_file"
+  )"
+
+  if [ -z "$conflicts" ]; then
+    return 0
+  fi
+
+  while IFS=: read -r line_number variable_name; do
+    [ -n "$line_number" ] || continue
+    warn "shell: conflicting standalone $variable_name export at $shell_file:$line_number"
+  done <<EOF
+$conflicts
+EOF
+  warn "shell: not changing $shell_file automatically; remove the conflicting export or confirm replacement"
+  return 1
+}
+
+ensure_shell_block() {
+  local tmp_file
+  local shell_dir
+
+  shell_dir="$(dirname -- "$shell_file")"
+  check_conflicting_shell_exports
+
+  if [ "$mode" = "check" ]; then
+    if [ -f "$shell_file" ]; then
+      local managed_count
+      managed_count="$(grep -Fxc "$managed_start" "$shell_file" || true)"
+      if [ "$managed_count" -gt 0 ]; then
+        info "shell: managed Grafana MCP block present in $shell_file"
+      elif grep -Fxq "$desired_url_line" "$shell_file" \
+        && grep -Fxq "$desired_token_line" "$shell_file"; then
+        info "shell: desired Grafana exports exist; --apply would normalize them into the managed block"
+      else
+        info "shell: managed Grafana MCP block missing; --apply would add it to $shell_file"
+      fi
+    else
+      info "shell: $shell_file missing; --apply would create it with the managed block"
+    fi
+    return
+  fi
+
+  mkdir -p "$shell_dir"
+  tmp_file="$(mktemp "${shell_file}.tmp.XXXXXX")"
+
+  if [ -f "$shell_file" ]; then
+    awk \
+      -v start="$managed_start" \
+      -v end="$managed_end" \
+      -v desired_url="$desired_url_line" \
+      -v desired_token="$desired_token_line" '
+        function print_block() {
+          print start
+          print desired_url
+          print desired_token
+          print end
+        }
+        $0 == start {
+          if (!inserted) {
+            print_block()
+            inserted = 1
+          }
+          in_block = 1
+          next
+        }
+        in_block {
+          if ($0 == end) {
+            in_block = 0
+          }
+          next
+        }
+        $0 == desired_url || $0 == desired_token {
+          if (!inserted) {
+            print_block()
+            inserted = 1
+          }
+          next
+        }
+        { print }
+        END {
+          if (!inserted) {
+            if (NR > 0) {
+              print ""
+            }
+            print_block()
+          }
+        }
+      ' "$shell_file" > "$tmp_file"
+    cat "$tmp_file" > "$shell_file"
+  else
+    build_shell_block > "$shell_file"
+  fi
+
+  rm -f "$tmp_file"
+  info "shell: ensured managed Grafana MCP block in $shell_file"
+}
+
+check_binary() {
+  if command -v mcp-grafana >/dev/null 2>&1; then
+    info "binary: mcp-grafana found at $(command -v mcp-grafana)"
+  else
+    warn "binary: mcp-grafana not found on PATH; install it before starting Codex MCP"
+  fi
+}
+
+ensure_codex_mcp() {
+  local existing_config
+  local mismatch
+
+  if ! command -v codex >/dev/null 2>&1; then
+    warn "codex: codex CLI not found on PATH; cannot inspect MCP config"
+    return
+  fi
+
+  if existing_config="$(codex mcp get "$mcp_server_name" 2>/dev/null)"; then
+    info "codex: MCP server '$mcp_server_name' already exists; inspecting it"
+    printf '%s\n' "$existing_config"
+
+    mismatch="false"
+    if ! printf '%s\n' "$existing_config" | grep -Fxq "  command: $wrapper_path"; then
+      warn "codex: existing MCP server '$mcp_server_name' does not use wrapper: $wrapper_path"
+      mismatch="true"
+    fi
+    if ! printf '%s\n' "$existing_config" | grep -Fxq "  args: --disable-write" \
+      && ! printf '%s\n' "$existing_config" | grep -Fxq "  args: -"; then
+      warn "codex: existing MCP server '$mcp_server_name' does not use --disable-write or wrapper defaults"
+      mismatch="true"
+    fi
+    if ! printf '%s\n' "$existing_config" | grep -Fq "GRAFANA_URL=*****"; then
+      warn "codex: existing MCP server '$mcp_server_name' is missing GRAFANA_URL"
+      mismatch="true"
+    fi
+    if ! printf '%s\n' "$existing_config" | grep -Fq "GRAFANA_TOKEN_FILE=*****"; then
+      warn "codex: existing MCP server '$mcp_server_name' is missing GRAFANA_TOKEN_FILE"
+      mismatch="true"
+    fi
+
+    if [ "$mismatch" = "true" ]; then
+      warn "codex: not replacing existing MCP server without explicit removal/replacement approval"
+      return 1
+    fi
+
+    info "codex: MCP server '$mcp_server_name' matches the wrapper-based Nebius setup"
+    return
+  fi
+
+  if [ "$mode" = "check" ]; then
+    info "codex: MCP server '$mcp_server_name' missing; --apply would add the wrapper-based server"
+    printf 'codex mcp add %q --env %q --env %q -- %q --disable-write\n' \
+      "$mcp_server_name" \
+      "GRAFANA_URL=${grafana_url}" \
+      "GRAFANA_TOKEN_FILE=${grafana_token_file}" \
+      "$wrapper_path"
+    return
+  fi
+
+  codex mcp add "$mcp_server_name" \
+    --env "GRAFANA_URL=${grafana_url}" \
+    --env "GRAFANA_TOKEN_FILE=${grafana_token_file}" \
+    -- "$wrapper_path" --disable-write
+  info "codex: added MCP server '$mcp_server_name'"
+}
+
+info "mode: $mode"
+info "mcp server: $mcp_server_name"
+info "grafana url: $grafana_url"
+info "token file: $grafana_token_file"
+info "wrapper: $wrapper_path"
+
+check_binary
+
+if [ "$skip_shell" = "false" ]; then
+  ensure_shell_block
+else
+  info "shell: skipped"
+fi
+
+if [ "$skip_codex" = "false" ]; then
+  ensure_codex_mcp
+else
+  info "codex: skipped"
+fi

--- a/skills/install-grafana-mcp-for-nebius/scripts/run-nebius-grafana-mcp.sh
+++ b/skills/install-grafana-mcp-for-nebius/scripts/run-nebius-grafana-mcp.sh
@@ -1,0 +1,180 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE'
+Run Grafana MCP for Nebius-managed Grafana with a refreshed Nebius IAM token.
+
+This wrapper writes a fresh Nebius access token to GRAFANA_TOKEN_FILE, exports
+that token to mcp-grafana, refreshes the file periodically while the server is
+running when the installed mcp-grafana supports token-file auth, and starts
+mcp-grafana in read-only mode by default.
+
+Environment:
+  GRAFANA_URL
+      Grafana base URL. Defaults to https://grafana.nebius.dev/.
+  GRAFANA_TOKEN_FILE
+      Local token file. Defaults to $HOME/.config/grafana-mcp/token.
+  NEBIUS_PROFILE
+      Optional Nebius CLI profile name passed to nebius --profile.
+  NEBIUS_GRAFANA_TOKEN_REFRESH_SECONDS
+      Refresh interval. Defaults to 36000 seconds, below the Nebius 12h token
+      lifetime.
+
+Usage:
+  run-nebius-grafana-mcp.sh [mcp-grafana args...]
+  run-nebius-grafana-mcp.sh --refresh-token-only
+  run-nebius-grafana-mcp.sh --print-config
+USAGE
+}
+
+require_command() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    printf 'error: required command not found on PATH: %s\n' "$1" >&2
+    exit 127
+  fi
+}
+
+refresh_token() {
+  local token_dir
+  local tmp_file
+
+  token_dir="$(dirname "$GRAFANA_TOKEN_FILE")"
+  if [ "$token_dir" != "." ] && [ ! -d "$token_dir" ]; then
+    mkdir -p "$token_dir"
+    chmod 700 "$token_dir" 2>/dev/null || true
+  fi
+
+  tmp_file="$(mktemp "${GRAFANA_TOKEN_FILE}.tmp.XXXXXX")"
+  chmod 600 "$tmp_file" 2>/dev/null || true
+
+  if [ -n "${NEBIUS_PROFILE:-}" ]; then
+    if ! nebius --profile "$NEBIUS_PROFILE" iam get-access-token >"$tmp_file"; then
+      rm -f "$tmp_file"
+      return 1
+    fi
+  else
+    if ! nebius iam get-access-token >"$tmp_file"; then
+      rm -f "$tmp_file"
+      return 1
+    fi
+  fi
+
+  if [ ! -s "$tmp_file" ]; then
+    rm -f "$tmp_file"
+    printf 'error: Nebius CLI returned an empty access token\n' >&2
+    return 1
+  fi
+
+  mv "$tmp_file" "$GRAFANA_TOKEN_FILE"
+  chmod 600 "$GRAFANA_TOKEN_FILE" 2>/dev/null || true
+}
+
+mcp_supports_token_file() {
+  local mcp_path
+
+  mcp_path="$(command -v mcp-grafana)"
+  if ! command -v strings >/dev/null 2>&1; then
+    return 1
+  fi
+
+  strings "$mcp_path" 2>/dev/null \
+    | grep -Fqx "GRAFANA_SERVICE_ACCOUNT_TOKEN_FILE"
+}
+
+configure_token_environment() {
+  local refreshed_token
+
+  if mcp_supports_token_file; then
+    if [ -n "${GRAFANA_SERVICE_ACCOUNT_TOKEN:-}" ]; then
+      printf 'warning: ignoring inline GRAFANA_SERVICE_ACCOUNT_TOKEN; using token file refresh\n' >&2
+      unset GRAFANA_SERVICE_ACCOUNT_TOKEN
+    fi
+    export GRAFANA_SERVICE_ACCOUNT_TOKEN_FILE="$GRAFANA_TOKEN_FILE"
+    MCP_GRAFANA_TOKEN_MODE="token-file"
+    return
+  fi
+
+  if [ -n "${GRAFANA_SERVICE_ACCOUNT_TOKEN:-}" ]; then
+    printf 'warning: replacing inline GRAFANA_SERVICE_ACCOUNT_TOKEN with refreshed Nebius token\n' >&2
+  else
+    printf 'warning: mcp-grafana does not advertise GRAFANA_SERVICE_ACCOUNT_TOKEN_FILE support; using refreshed token inline\n' >&2
+  fi
+
+  refreshed_token="$(head -n 1 "$GRAFANA_TOKEN_FILE")"
+  if [ -z "$refreshed_token" ]; then
+    printf 'error: refreshed token file is empty: %s\n' "$GRAFANA_TOKEN_FILE" >&2
+    exit 1
+  fi
+
+  unset GRAFANA_SERVICE_ACCOUNT_TOKEN_FILE
+  export GRAFANA_SERVICE_ACCOUNT_TOKEN="$refreshed_token"
+  MCP_GRAFANA_TOKEN_MODE="inline-env"
+}
+
+: "${GRAFANA_URL:=https://grafana.nebius.dev/}"
+: "${GRAFANA_TOKEN_FILE:=${HOME}/.config/grafana-mcp/token}"
+: "${NEBIUS_GRAFANA_TOKEN_REFRESH_SECONDS:=36000}"
+
+case "${1:-}" in
+  -h|--help)
+    usage
+    exit 0
+    ;;
+  --print-config)
+    printf 'GRAFANA_URL=%s\n' "$GRAFANA_URL"
+    printf 'GRAFANA_TOKEN_FILE=%s\n' "$GRAFANA_TOKEN_FILE"
+    if command -v mcp-grafana >/dev/null 2>&1 && mcp_supports_token_file; then
+      printf 'MCP_GRAFANA_TOKEN_MODE=token-file\n'
+      printf 'GRAFANA_SERVICE_ACCOUNT_TOKEN_FILE=%s\n' "$GRAFANA_TOKEN_FILE"
+    else
+      printf 'MCP_GRAFANA_TOKEN_MODE=inline-env\n'
+      printf 'GRAFANA_SERVICE_ACCOUNT_TOKEN=<refreshed from GRAFANA_TOKEN_FILE at startup>\n'
+    fi
+    printf 'NEBIUS_PROFILE=%s\n' "${NEBIUS_PROFILE:-<default>}"
+    printf 'NEBIUS_GRAFANA_TOKEN_REFRESH_SECONDS=%s\n' "$NEBIUS_GRAFANA_TOKEN_REFRESH_SECONDS"
+    exit 0
+    ;;
+esac
+
+require_command nebius
+
+refresh_token
+
+if [ "${1:-}" = "--refresh-token-only" ]; then
+  exit 0
+fi
+
+require_command mcp-grafana
+
+export GRAFANA_URL
+MCP_GRAFANA_TOKEN_MODE=""
+configure_token_environment
+
+if [ "$#" -eq 0 ]; then
+  set -- --disable-write
+fi
+
+refresher_pid=""
+cleanup() {
+  if [ -n "$refresher_pid" ]; then
+    kill "$refresher_pid" >/dev/null 2>&1 || true
+    wait "$refresher_pid" >/dev/null 2>&1 || true
+  fi
+}
+trap cleanup EXIT INT TERM
+
+if [ "$MCP_GRAFANA_TOKEN_MODE" = "token-file" ]; then
+  (
+    while sleep "$NEBIUS_GRAFANA_TOKEN_REFRESH_SECONDS"; do
+      if ! refresh_token; then
+        printf 'warning: failed to refresh Nebius Grafana token file\n' >&2
+      fi
+    done
+  ) &
+  refresher_pid="$!"
+else
+  printf 'warning: inline token mode cannot refresh credentials inside a running mcp-grafana process; restart Codex before the Nebius token expires\n' >&2
+fi
+
+mcp-grafana "$@"

--- a/skills/install-grafana-mcp-for-nebius/scripts/test-run-nebius-grafana-mcp.sh
+++ b/skills/install-grafana-mcp-for-nebius/scripts/test-run-nebius-grafana-mcp.sh
@@ -1,0 +1,142 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(CDPATH='' cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+wrapper="${script_dir}/run-nebius-grafana-mcp.sh"
+ensure_config="${script_dir}/ensure-local-config.sh"
+
+tmp_dir="$(mktemp -d)"
+cleanup() {
+  rm -rf "$tmp_dir"
+}
+trap cleanup EXIT
+
+cat >"${tmp_dir}/nebius" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ "${1:-}" = "--profile" ]; then
+  shift 2
+fi
+
+if [ "${1:-}" = "iam" ] && [ "${2:-}" = "get-access-token" ]; then
+  printf 'fake-nebius-token\n'
+  exit 0
+fi
+
+printf 'unexpected nebius args: %s\n' "$*" >&2
+exit 2
+SH
+
+cat >"${tmp_dir}/mcp-grafana" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+
+: "${MCP_CAPTURE_FILE:?MCP_CAPTURE_FILE is required}"
+
+{
+  printf 'token=%s\n' "${GRAFANA_SERVICE_ACCOUNT_TOKEN:-}"
+  printf 'token_file=%s\n' "${GRAFANA_SERVICE_ACCOUNT_TOKEN_FILE:-}"
+  printf 'args=%s\n' "$*"
+  if [ "${MCP_CAPTURE_STDIN:-}" = "1" ]; then
+    if IFS= read -r line; then
+      printf 'stdin=%s\n' "$line"
+    else
+      printf 'stdin=<eof>\n'
+    fi
+  fi
+} >"$MCP_CAPTURE_FILE"
+SH
+
+cat >"${tmp_dir}/strings" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ "${STRINGS_MODE:-}" = "token-file" ]; then
+  printf 'GRAFANA_SERVICE_ACCOUNT_TOKEN_FILE\n'
+fi
+SH
+
+chmod +x "${tmp_dir}/nebius" "${tmp_dir}/mcp-grafana" "${tmp_dir}/strings"
+
+capture_file="${tmp_dir}/capture"
+token_file="${tmp_dir}/token"
+
+PATH="${tmp_dir}:${PATH}" \
+  STRINGS_MODE="inline" \
+  GRAFANA_TOKEN_FILE="$token_file" \
+  GRAFANA_SERVICE_ACCOUNT_TOKEN="stale-token" \
+  MCP_CAPTURE_FILE="$capture_file" \
+  NEBIUS_GRAFANA_TOKEN_REFRESH_SECONDS=99999 \
+  "$wrapper" --probe-arg
+
+grep -Fxq 'token=fake-nebius-token' "$capture_file"
+grep -Fxq 'token_file=' "$capture_file"
+grep -Fxq 'args=--probe-arg' "$capture_file"
+test "$(stat -f '%OLp' "$token_file" 2>/dev/null || stat -c '%a' "$token_file")" = "600"
+
+cwd_dir="${tmp_dir}/cwd-mode"
+mkdir "$cwd_dir"
+chmod 755 "$cwd_dir"
+cwd_mode_before="$(stat -f '%OLp' "$cwd_dir" 2>/dev/null || stat -c '%a' "$cwd_dir")"
+
+(
+  cd "$cwd_dir"
+  PATH="${tmp_dir}:${PATH}" \
+    GRAFANA_TOKEN_FILE="token" \
+    "$wrapper" --refresh-token-only
+)
+
+cwd_mode_after="$(stat -f '%OLp' "$cwd_dir" 2>/dev/null || stat -c '%a' "$cwd_dir")"
+test "$cwd_mode_after" = "$cwd_mode_before"
+test "$(stat -f '%OLp' "${cwd_dir}/token" 2>/dev/null || stat -c '%a' "${cwd_dir}/token")" = "600"
+
+capture_file="${tmp_dir}/capture-stdin"
+token_file="${tmp_dir}/token-stdin"
+
+PATH="${tmp_dir}:${PATH}" \
+  STRINGS_MODE="inline" \
+  GRAFANA_TOKEN_FILE="$token_file" \
+  MCP_CAPTURE_FILE="$capture_file" \
+  MCP_CAPTURE_STDIN=1 \
+  NEBIUS_GRAFANA_TOKEN_REFRESH_SECONDS=99999 \
+  "$wrapper" --probe-arg <<<"probe-stdin"
+
+grep -Fxq 'stdin=probe-stdin' "$capture_file"
+
+capture_file="${tmp_dir}/capture-token-file"
+token_file="${tmp_dir}/token-file"
+
+PATH="${tmp_dir}:${PATH}" \
+  STRINGS_MODE="token-file" \
+  GRAFANA_TOKEN_FILE="$token_file" \
+  GRAFANA_SERVICE_ACCOUNT_TOKEN="stale-token" \
+  MCP_CAPTURE_FILE="$capture_file" \
+  NEBIUS_GRAFANA_TOKEN_REFRESH_SECONDS=99999 \
+  "$wrapper" --probe-arg
+
+grep -Fxq 'token=' "$capture_file"
+grep -Fxq "token_file=$token_file" "$capture_file"
+grep -Fxq 'args=--probe-arg' "$capture_file"
+test "$(stat -f '%OLp' "$token_file" 2>/dev/null || stat -c '%a' "$token_file")" = "600"
+
+shell_file="${tmp_dir}/zshrc-conflict"
+cat >"$shell_file" <<'SH'
+export GRAFANA_URL="https://custom.example/"
+export GRAFANA_TOKEN_FILE="$HOME/custom-token"
+SH
+
+if "$ensure_config" --check --skip-codex --shell-file "$shell_file" >/dev/null 2>&1; then
+  printf 'expected --check to fail on conflicting shell exports\n' >&2
+  exit 1
+fi
+
+if "$ensure_config" --apply --skip-codex --shell-file "$shell_file" >/dev/null 2>&1; then
+  printf 'expected --apply to fail on conflicting shell exports\n' >&2
+  exit 1
+fi
+
+if grep -Fq '# >>> grafana-mcp-for-nebius >>>' "$shell_file"; then
+  printf 'conflicting shell file was modified unexpectedly\n' >&2
+  exit 1
+fi


### PR DESCRIPTION
## Summary

- add the `install-grafana-mcp-for-nebius` Codex skill with Grafana MCP setup docs, idempotent local config helper, Nebius token-refresh wrapper, and smoke tests
- add cxcli app chart version controls for create/component add and align Soperator SFS defaults to the selected cluster target
- update README, design docs, changelog, CLI coverage, and docs-alignment tests for the new behavior

## Validation

- `git diff --check origin/main...HEAD`
- `rg -n '^(<{7}|={7}|>{7})' services skills`
- `git merge-tree --write-tree origin/main HEAD`
- `bash -n install-skills.sh skills/install-grafana-mcp-for-nebius/scripts/*.sh`
- `shellcheck skills/install-grafana-mcp-for-nebius/scripts/*.sh`
- `markdownlint skills/README.md skills/CHANGELOG.md skills/install-grafana-mcp-for-nebius/README.md skills/install-grafana-mcp-for-nebius/SKILL.md skills/install-grafana-mcp-for-nebius/references/setup-guide.md`
- `skills/install-grafana-mcp-for-nebius/scripts/test-run-nebius-grafana-mcp.sh`
- `skills/install-grafana-mcp-for-nebius/scripts/ensure-local-config.sh --check`
- `skills/install-grafana-mcp-for-nebius/scripts/run-nebius-grafana-mcp.sh --print-config`
- `skills/install-grafana-mcp-for-nebius/scripts/run-nebius-grafana-mcp.sh --refresh-token-only`
- MCP SDK `initialize`, `tools/list`, and `list_datasources` through the wrapper
