### PR TITLE
Fix Soperator defaults and some skills issues

### DIFF
--- a/services/nebius-cxcli/CHANGELOG.md
+++ b/services/nebius-cxcli/CHANGELOG.md
@@ -107,6 +107,12 @@ All notable changes to this project are tracked here. This changelog follows
   or recovery.
 - Changed the bundled Soperator portable app source to the published Nebius OCI
   chart at version `4.0.2-ps.1`.
+- Changed bundled Soperator production profiles to leave worker `slurmd` and
+  `munge` image selection to the selected chart defaults instead of duplicating
+  image tags in `component_cli_settings.yaml`. The same profiles now default
+  `system` to autoscaling from 3 to 5 nodes, and default `controller`, `login`,
+  and `accounting` to two fixed nodes each. Their catalog-owned CPU role shape
+  now uses `cpu-d3/32vcpu-128gb` as the production minimum.
 - Clarified external Soperator safe-surge rollout output so the dry-run/execute
   plan says the spare worker quota and capacity gate runs during `--execute`
   preflight before any cluster mutation, and pinned that gate with executor
@@ -707,9 +713,7 @@ All notable changes to this project are tracked here. This changelog follows
 - Updated the bundled Soperator app catalog pin to chart version
   `3.0.5-ps.1`, and made local-profile Helm chart sources derive missing
   chart name/version metadata from their checked-out `Chart.yaml` so generated
-  `config.yaml` rows show the active local chart version. The bundled
-  Soperator profile defaults now use the matching `3.0.5-slurm25.11.3`
-  worker and Munge image tags.
+  `config.yaml` rows show the active local chart version.
 - Added live VPC network/subnet selection for subnet-attached infra in `create`
   and `component add`. `mk8s`, `vm`, `nfs`, `wireguard-gw`, and
   `ssh-jumphost` now list project VPC networks first, list only subnets in the
@@ -1100,7 +1104,7 @@ All notable changes to this project are tracked here. This changelog follows
   defaults are applied to the `system`, `controller`, `login`, `accounting`,
   and CPU worker MK8s node groups before Terraform render.
 - Raised the built-in Soperator production CPU role baseline to
-  `cpu-d3/8vcpu-32gb` and added the catalog-owned login role taint so fresh
+  `cpu-d3/32vcpu-128gb` and added the catalog-owned login role taint so fresh
   production clusters have schedulable controller/login capacity while cxcli
   still derives the matching Soperator tolerations from node-group taints.
 - Fixed Soperator MK8s node-group boot-disk materialization so profile-owned

--- a/services/nebius-cxcli/README.md
+++ b/services/nebius-cxcli/README.md
@@ -1333,7 +1333,9 @@ Wizard field behavior:
   and `component add` print explicit adjusted-selection reasons for those
   Soperator-owned additions. The Soperator create/component wizard uses
   `production-cluster` and creates the complete MK8s+SFS+Soperator five-role
-  bundle. Existing Nebius MK8s clusters use the dedicated
+  bundle with `system` autoscaling from 3 to 5 nodes, two fixed `controller`,
+  `login`, and `accounting` nodes, and one worker node by default. Existing
+  Nebius MK8s clusters use the dedicated
   [Soperator Commands](#soperator-commands) workflow: `ext-soperator onboard`
   registers the external target and `ext-soperator migrate` plans or executes
   approved source-cluster migration without Terraform-importing the cluster.
@@ -1346,9 +1348,9 @@ Wizard field behavior:
   chart-managed MariaDB accounting, and Slurm REST so worker NodeSets are
   registered before worker pods undrain themselves. It also mounts
   generated Slurm scripts into worker NodeSets and points Slurm at the plugin
-  directory used by the pinned images, which keeps basic `srun` jobs runnable
-  from the default chart values. For GPU NodeSets, the chart derives Slurm
-  `Gres=gpu:<count>` from `slurmd.resources.gpu`, so the profile does not
+  directory used by the selected chart images, which keeps basic `srun` jobs
+  runnable from the default chart values. For GPU NodeSets, the chart derives
+  Slurm `Gres=gpu:<count>` from `slurmd.resources.gpu`, so the profile does not
   duplicate GPU counts but GPU partitions still accept `--gres=gpu:*` jobs. For
   Soperator cert-manager and MariaDB webhook chart values, cxcli treats
   generated YAML `null` booleans as unset before render so optional wizard skips
@@ -1572,16 +1574,19 @@ Wizard field behavior:
   small external CPU pools can pass first install; production-cluster mode keeps
   the chart's production resource defaults, and operators can still override
   the rendered Helm values in `config.yaml`. Fresh production-cluster profiles
-  use `cpu-d3/8vcpu-32gb` for catalog-owned CPU role groups and taint the login
-  group with `slurm.nebius.ai/nodeset-name=login:NoSchedule` so the Soperator
-  login pod has enough dedicated capacity instead of competing with generic
-  cluster workloads. The production wizard now exposes curated service-role
+  use `cpu-d3/32vcpu-128gb` for catalog-owned CPU role groups and taint the
+  login group with `slurm.nebius.ai/nodeset-name=login:NoSchedule` so the
+  Soperator login pod has enough dedicated capacity instead of competing with
+  generic cluster workloads. The production wizard now exposes curated service-role
   node count helpers under `inputs.soperator.system_node_count`,
   `controller_node_count`, `login_node_count`, and `accounting_node_count`,
   plus per-role autoscaling helpers under
   `inputs.soperator.<role>_autoscaling.*` for `system`, `controller`,
-  `login`, `accounting`, and `worker`. Autoscaling helpers are disabled by
-  default. When one is enabled, cxcli materializes the matching concrete
+  `login`, `accounting`, and `worker`. Production profiles default the
+  `system` role to autoscaling from 3 to 5 nodes. `controller`, `login`, and
+  `accounting` default to two fixed nodes each, and worker capacity defaults to
+  one node. Other autoscaling helpers are disabled by default. When one is
+  enabled, cxcli materializes the matching concrete
   `inputs.node_groups.*.autoscaling` block and omits `node_count`; otherwise it
   writes the fixed count. Raw profile-owned `inputs.node_groups.*` prompts stay
   hidden.
@@ -1600,10 +1605,14 @@ Wizard field behavior:
   catalog-derived `values.partitionProfile` and `values.topologyProfile`
   choices for the selected worker profile. Those profiles fill or replace
   catalog-owned defaults only; repeated create/render materialization preserves
-  explicit operator edits to the same value paths. The production profiles seed
-  a catalog-owned CPU shape for `system`, `controller`, `login`, `accounting`,
-  and CPU worker node groups so every Terraform `node_groups` entry has the
-  required `platform` and `preset` fields before render. The opt-in
+  explicit operator edits to the same value paths. Profile-owned NodeSet values
+  intentionally leave worker `slurmd` and `munge` image selection to the
+  selected Soperator chart defaults, so bumping the app source version does not
+  require duplicating worker image tags in `component_cli_settings.yaml`. The
+  production profiles seed a catalog-owned CPU shape for `system`,
+  `controller`, `login`, `accounting`, and CPU worker node groups so every
+  Terraform `node_groups` entry has the required `platform` and `preset` fields
+  before render. The opt-in
   `with-qos-preemption` partition profile writes persistent Slurm
   `PreemptType=preempt/qos` config plus `debug`, `eval`, `train`, and `data`
   policy partitions and standard QOS object definitions. The bundled profile
@@ -1626,9 +1635,11 @@ Wizard field behavior:
   sharded by `worker_nodes_per_group`, minimum nodes are distributed across the
   generated groups, and NodeSet replicas reflect each shard's max, including an
   explicit `0..0` scale-to-zero worker range. CPU
-  service-role counts are independent of worker sharding and use the dedicated
-  `inputs.soperator.*_node_count` helpers unless that role's autoscaling helper
-  is enabled; service-role autoscaling must keep `max_node_count` at least `1`.
+  service-role counts are independent of worker sharding: `system` defaults to
+  autoscaling 3..5, and if that helper is disabled it falls back to fixed count
+  3; `controller`, `login`, and `accounting` default to fixed count 2 unless
+  their autoscaling helpers are enabled. Service-role autoscaling must keep
+  `max_node_count` at least `1`.
   NFS stays a VM-based sibling infra component, not an MK8s node
   group.
 - The five-role Nebius Soperator production shape and Slurm topology are separate concerns. The five role groups provide workload isolation and placement for `system`, `controller`, `login`, `accounting`, and `worker`. Slurm topology is an additional worker-placement optimization for distributed jobs that care about physical or fabric locality, especially multi-node GPU/NCCL jobs.
@@ -2139,8 +2150,12 @@ Helm values into `config.yaml`. Slurm users still own per-job choices such as
 `--qos`, `--nice`, `--time`, and `--requeue`.
 For production clusters, cxcli keeps raw profile-owned `inputs.node_groups.*`
 prompts hidden but exposes `inputs.soperator.*_node_count` helpers for CPU
-service-role counts and disabled-by-default `inputs.soperator.*_autoscaling`
-helpers for every Soperator-managed role. Worker fixed sizing stays on
+service-role counts and `inputs.soperator.*_autoscaling` helpers for every
+Soperator-managed role. The `system` service role defaults to autoscaling from
+3 to 5 nodes; disabling that helper falls back to three fixed nodes.
+`controller`, `login`, and `accounting` default to two fixed nodes each, with
+their autoscaling helpers disabled unless the operator enables them. Worker
+fixed sizing stays on
 `soperator.worker_total_nodes` and `worker_nodes_per_group`; worker autoscaling
 uses `worker_autoscaling.max_node_count` with the same shard size and preserves
 an explicit `0..0` scale-to-zero range. CPU service-role counts are independent
@@ -3937,7 +3952,9 @@ nebius-cxcli auth --project-config /path/to/config.yaml --validate-profile
     `production-cluster` and asks for the worker profile before MK8s/SFS field
     materialization so CPU-only, GPU-only, or mixed layout is known before
     shape/fabric helpers and target GPU validation prompts. `production-cluster`
-    creates the complete MK8s+SFS+Soperator five-role bundle and skips external
+    creates the complete MK8s+SFS+Soperator five-role bundle with `system`
+    autoscaling from 3 to 5 nodes, two fixed `controller`, `login`, and
+    `accounting` nodes, one worker node by default, and skips external
     role-mapping prompts. Existing external Nebius MK8s targets should use
     `nebius-cxcli ext-soperator onboard <config.yaml-or-deployments-root>`; see
     [Soperator Commands](#soperator-commands) for onboarding, migration, and

--- a/services/nebius-cxcli/component_cli_settings.yaml
+++ b/services/nebius-cxcli/component_cli_settings.yaml
@@ -666,20 +666,23 @@ components:
                   node_group_defaults:
                     cpu:
                       platform: cpu-d3
-                      preset: 8vcpu-32gb
+                      preset: 32vcpu-128gb
                 node_groups:
                   system:
                     nodeset_name: system
                     workload: system
-                    node_count: 1
+                    node_count: 3
                     node_count_input: soperator.system_node_count
                     autoscaling_input: soperator.system_autoscaling
+                    autoscaling:
+                      min_node_count: 3
+                      max_node_count: 5
                     gpu: false
                     jail: true
                   controller:
                     nodeset_name: controller
                     workload: controller
-                    node_count: 1
+                    node_count: 2
                     node_count_input: soperator.controller_node_count
                     autoscaling_input: soperator.controller_autoscaling
                     gpu: false
@@ -693,7 +696,7 @@ components:
                   login:
                     nodeset_name: login
                     workload: login
-                    node_count: 1
+                    node_count: 2
                     node_count_input: soperator.login_node_count
                     autoscaling_input: soperator.login_autoscaling
                     gpu: false
@@ -705,7 +708,7 @@ components:
                   accounting:
                     nodeset_name: accounting
                     workload: accounting
-                    node_count: 1
+                    node_count: 2
                     node_count_input: soperator.accounting_node_count
                     autoscaling_input: soperator.accounting_autoscaling
                     gpu: false
@@ -896,10 +899,6 @@ components:
                         static: Boards=1 SocketsPerBoard=1 CoresPerSocket=8 ThreadsPerCore=1
                         dynamic: "InstanceId={{ .PodName }}"
                       slurmd:
-                        image:
-                          repository: cr.eu-north1.nebius.cloud/soperator/worker_slurmd
-                          tag: 3.0.5-slurm25.11.3
-                          pullPolicy: IfNotPresent
                         resources:
                           cpu: "4"
                           memory: 16Gi
@@ -917,10 +916,6 @@ components:
                           limitsConfig: ""
                           procMount: Default
                       munge:
-                        image:
-                          repository: cr.eu-north1.nebius.cloud/soperator/munge
-                          tag: 3.0.5-slurm25.11.3
-                          pullPolicy: IfNotPresent
                         resources:
                           cpu: 200m
                           memory: 512Mi
@@ -1180,7 +1175,7 @@ components:
                   node_group_defaults:
                     cpu:
                       platform: cpu-d3
-                      preset: 8vcpu-32gb
+                      preset: 32vcpu-128gb
                     gpu:
                       platform: gpu-h100-sxm
                       preset: 8gpu-128vcpu-1600gb
@@ -1194,15 +1189,18 @@ components:
                   system:
                     nodeset_name: system
                     workload: system
-                    node_count: 1
+                    node_count: 3
                     node_count_input: soperator.system_node_count
                     autoscaling_input: soperator.system_autoscaling
+                    autoscaling:
+                      min_node_count: 3
+                      max_node_count: 5
                     gpu: false
                     jail: true
                   controller:
                     nodeset_name: controller
                     workload: controller
-                    node_count: 1
+                    node_count: 2
                     node_count_input: soperator.controller_node_count
                     autoscaling_input: soperator.controller_autoscaling
                     gpu: false
@@ -1216,7 +1214,7 @@ components:
                   login:
                     nodeset_name: login
                     workload: login
-                    node_count: 1
+                    node_count: 2
                     node_count_input: soperator.login_node_count
                     autoscaling_input: soperator.login_autoscaling
                     gpu: false
@@ -1228,7 +1226,7 @@ components:
                   accounting:
                     nodeset_name: accounting
                     workload: accounting
-                    node_count: 1
+                    node_count: 2
                     node_count_input: soperator.accounting_node_count
                     autoscaling_input: soperator.accounting_autoscaling
                     gpu: false
@@ -1349,10 +1347,6 @@ components:
                         static: Boards=1 SocketsPerBoard=1 CoresPerSocket=8 ThreadsPerCore=1
                         dynamic: "InstanceId={{ .PodName }}"
                       slurmd:
-                        image:
-                          repository: cr.eu-north1.nebius.cloud/soperator/worker_slurmd
-                          tag: 3.0.5-slurm25.11.3
-                          pullPolicy: IfNotPresent
                         resources:
                           cpu: "4"
                           memory: 16Gi
@@ -1370,10 +1364,6 @@ components:
                           limitsConfig: ""
                           procMount: Default
                       munge:
-                        image:
-                          repository: cr.eu-north1.nebius.cloud/soperator/munge
-                          tag: 3.0.5-slurm25.11.3
-                          pullPolicy: IfNotPresent
                         resources:
                           cpu: 200m
                           memory: 512Mi
@@ -1406,10 +1396,6 @@ components:
                         gresConfig:
                           - AutoDetect=nvidia
                       slurmd:
-                        image:
-                          repository: cr.eu-north1.nebius.cloud/soperator/worker_slurmd
-                          tag: 3.0.5-slurm25.11.3
-                          pullPolicy: IfNotPresent
                         customEnv:
                           - name: NVIDIA_DRIVER_CAPABILITIES
                             value: compute,graphics,utility,video
@@ -1431,10 +1417,6 @@ components:
                           limitsConfig: ""
                           procMount: Default
                       munge:
-                        image:
-                          repository: cr.eu-north1.nebius.cloud/soperator/munge
-                          tag: 3.0.5-slurm25.11.3
-                          pullPolicy: IfNotPresent
                         resources:
                           cpu: 200m
                           memory: 512Mi
@@ -1706,10 +1688,6 @@ components:
                             static: Boards=1 SocketsPerBoard=1 CoresPerSocket=8 ThreadsPerCore=1
                             dynamic: "InstanceId={{ .PodName }}"
                           slurmd:
-                            image:
-                              repository: cr.eu-north1.nebius.cloud/soperator/worker_slurmd
-                              tag: 3.0.5-slurm25.11.3
-                              pullPolicy: IfNotPresent
                             resources:
                               cpu: "4"
                               memory: 16Gi
@@ -1727,10 +1705,6 @@ components:
                               limitsConfig: ""
                               procMount: Default
                           munge:
-                            image:
-                              repository: cr.eu-north1.nebius.cloud/soperator/munge
-                              tag: 3.0.5-slurm25.11.3
-                              pullPolicy: IfNotPresent
                             resources:
                               cpu: 200m
                               memory: 512Mi
@@ -1765,10 +1739,6 @@ components:
                             gresConfig:
                               - AutoDetect=nvidia
                           slurmd:
-                            image:
-                              repository: cr.eu-north1.nebius.cloud/soperator/worker_slurmd
-                              tag: 3.0.5-slurm25.11.3
-                              pullPolicy: IfNotPresent
                             customEnv:
                               - name: NVIDIA_DRIVER_CAPABILITIES
                                 value: compute,graphics,utility,video
@@ -1790,10 +1760,6 @@ components:
                               limitsConfig: ""
                               procMount: Default
                           munge:
-                            image:
-                              repository: cr.eu-north1.nebius.cloud/soperator/munge
-                              tag: 3.0.5-slurm25.11.3
-                              pullPolicy: IfNotPresent
                             resources:
                               cpu: 200m
                               memory: 512Mi
@@ -1866,7 +1832,7 @@ components:
                   node_group_defaults:
                     cpu:
                       platform: cpu-d3
-                      preset: 8vcpu-32gb
+                      preset: 32vcpu-128gb
                     gpu:
                       platform: gpu-h100-sxm
                       preset: 8gpu-128vcpu-1600gb
@@ -1880,15 +1846,18 @@ components:
                   system:
                     nodeset_name: system
                     workload: system
-                    node_count: 1
+                    node_count: 3
                     node_count_input: soperator.system_node_count
                     autoscaling_input: soperator.system_autoscaling
+                    autoscaling:
+                      min_node_count: 3
+                      max_node_count: 5
                     gpu: false
                     jail: true
                   controller:
                     nodeset_name: controller
                     workload: controller
-                    node_count: 1
+                    node_count: 2
                     node_count_input: soperator.controller_node_count
                     autoscaling_input: soperator.controller_autoscaling
                     gpu: false
@@ -1902,7 +1871,7 @@ components:
                   login:
                     nodeset_name: login
                     workload: login
-                    node_count: 1
+                    node_count: 2
                     node_count_input: soperator.login_node_count
                     autoscaling_input: soperator.login_autoscaling
                     gpu: false
@@ -1914,7 +1883,7 @@ components:
                   accounting:
                     nodeset_name: accounting
                     workload: accounting
-                    node_count: 1
+                    node_count: 2
                     node_count_input: soperator.accounting_node_count
                     autoscaling_input: soperator.accounting_autoscaling
                     gpu: false
@@ -1997,10 +1966,6 @@ components:
                         gresConfig:
                           - AutoDetect=nvidia
                       slurmd:
-                        image:
-                          repository: cr.eu-north1.nebius.cloud/soperator/worker_slurmd
-                          tag: 3.0.5-slurm25.11.3
-                          pullPolicy: IfNotPresent
                         customEnv:
                           - name: NVIDIA_DRIVER_CAPABILITIES
                             value: compute,graphics,utility,video
@@ -2022,10 +1987,6 @@ components:
                           limitsConfig: ""
                           procMount: Default
                       munge:
-                        image:
-                          repository: cr.eu-north1.nebius.cloud/soperator/munge
-                          tag: 3.0.5-slurm25.11.3
-                          pullPolicy: IfNotPresent
                         resources:
                           cpu: 200m
                           memory: 512Mi

--- a/services/nebius-cxcli/docs/design.md
+++ b/services/nebius-cxcli/docs/design.md
@@ -791,7 +791,7 @@ Production profiles also seed a catalog-owned CPU shape under
 `inputs.node_group_defaults.cpu` so the generated `system`, `controller`,
 `login`, `accounting`, and CPU worker groups all carry the MK8s module's
 required `platform` and `preset` fields before render. The built-in production
-profiles use `cpu-d3/8vcpu-32gb` for those CPU role groups so Soperator's
+profiles use `cpu-d3/32vcpu-128gb` for those CPU role groups so Soperator's
 production controller/login requests can schedule alongside Kubernetes daemon
 overhead. The `nebius-cpu-v1` profile maps Slurm workers only to `worker-cpu`,
 keeps the service groups out of the CPU partition, and disables the Soperator
@@ -1302,8 +1302,9 @@ If the operator answers `n` to the app field phase, cxcli keeps the catalog
 production chart config defaults: five-role GPU layout (`system`, `controller`,
 `login`, `accounting`, and GPU `worker`), SFS jail/controller-spool/accounting
 filesystems, Slurm accounting, SlurmDBD, and chart-managed MariaDB enabled with
-storage bound to the accounting SFS-backed `slurm-local-pv` class, one node in
-each generated role group by default, with
+storage bound to the accounting SFS-backed `slurm-local-pv` class, `system`
+autoscaling from 3 to 5 nodes, two fixed `controller`, `login`, and
+`accounting` nodes, one worker node by default, with
 ActiveChecks, checks controller, Soperator DCGM job mapping, notifier, backup,
 QoS reconcile, SSSD, and the NodeConfigurator rebooter disabled. Exact
 descendant wizard entries can still prompt under `values.*`; broad chart
@@ -1750,7 +1751,7 @@ Wizard field/option model:
 - The bundled `mk8s` source entry also sets `defaults.inputs.cluster.kube_network.service_cidrs: ["/20"]`. Nebius defaults omitted MK8s service CIDRs to `["/16"]`; on a single-pool `/16` subnet that can consume the entire pool and stall control-plane provisioning. `validate` and `deploy` now preflight that case against the live subnet before Terraform apply, and the same VPC networking preflight verifies that selected subnet IDs belong to the selected project VPC network.
 - The bundled `mk8s` source entry does not default `inputs.node_groups`; the wizard materializes explicit typed node groups from profile data or operator answers so the rendered config owns every node-group role, size, platform, preset, storage, reservation, service account, and SSH assignment. Node-group service-account assignment defaults to none; the wizard only writes `service_account` when the operator selects an existing service account ID or a create-by-name path.
 - For a plain MK8s-only target, the interactive flow enters a node-group creation loop after the cluster fields. Each loop iteration writes one concrete `inputs.node_groups.<name>` entry and asks for the node-group name, autoscaling or fixed size, CPU/GPU resource type, preemptible flag, platform, preset, optional GPU cluster fabric, GPU reservation policy and tenant Capacity Block Group IDs when relevant, OS, boot-disk type/size, same-session SFS attachment keys when available, SSH public-key attachment, and service-account attachment. The reservation policy prompt follows platform/preset/fabric selection because Capacity Block Groups are matched by region, service, platform, and fabric; if the selected live shape or fabric exposes reserved capacity, the default policy is `AUTO`, otherwise it is `FORBID`.
-- The bundled MK8s flow also treats effective node-group prerequisites as conditionally required: each concrete enabled `inputs.node_groups.*` entry must provide effective `platform` and `preset`, plus either `node_count` or enabled autoscaling. For a plain MK8s-only target, the default CPU baseline group name is `system`; `node_group_defaults.*` is a profile helper surface used only when another flow, such as Soperator `production-cluster`, materializes profile-owned groups into concrete `inputs.node_groups` and `inputs.gpu_clusters`. Runtime config normalization prunes inactive helper blocks for bundled MK8s-only configs, while preserving custom module/catalog entries that explicitly declare or seed that input. Profile-owned Soperator boot-disk defaults merge into concrete node groups and preserve cxcli-computed `size_gibibytes` values. The curated `inputs.soperator.*_node_count` helpers materialize CPU service-role fixed sizes for `system`, `controller`, `login`, and `accounting`; disabled-by-default `inputs.soperator.*_autoscaling` helpers materialize concrete node-group autoscaling blocks for those roles and `worker` when enabled, omitting fixed `node_count` so rendered Terraform node-group templates keep the provider-valid scale contract. When a Soperator autoscaling helper is disabled again, materialization restores the profile fixed count and removes any stale concrete `autoscaling` block.
+- The bundled MK8s flow also treats effective node-group prerequisites as conditionally required: each concrete enabled `inputs.node_groups.*` entry must provide effective `platform` and `preset`, plus either `node_count` or enabled autoscaling. For a plain MK8s-only target, the default CPU baseline group name is `system`; `node_group_defaults.*` is a profile helper surface used only when another flow, such as Soperator `production-cluster`, materializes profile-owned groups into concrete `inputs.node_groups` and `inputs.gpu_clusters`. Runtime config normalization prunes inactive helper blocks for bundled MK8s-only configs, while preserving custom module/catalog entries that explicitly declare or seed that input. Profile-owned Soperator boot-disk defaults merge into concrete node groups and preserve cxcli-computed `size_gibibytes` values. The curated `inputs.soperator.*_node_count` helpers materialize CPU service-role fixed sizes for `system`, `controller`, `login`, and `accounting`; `system` autoscaling defaults to enabled with a 3..5 node range, and disabling it restores fixed count 3. `controller`, `login`, `accounting`, and `worker` autoscaling helpers default to disabled; enabling any role helper materializes a concrete node-group autoscaling block and omits fixed `node_count` so rendered Terraform node-group templates keep the provider-valid scale contract. When a Soperator autoscaling helper is disabled again, materialization restores the profile fixed count and removes any stale concrete `autoscaling` block.
 - `component_sources.yaml` can declare consumer-side `input` bindings so component outputs feed other component inputs without adding hardcoded wiring to the CLI.
 - Interactive field prompting now offers all discoverable required and optional component fields for newly selected components.
 - Per-component field phases default to `y` for infra modules and `n` for app charts, because Helm/chart defaults still cover the app case unless the operator explicitly wants overrides.
@@ -2690,17 +2691,22 @@ Profile concepts:
   curated CPU service-role count helpers:
   `inputs.soperator.system_node_count`,
   `controller_node_count`, `login_node_count`, and `accounting_node_count`.
-  It also exposes disabled-by-default `inputs.soperator.*_autoscaling` helpers
-  for `system`, `controller`, `login`, `accounting`, and `worker`; enabling a
-  helper writes concrete `inputs.node_groups.*.autoscaling` and suppresses the
-  fixed count for that role. Disabling it restores that role's fixed profile
-  count and removes any stale concrete autoscaling block. Worker fixed capacity
+  It also exposes `inputs.soperator.*_autoscaling` helpers for `system`,
+  `controller`, `login`, `accounting`, and `worker`; `system` defaults to
+  autoscaling 3..5, while the other service-role and worker autoscaling helpers
+  default off. Enabling a helper writes concrete
+  `inputs.node_groups.*.autoscaling` and suppresses the fixed count for that
+  role. Disabling it restores that role's fixed profile count and removes any
+  stale concrete autoscaling block. Worker fixed capacity
   still uses `inputs.soperator.worker_total_nodes` and `worker_nodes_per_group`
   because workers can shard into multiple MK8s groups; worker autoscaling uses
   the same shard size with `max_node_count` as the desired upper capacity and
   preserves an explicit `0..0` scale-to-zero range. Service-role autoscaling
   must keep `max_node_count` at least `1` because those groups back required
   Soperator placement.
+  Profile-owned NodeSet values leave worker `slurmd` and `munge` image
+  selection to the selected Soperator chart defaults, so chart-version bumps do
+  not duplicate worker image tags in `component_cli_settings.yaml`.
 - Partition profile chooses Slurm queues and scheduling policy. `shape-default`
   creates the default worker partition. At render time, when ActiveChecks are
   enabled, cxcli can add an internal `hidden` partition for ActiveChecks
@@ -2863,7 +2869,8 @@ The command boundary is intentional:
 - For `apps:soperator`, the create/component wizard uses
   `production-cluster`, asks for the worker profile before MK8s/SFS
   materialization, materializes the complete MK8s+SFS+Soperator five-role
-  bundle with one node in each generated role group by default, and skips
+  bundle with `system` autoscaling from 3 to 5 nodes, two fixed `controller`,
+  `login`, and `accounting` nodes, one worker node by default, and skips
   role-mapping prompts.
   `nebius-cxcli ext-soperator onboard <config.yaml-or-deployments-root>` resolves
   the selected project, lists existing Nebius MK8s clusters, registers one

--- a/services/nebius-cxcli/src/nebius_cxcli/cli.py
+++ b/services/nebius-cxcli/src/nebius_cxcli/cli.py
@@ -13608,13 +13608,39 @@ def _soperator_apply_profile_node_group_count_inputs(
         if isinstance(group, dict):
             default_node_count = _positive_int(raw_group.get("node_count"), default=1)
             scale_node_count = node_count if node_count is not None else default_node_count
+            default_autoscaling = raw_group.get("autoscaling")
+            default_autoscaling_min_node_count = scale_node_count
+            default_autoscaling_max_node_count = scale_node_count
+            if isinstance(default_autoscaling, Mapping):
+                default_autoscaling_min_node_count = _positive_int(
+                    default_autoscaling.get("min_node_count"),
+                    default=scale_node_count,
+                )
+                default_autoscaling_max_node_count = _positive_int(
+                    default_autoscaling.get("max_node_count"),
+                    default=max(default_autoscaling_min_node_count, scale_node_count),
+                )
             autoscaling = _soperator_profile_autoscaling_input(
                 inputs=inputs,
                 raw_group=raw_group,
-                default_min_node_count=scale_node_count,
-                default_max_node_count=scale_node_count,
+                default_min_node_count=default_autoscaling_min_node_count,
+                default_max_node_count=default_autoscaling_max_node_count,
                 min_max_node_count=1,
             )
+            autoscaling_input = _non_empty_text(raw_group.get("autoscaling_input"))
+            raw_autoscaling_input = (
+                _mapping_path_value(inputs, autoscaling_input) if autoscaling_input else None
+            )
+            if (
+                autoscaling is None
+                and node_count is None
+                and not isinstance(raw_autoscaling_input, Mapping)
+                and isinstance(default_autoscaling, Mapping)
+            ):
+                autoscaling = {
+                    "min_node_count": default_autoscaling_min_node_count,
+                    "max_node_count": default_autoscaling_max_node_count,
+                }
             _soperator_set_node_group_scale(
                 group,
                 node_count=scale_node_count,
@@ -15302,7 +15328,19 @@ def _materialize_soperator_component_defaults(payload: dict[str, Any]) -> bool:
                 if isinstance(sfs_values, dict):
                     filesystems_values = sfs_values.setdefault("filesystems", {})
                     if isinstance(filesystems_values, dict):
-                        _merge_missing_mapping(filesystems_values, soperator_filesystems)
+                        for filesystem_key, filesystem_spec in soperator_filesystems.items():
+                            if not isinstance(filesystem_spec, Mapping):
+                                filesystems_values[filesystem_key] = copy.deepcopy(
+                                    to_plain_data(filesystem_spec)
+                                )
+                                continue
+                            target_filesystem = filesystems_values.setdefault(filesystem_key, {})
+                            if isinstance(target_filesystem, dict):
+                                _merge_replace_mapping(target_filesystem, filesystem_spec)
+                            else:
+                                filesystems_values[filesystem_key] = copy.deepcopy(
+                                    to_plain_data(filesystem_spec)
+                                )
                 volume_values = values.setdefault("volume", {})
                 if isinstance(volume_values, dict):
                     jail_fs = soperator_filesystems.get("jail", {})
@@ -15310,37 +15348,29 @@ def _materialize_soperator_component_defaults(payload: dict[str, Any]) -> bool:
                         jail_values = volume_values.setdefault("jail", {})
                         if isinstance(jail_values, dict):
                             if "size_gib" in jail_fs:
-                                jail_values.setdefault("size", f"{jail_fs['size_gib']}Gi")
+                                jail_values["size"] = f"{jail_fs['size_gib']}Gi"
                             if str(jail_fs.get("mount_tag", "") or "").strip():
-                                jail_values.setdefault("filestoreDeviceName", jail_fs["mount_tag"])
+                                jail_values["filestoreDeviceName"] = jail_fs["mount_tag"]
                     controller_fs = soperator_filesystems.get("controller-spool", {})
                     if isinstance(controller_fs, Mapping):
                         controller_values = volume_values.setdefault("controllerSpool", {})
                         if isinstance(controller_values, dict):
                             if "size_gib" in controller_fs:
-                                controller_values.setdefault(
-                                    "size",
-                                    f"{controller_fs['size_gib']}Gi",
-                                )
+                                controller_values["size"] = f"{controller_fs['size_gib']}Gi"
                             if str(controller_fs.get("mount_tag", "") or "").strip():
-                                controller_values.setdefault(
-                                    "filestoreDeviceName",
-                                    controller_fs["mount_tag"],
-                                )
+                                controller_values["filestoreDeviceName"] = controller_fs[
+                                    "mount_tag"
+                                ]
                     accounting_fs = soperator_filesystems.get("accounting", {})
                     if isinstance(accounting_fs, Mapping):
                         accounting_values = volume_values.setdefault("accounting", {})
                         if isinstance(accounting_values, dict):
                             if "size_gib" in accounting_fs:
-                                accounting_values.setdefault(
-                                    "size",
-                                    f"{accounting_fs['size_gib']}Gi",
-                                )
+                                accounting_values["size"] = f"{accounting_fs['size_gib']}Gi"
                             if str(accounting_fs.get("mount_tag", "") or "").strip():
-                                accounting_values.setdefault(
-                                    "filestoreDeviceName",
-                                    accounting_fs["mount_tag"],
-                                )
+                                accounting_values["filestoreDeviceName"] = accounting_fs[
+                                    "mount_tag"
+                                ]
         if row != before:
             changed = True
     return changed

--- a/services/nebius-cxcli/src/nebius_cxcli/wizard_profiles.py
+++ b/services/nebius-cxcli/src/nebius_cxcli/wizard_profiles.py
@@ -198,14 +198,22 @@ def _mk8s_soperator_autoscaling_fields() -> dict[str, dict[str, Any]]:
     fields: dict[str, dict[str, Any]] = {}
     for role in ("system", "controller", "login", "accounting", "worker"):
         prefix = f"inputs.soperator.{role}_autoscaling"
-        fields[f"{prefix}.enabled"] = _disabled_bool_wizard_field()
+        fields[f"{prefix}.enabled"] = (
+            {
+                "default": True,
+                "write_default_to_config": True,
+                "type_hint": "bool",
+            }
+            if role == "system"
+            else _disabled_bool_wizard_field()
+        )
         fields[f"{prefix}.min_node_count"] = {
-            "default": 1,
+            "default": 3 if role == "system" else 1,
             "write_default_to_config": True,
             "type_hint": "number",
         }
         fields[f"{prefix}.max_node_count"] = {
-            "default": 1,
+            "default": 5 if role == "system" else 1,
             "write_default_to_config": True,
             "type_hint": "number",
         }
@@ -546,22 +554,22 @@ BUILTIN_WIZARD_PROFILES: dict[str, dict[str, dict[str, Any]]] = {
             "required": False,
         },
         "inputs.soperator.system_node_count": {
-            "default": 1,
+            "default": 3,
             "write_default_to_config": True,
             "type_hint": "number",
         },
         "inputs.soperator.controller_node_count": {
-            "default": 1,
+            "default": 2,
             "write_default_to_config": True,
             "type_hint": "number",
         },
         "inputs.soperator.login_node_count": {
-            "default": 1,
+            "default": 2,
             "write_default_to_config": True,
             "type_hint": "number",
         },
         "inputs.soperator.accounting_node_count": {
-            "default": 1,
+            "default": 2,
             "write_default_to_config": True,
             "type_hint": "number",
         },

--- a/services/nebius-cxcli/tests/test_cli_command_coverage.py
+++ b/services/nebius-cxcli/tests/test_cli_command_coverage.py
@@ -20610,7 +20610,14 @@ def test_soperator_selection_seeds_required_infra_and_defaults() -> None:
     assert mk8s_inputs["node_groups"]["login"]["gpu"] is False
     assert mk8s_inputs["node_groups"]["accounting"]["gpu"] is False
     assert mk8s_inputs["node_groups"]["worker"]["nodeset_name"] == "worker"
-    assert mk8s_inputs["node_groups"]["system"]["node_count"] == 1
+    assert mk8s_inputs["node_groups"]["system"]["autoscaling"] == {
+        "min_node_count": 3,
+        "max_node_count": 5,
+    }
+    assert "node_count" not in mk8s_inputs["node_groups"]["system"]
+    assert mk8s_inputs["node_groups"]["controller"]["node_count"] == 2
+    assert mk8s_inputs["node_groups"]["login"]["node_count"] == 2
+    assert mk8s_inputs["node_groups"]["accounting"]["node_count"] == 2
     assert mk8s_inputs["node_groups"]["worker"]["node_count"] == 1
     assert mk8s_inputs["node_groups"]["worker"]["gpu"] is True
     assert mk8s_inputs["node_groups"]["worker"]["reservation"] == {"policy": "AUTO"}
@@ -20735,6 +20742,109 @@ def test_soperator_sfs_defaults_are_target_scoped_for_multi_target_rows() -> Non
     assert values_by_target["cluster-b"]["volume"]["jail"]["filestoreDeviceName"] == "jail-b"
     assert values_by_target["cluster-b"]["sfs"]["filesystems"]["jail"]["block_size_kib"] == 4
     assert values_by_target["cluster-b"]["sfs"]["filesystems"]["jail"]["forbid_deletion"] is False
+
+
+def test_soperator_sfs_mirror_values_replace_stale_generated_values() -> None:
+    payload = {
+        "infra": {
+            "components": [
+                {
+                    "id": "mk8s",
+                    "instance_id": "cxcli-slurm",
+                    "enabled": True,
+                    "inputs": {},
+                },
+                {
+                    "id": "sfs",
+                    "instance_id": "cxcli-slurm",
+                    "enabled": True,
+                    "inputs": {
+                        "filesystems": {
+                            "jail": {
+                                "name": "cxcli-slurm-jail",
+                                "size_gib": 1024,
+                                "block_size_kib": 4,
+                                "mount_tag": "cxcli-slurm-jail",
+                                "forbid_deletion": False,
+                            },
+                            "controller-spool": {
+                                "name": "cxcli-slurm-controller-spool",
+                                "size_gib": 128,
+                                "block_size_kib": 4,
+                                "mount_tag": "cxcli-slurm-controller-spool",
+                                "forbid_deletion": False,
+                            },
+                            "accounting": {
+                                "name": "cxcli-slurm-accounting",
+                                "size_gib": 128,
+                                "block_size_kib": 4,
+                                "mount_tag": "cxcli-slurm-accounting",
+                                "forbid_deletion": False,
+                            },
+                        }
+                    },
+                },
+            ]
+        },
+        "apps": {
+            "charts": [
+                {
+                    "id": "soperator",
+                    "instance_id": "cxcli-slurm",
+                    "enabled": True,
+                    "install_mode": "production-cluster",
+                    "values": {
+                        "sfs": {
+                            "filesystems": {
+                                "jail": {"name": "mk8s-jail", "mount_tag": "mk8s-jail"},
+                                "controller-spool": {
+                                    "name": "mk8s-controller-spool",
+                                    "mount_tag": "mk8s-controller-spool",
+                                },
+                                "accounting": {
+                                    "name": "mk8s-accounting",
+                                    "mount_tag": "mk8s-accounting",
+                                },
+                            }
+                        },
+                        "volume": {
+                            "jail": {
+                                "size": "1Gi",
+                                "filestoreDeviceName": "mk8s-jail",
+                            },
+                            "controllerSpool": {
+                                "size": "1Gi",
+                                "filestoreDeviceName": "mk8s-controller-spool",
+                            },
+                            "accounting": {
+                                "size": "1Gi",
+                                "filestoreDeviceName": "mk8s-accounting",
+                            },
+                        },
+                    },
+                }
+            ]
+        },
+    }
+
+    assert cli._materialize_soperator_component_defaults(payload) is True
+
+    values = payload["apps"]["charts"][0]["values"]
+    assert values["sfs"]["filesystems"]["jail"]["name"] == "cxcli-slurm-jail"
+    assert (
+        values["sfs"]["filesystems"]["controller-spool"]["mount_tag"]
+        == "cxcli-slurm-controller-spool"
+    )
+    assert values["sfs"]["filesystems"]["accounting"]["name"] == "cxcli-slurm-accounting"
+    assert values["volume"]["jail"] == {
+        "size": "1024Gi",
+        "filestoreDeviceName": "cxcli-slurm-jail",
+    }
+    assert values["volume"]["controllerSpool"] == {
+        "size": "128Gi",
+        "filestoreDeviceName": "cxcli-slurm-controller-spool",
+    }
+    assert values["volume"]["accounting"]["filestoreDeviceName"] == "cxcli-slurm-accounting"
 
 
 def test_soperator_profiles_share_complete_sfs_filesystem_defaults() -> None:
@@ -20941,7 +21051,7 @@ def test_soperator_production_disabled_service_autoscaling_clears_stale_group_sc
     assert cli._materialize_soperator_component_defaults(payload) is True
 
     system_group = mk8s_inputs["node_groups"]["system"]
-    assert system_group["node_count"] == 1
+    assert system_group["node_count"] == 3
     assert "autoscaling" not in system_group
 
 
@@ -20969,7 +21079,7 @@ def test_soperator_production_disabled_service_autoscaling_clears_first_render_s
                                 },
                                 "gpu": False,
                                 "platform": "cpu-d3",
-                                "preset": "8vcpu-32gb",
+                                "preset": "32vcpu-128gb",
                             },
                         },
                     },
@@ -20998,7 +21108,7 @@ def test_soperator_production_disabled_service_autoscaling_clears_first_render_s
     assert cli._materialize_soperator_component_defaults(payload) is True
 
     system_group = payload["infra"]["components"][0]["inputs"]["node_groups"]["system"]
-    assert system_group["node_count"] == 1
+    assert system_group["node_count"] == 3
     assert "autoscaling" not in system_group
 
 
@@ -21444,7 +21554,7 @@ def test_mk8s_image_defaults_replace_stale_soperator_gpu_stack_default() -> None
                         "node_group_defaults": {
                             "cpu": {
                                 "platform": "cpu-d3",
-                                "preset": "8vcpu-32gb",
+                                "preset": "32vcpu-128gb",
                                 "os": "ubuntu24.04",
                             },
                             "gpu": {
@@ -21638,7 +21748,15 @@ def test_soperator_cpu_profile_materializes_only_cpu_worker_nodeset() -> None:
         "accounting",
         "worker-cpu",
     }
-    assert all(group["node_count"] == 1 for group in mk8s_inputs["node_groups"].values())
+    assert mk8s_inputs["node_groups"]["system"]["autoscaling"] == {
+        "min_node_count": 3,
+        "max_node_count": 5,
+    }
+    assert "node_count" not in mk8s_inputs["node_groups"]["system"]
+    assert mk8s_inputs["node_groups"]["controller"]["node_count"] == 2
+    assert mk8s_inputs["node_groups"]["login"]["node_count"] == 2
+    assert mk8s_inputs["node_groups"]["accounting"]["node_count"] == 2
+    assert mk8s_inputs["node_groups"]["worker-cpu"]["node_count"] == 1
     assert all(group["gpu"] is False for group in mk8s_inputs["node_groups"].values())
     assert mk8s_inputs["node_groups"]["worker-cpu"]["nodeset_name"] == "worker-cpu"
     assert mk8s_inputs["node_groups"]["worker-cpu"]["node_count"] == 1
@@ -21713,10 +21831,14 @@ def test_soperator_mixed_profile_materializes_cpu_and_gpu_workers() -> None:
     assert "gpu_enabled" not in mk8s_inputs
     assert "gpu_node_groups" not in mk8s_inputs
     assert "gpu_nodes_count_per_group" not in mk8s_inputs
-    assert mk8s_inputs["node_groups"]["system"]["node_count"] == 1
-    assert mk8s_inputs["node_groups"]["controller"]["node_count"] == 1
-    assert mk8s_inputs["node_groups"]["login"]["node_count"] == 1
-    assert mk8s_inputs["node_groups"]["accounting"]["node_count"] == 1
+    assert mk8s_inputs["node_groups"]["system"]["autoscaling"] == {
+        "min_node_count": 3,
+        "max_node_count": 5,
+    }
+    assert "node_count" not in mk8s_inputs["node_groups"]["system"]
+    assert mk8s_inputs["node_groups"]["controller"]["node_count"] == 2
+    assert mk8s_inputs["node_groups"]["login"]["node_count"] == 2
+    assert mk8s_inputs["node_groups"]["accounting"]["node_count"] == 2
     assert mk8s_inputs["node_groups"]["worker-cpu"]["nodeset_name"] == "worker-cpu"
     assert mk8s_inputs["node_groups"]["worker-cpu"]["node_count"] == 1
     assert mk8s_inputs["node_groups"]["worker-cpu"]["gpu"] is False

--- a/services/nebius-cxcli/tests/test_component_sources.py
+++ b/services/nebius-cxcli/tests/test_component_sources.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+from collections.abc import Iterator
 from copy import deepcopy
 from dataclasses import asdict
 from pathlib import Path
@@ -83,6 +84,16 @@ def _deep_merge_mapping(base: dict, override: dict) -> dict:
         else:
             merged[key] = deepcopy(value)
     return merged
+
+
+def _walk_mappings(value: object) -> Iterator[dict]:
+    if isinstance(value, dict):
+        yield value
+        for item in value.values():
+            yield from _walk_mappings(item)
+    elif isinstance(value, list):
+        for item in value:
+            yield from _walk_mappings(item)
 
 
 def setup_function() -> None:
@@ -557,7 +568,7 @@ def test_bundled_catalog_exposes_soperator_and_nfs_local_sources() -> None:
         profile = soperator.soperator_nodesets.profiles[profile_name]
         assert profile["mk8s"]["inputs"]["node_group_defaults"]["cpu"] == {
             "platform": "cpu-d3",
-            "preset": "8vcpu-32gb",
+            "preset": "32vcpu-128gb",
         }
         for role in ("system", "controller", "login", "accounting"):
             assert profile["mk8s"]["node_groups"][role]["autoscaling_input"] == (
@@ -2860,6 +2871,47 @@ def test_component_sources_rejects_invalid_observability_gpu_node_label_stack_so
         load_component_sources(explicit=sources_file)
 
 
+def _repo_soperator_nodesets_profiles() -> dict:
+    profiles = (
+        _repo_component_cli_settings_payload()["components"]["apps"]["soperator"]["cli"][
+            "soperator_nodesets_profile"
+        ]["profiles"]
+    )
+    assert isinstance(profiles, dict)
+    return profiles
+
+
+def test_bundled_soperator_profile_service_role_defaults_are_consistent() -> None:
+    profiles = _repo_soperator_nodesets_profiles()
+
+    for profile_name in ("nebius-cpu-v1", "nebius-mixed-v1", "nebius-gpu-v1"):
+        node_groups = profiles[profile_name]["mk8s"]["node_groups"]
+        assert node_groups["system"]["node_count"] == 3
+        assert node_groups["system"]["autoscaling"] == {
+            "min_node_count": 3,
+            "max_node_count": 5,
+        }
+        assert node_groups["system"]["node_count_input"] == "soperator.system_node_count"
+        assert (
+            node_groups["system"]["autoscaling_input"] == "soperator.system_autoscaling"
+        )
+        for role in ("controller", "login", "accounting"):
+            assert node_groups[role]["node_count"] == 2
+            assert node_groups[role]["node_count_input"] == f"soperator.{role}_node_count"
+            assert node_groups[role]["autoscaling_input"] == f"soperator.{role}_autoscaling"
+
+
+def test_bundled_soperator_profiles_leave_worker_images_to_chart_defaults() -> None:
+    profiles = _repo_soperator_nodesets_profiles()
+
+    for profile_name in ("nebius-cpu-v1", "nebius-mixed-v1", "nebius-gpu-v1"):
+        for item in _walk_mappings(profiles[profile_name]):
+            for container_key in ("slurmd", "munge"):
+                container = item.get(container_key)
+                if isinstance(container, dict):
+                    assert "image" not in container
+
+
 def test_bundled_mk8s_declares_optional_wizard_field_override() -> None:
     loaded = load_component_sources(
         explicit=Path(__file__).resolve().parents[1] / "component_sources.yaml"
@@ -2947,18 +2999,33 @@ def test_bundled_mk8s_declares_optional_wizard_field_override() -> None:
         "write_default_to_config": True,
         "type_hint": "number",
     }
-    for field in (
-        "system_node_count",
-        "controller_node_count",
-        "login_node_count",
-        "accounting_node_count",
-    ):
+    assert mk8s_wizard_fields["inputs.soperator.system_node_count"] == {
+        "default": 3,
+        "write_default_to_config": True,
+        "type_hint": "number",
+    }
+    for field in ("controller_node_count", "login_node_count", "accounting_node_count"):
         assert mk8s_wizard_fields[f"inputs.soperator.{field}"] == {
-            "default": 1,
+            "default": 2,
             "write_default_to_config": True,
             "type_hint": "number",
         }
-    for role in ("system", "controller", "login", "accounting", "worker"):
+    assert mk8s_wizard_fields["inputs.soperator.system_autoscaling.enabled"] == {
+        "default": True,
+        "write_default_to_config": True,
+        "type_hint": "bool",
+    }
+    assert mk8s_wizard_fields["inputs.soperator.system_autoscaling.min_node_count"] == {
+        "default": 3,
+        "write_default_to_config": True,
+        "type_hint": "number",
+    }
+    assert mk8s_wizard_fields["inputs.soperator.system_autoscaling.max_node_count"] == {
+        "default": 5,
+        "write_default_to_config": True,
+        "type_hint": "number",
+    }
+    for role in ("controller", "login", "accounting", "worker"):
         assert mk8s_wizard_fields[f"inputs.soperator.{role}_autoscaling.enabled"] == {
             "default": False,
             "write_default_to_config": True,

--- a/services/nebius-cxcli/tests/test_config_model.py
+++ b/services/nebius-cxcli/tests/test_config_model.py
@@ -270,7 +270,7 @@ def test_normalize_runtime_config_prunes_cpu_soperator_gpu_node_group_defaults()
                         "node_group_defaults": {
                             "cpu": {
                                 "platform": "cpu-d3",
-                                "preset": "8vcpu-32gb",
+                                "preset": "32vcpu-128gb",
                             },
                             "gpu": {
                                 "platform": "gpu-h100-sxm",
@@ -304,7 +304,7 @@ def test_normalize_runtime_config_prunes_cpu_soperator_gpu_node_group_defaults()
     assert normalize_runtime_config_payload(payload) is True
 
     defaults = payload["infra"]["components"][0]["inputs"]["node_group_defaults"]
-    assert defaults == {"cpu": {"platform": "cpu-d3", "preset": "8vcpu-32gb"}}
+    assert defaults == {"cpu": {"platform": "cpu-d3", "preset": "32vcpu-128gb"}}
     assert "gpu_clusters" not in payload["infra"]["components"][0]["inputs"]
 
 

--- a/services/nebius-cxcli/tests/test_mk8s_gpu.py
+++ b/services/nebius-cxcli/tests/test_mk8s_gpu.py
@@ -821,7 +821,7 @@ def test_prune_inactive_mk8s_gpu_app_rows_removes_stale_operator_only_apps() -> 
                                 "node_count": 1,
                                 "gpu": False,
                                 "platform": "cpu-d3",
-                                "preset": "8vcpu-32gb",
+                                "preset": "32vcpu-128gb",
                             }
                         }
                     },
@@ -879,7 +879,7 @@ def test_prune_inactive_mk8s_gpu_app_rows_removes_stripped_soperator_policy_apps
                                 "node_count": 1,
                                 "gpu": False,
                                 "platform": "cpu-d3",
-                                "preset": "8vcpu-32gb",
+                                "preset": "32vcpu-128gb",
                             }
                         }
                     },

--- a/services/nebius-cxcli/tests/test_phase3_prompt_introspection.py
+++ b/services/nebius-cxcli/tests/test_phase3_prompt_introspection.py
@@ -846,7 +846,7 @@ def test_prune_gpu_node_group_defaults_for_cpu_only_soperator_profile() -> None:
                         "node_group_defaults": {
                             "cpu": {
                                 "platform": "cpu-d3",
-                                "preset": "8vcpu-32gb",
+                                "preset": "32vcpu-128gb",
                             },
                             "gpu": {
                                 "platform": "gpu-h100-sxm",
@@ -880,7 +880,7 @@ def test_prune_gpu_node_group_defaults_for_cpu_only_soperator_profile() -> None:
     _prune_mk8s_node_group_defaults_without_soperator(payload, infra_entries=(entry,))
 
     defaults = payload["infra"]["components"][0]["inputs"]["node_group_defaults"]
-    assert defaults == {"cpu": {"platform": "cpu-d3", "preset": "8vcpu-32gb"}}
+    assert defaults == {"cpu": {"platform": "cpu-d3", "preset": "32vcpu-128gb"}}
 
 
 def test_prune_mk8s_node_group_defaults_for_soperator_onboarding_target() -> None:

--- a/services/nebius-cxcli/tests/test_render.py
+++ b/services/nebius-cxcli/tests/test_render.py
@@ -1681,7 +1681,7 @@ def test_render_project_materializes_soperator_profile_defaults(tmp_path: Path) 
     for group_name in ("system", "controller", "login", "accounting"):
         group = mk8s_inputs["node_groups"][group_name]
         assert group["platform"] == "cpu-d3"
-        assert group["preset"] == "8vcpu-32gb"
+        assert group["preset"] == "32vcpu-128gb"
     assert mk8s_inputs["node_groups"]["system"]["autoscaling"] == {
         "min_node_count": 1,
         "max_node_count": 4,

--- a/skills/CHANGELOG.md
+++ b/skills/CHANGELOG.md
@@ -16,6 +16,10 @@ All notable changes to the reusable Codex skills are tracked here.
   Agent Skill folders, including `SKILL.md`, references, assets, scripts,
   official vendor-doc verification, safety guardrails, canonical structure, and
   validation evidence.
+- Added the `apply-security` Codex skill for security scans, remediation
+  plans, safe patching, verification, and explanation across Terraform,
+  Kubernetes, Helm, CI/CD, Bash, Python, Java, JavaScript, TypeScript, and Rust
+  codebases.
 - Added the `attach-ubuntu` Codex skill with a Bash helper that creates or
   reuses a per-project Ubuntu container, mounts the current project at
   `/workdir`, updates VS Code attached-container defaults, bootstraps Ubuntu
@@ -61,6 +65,24 @@ All notable changes to the reusable Codex skills are tracked here.
 
 ### Changed
 
+- Hardened `apply-security` validation guidance so lockfile maintenance,
+  cache/build directory writes, external registry submissions,
+  package-manager auto-install behavior, and live-credential checks require
+  explicit scope and safety review.
+- Updated `align-skill` so each alignment run captures evidence-backed,
+  public-safe reusable learnings back into the target skill's local source
+  materials before completion, and reports any source updates that were skipped.
+- Updated `align-skill` so it can be triggered as a helper for hardening
+  scaffolded or draft skills and applies safe, secure, fast authoring guidance
+  without replacing `skill-creator` for initial scaffolding.
+- Updated `align-skill` to recognize optional `evals/` folders for reusable
+  trigger or quality-evaluation prompts, matching the existing `helmchart`
+  trigger-eval convention, and added a validator self-test for the `evals/`
+  acceptance plus unknown-folder warning behavior.
+- Added a standard `## Learning Loop` rule to every reusable skill so durable,
+  public-safe, evidence-backed learnings can be captured by the task skill that
+  is already loaded, and taught `align-skill` validation to enforce the rule on
+  target skills while preserving read-only and report-only task contracts.
 - Tightened the `code-info` skill contract so invoking it is explicitly
   read-only information gathering: it reports from existing files only and does
   not edit, format, build, test, install, generate coverage, or stage files.

--- a/skills/CHANGELOG.md
+++ b/skills/CHANGELOG.md
@@ -83,6 +83,13 @@ All notable changes to the reusable Codex skills are tracked here.
 
 ### Changed
 
+- Relaxed `global-context-management` subagent guidance so, after a prompt or
+  user-enabled local hook policy authorizes delegation, Codex should choose
+  useful targeted read-only helper roles instead of waiting for the prompt to
+  name them, while still treating runtime tool availability and active
+  instructions as hard gates; `SKILL.md` now also has explicit stateful
+  workflow sections for inputs, required reads, writes, idempotency, failure
+  handling, must-not rules, process, and completion criteria.
 - Renamed SDLC-only workflow skills and the coordinator to `sdlc-*` names, and
   made their front matter descriptions start with
   `Use only as part of the Agentic SDLC workflow;` so tool discovery separates
@@ -115,6 +122,8 @@ All notable changes to the reusable Codex skills are tracked here.
   state-machine skills that manage local state, locked plans, evidence,
   continuation, retries, or failure routing, including a reusable template and
   `--profile stateful-workflow` validator support.
+- Clarified the `align-skill` README definition of stateful workflow skills,
+  including when to use the profile and a concise SDLC coordinator example.
 - Updated `create-pr` and `review-pr` with Agentic SDLC handoff guidance so
   they can read local SDLC evidence when invoked in that workflow while
   preserving their general PR behavior.

--- a/skills/CHANGELOG.md
+++ b/skills/CHANGELOG.md
@@ -6,6 +6,20 @@ All notable changes to the reusable Codex skills are tracked here.
 
 ### Added
 
+- Added the Agentic SDLC skill set: `sdlc-create-requirements`, `sdlc-start`,
+  `sdlc-gather-context`, `sdlc-create-design`, `sdlc-create-plan`,
+  `sdlc-tdd`, `sdlc-implement-plan`, `sdlc-validate-codes`,
+  `sdlc-unit-tests`, `sdlc-evaluate`, `sdlc-classify-failure`,
+  `sdlc-gui-test`, `sdlc-tui-test`, `sdlc-commit`, `sdlc-uat-tests`,
+  `sdlc-merge-pr`, and `sdlc-align-specs`. These skills keep committed
+  product truth in `docs/requirements.md` and
+  `docs/design.md`, keep execution state under `~/.codex/sdlc-runs`, and
+  model the SDLC loop as skill-selected phases rather than a workflow CLI. The
+  SDLC flow reuses existing `create-pr` and `review-pr` as PR creation and
+  review handoff phases.
+- Added SDLC templates for requirements, design, context packs, locked feature
+  plans, validation/test/evaluation evidence, local commit evidence, and UAT
+  reports, plus state-schema and failure-taxonomy references.
 - Added this `skills/CHANGELOG.md` so reusable-skill release notes live with
   the skills instead of in the monorepo root changelog.
 - Added the `align` Codex skill for end-to-end project review and repair passes
@@ -65,6 +79,35 @@ All notable changes to the reusable Codex skills are tracked here.
 
 ### Changed
 
+- Renamed SDLC-only workflow skills to `sdlc-*` names, with `start-sdlc`
+  becoming `sdlc-start`, and made their front matter descriptions start with
+  `Use only as part of the Agentic SDLC workflow;` so tool discovery separates
+  SDLC phases from ordinary commands and general-purpose skills.
+- Updated `align-skill` with an optional stateful-workflow profile for
+  state-machine skills that manage local state, locked plans, evidence,
+  continuation, retries, or failure routing, including a reusable template and
+  `--profile stateful-workflow` validator support.
+- Updated `create-pr` and `review-pr` with Agentic SDLC handoff guidance so
+  they can read local SDLC evidence when invoked in that workflow while
+  preserving their general PR behavior.
+- Hardened `sdlc-start` so coordinator reruns resume from explicit
+  checkpoints, repair partial pointer writes from the newest complete
+  checkpoint, avoid duplicate history on unchanged resumes, and keep locked
+  plans append-only by superseding instead of editing in place.
+- Documented the runtime hook authorization handoff for Agentic SDLC:
+  `sdlc-commit`, `create-pr`, and `sdlc-merge-pr` now write short-lived local
+  authorization files under the active run before guarded Git actions, and
+  `sdlc-start` state schema records the `permissions/` directory contract.
+- Clarified hook ownership boundaries: non-SDLC global-context hooks own
+  `SessionStart` and lightweight `UserPromptSubmit` context, while Agentic
+  SDLC uses only separate `PreToolUse` and `Stop` hooks.
+- Tightened global-context hook rules so `SessionStart` is limited to stable
+  global context and `UserPromptSubmit` is limited to lightweight prompt-time
+  hints, with no SDLC routing, requirements parsing, workflow skill selection,
+  run-state creation, or large-document injection.
+- Reduced global-context hook payloads so `SessionStart` and `UserPromptSubmit`
+  no longer repeat detailed workflow or subagent lifecycle instructions already
+  owned by `global-context-management`.
 - Hardened `apply-security` validation guidance so lockfile maintenance,
   cache/build directory writes, external registry submissions,
   package-manager auto-install behavior, and live-credential checks require
@@ -175,10 +218,10 @@ All notable changes to the reusable Codex skills are tracked here.
   existing nonempty `current.md` task-state file is preserved for the agent to
   read instead of being overwritten or injected into hook context, and tightened
   hook templates so reused task-state files are chmod-repaired to `0600`.
-- Changed task-state hook behavior to lazy automatic creation: `SessionStart`
-  now injects the session-scoped path without creating a missing `current.md`,
-  while `UserPromptSubmit` creates or reuses task state only for prompts that
-  look complex.
+- Changed task-state hook behavior to advertise-only: `SessionStart` injects
+  the session-scoped path without creating a missing `current.md`, while
+  `UserPromptSubmit` only advertises or reuses the same path for complex
+  prompts and does not create task-state, SDLC run state, or workflow state.
 - Tightened the `global-context-management` `SKILL.md` non-goals so a missing
   global task-state path no longer permits repo-local or manual fallback state;
   repo-local task-state files remain explicit-user-request only.

--- a/skills/CHANGELOG.md
+++ b/skills/CHANGELOG.md
@@ -20,6 +20,10 @@ All notable changes to the reusable Codex skills are tracked here.
 - Added SDLC templates for requirements, design, context packs, locked feature
   plans, validation/test/evaluation evidence, local commit evidence, and UAT
   reports, plus state-schema and failure-taxonomy references.
+- Added a source bundle for optional Agentic SDLC PreToolUse and Stop hooks
+  under `sdlc-start/assets/hooks/`, including shared hook helpers and local
+  unit tests for continuation, write-policy, authorization, steering, and
+  short-alias behavior.
 - Added this `skills/CHANGELOG.md` so reusable-skill release notes live with
   the skills instead of in the monorepo root changelog.
 - Added the `align` Codex skill for end-to-end project review and repair passes
@@ -79,10 +83,34 @@ All notable changes to the reusable Codex skills are tracked here.
 
 ### Changed
 
-- Renamed SDLC-only workflow skills to `sdlc-*` names, with `start-sdlc`
-  becoming `sdlc-start`, and made their front matter descriptions start with
+- Renamed SDLC-only workflow skills and the coordinator to `sdlc-*` names, and
+  made their front matter descriptions start with
   `Use only as part of the Agentic SDLC workflow;` so tool discovery separates
   SDLC phases from ordinary commands and general-purpose skills.
+- Hardened the Agentic SDLC Stop hook source so continuation prompts emit
+  `sdlc-start` and canonical `sdlc-*` next-skill names, normalize short
+  phase aliases only as input, and recognize pause or PR-control steering such as
+  `Pause after the current feature. Do not create a PR.`
+- Allowed the Agentic SDLC PreToolUse hook source to write
+  `$CODEX_HOME/task-state` files so `global-context-management` can persist
+  session-scoped continuity notes while unrelated `$CODEX_HOME/hooks` writes
+  remain blocked.
+- Updated `install-skills.sh` with an explicit
+  `--install-hooks <source_hook_dir>` option that copies hook files from a
+  selected hook source directory into `${CODEX_HOME:-$HOME/.codex}/hooks`,
+  keeping runtime hook sync separate from normal skill installation and from
+  `hooks.json` trust decisions.
+- Added `install-skills.sh --install-all-hooks` to install every reviewed
+  skill-owned hook bundle from `*/assets/hooks` under the source skills folder,
+  with destination collision checks and idempotent unchanged reporting for hook
+  files.
+- Aligned `config-codex` idempotency checks with the current local setup model:
+  exact global `AGENTS.md` parity when requested, required global hook
+  registrations as a `hooks.json` subset, and required public-safe MCP servers
+  while preserving extra workflow hooks and machine-specific MCP entries.
+- Strengthened `global-context-management` wording so authorized read-only
+  subagents are preferred for useful read-heavy sidecar work when the prompt or
+  local hook policy authorizes delegation and the current runtime permits it.
 - Updated `align-skill` with an optional stateful-workflow profile for
   state-machine skills that manage local state, locked plans, evidence,
   continuation, retries, or failure routing, including a reusable template and

--- a/skills/README.md
+++ b/skills/README.md
@@ -21,6 +21,13 @@ For skill-specific release notes, see [CHANGELOG.md](CHANGELOG.md).
 ## Included Skills
 
 - End-to-end project alignment: `align`
+- Agentic SDLC workflow skills: `sdlc-create-requirements`, `sdlc-start`,
+  `sdlc-gather-context`, `sdlc-create-design`, `sdlc-create-plan`,
+  `sdlc-tdd`, `sdlc-implement-plan`, `sdlc-validate-codes`,
+  `sdlc-unit-tests`, `sdlc-evaluate`, `sdlc-classify-failure`,
+  `sdlc-gui-test`, `sdlc-tui-test`, `sdlc-align-specs`, `sdlc-commit`,
+  `sdlc-uat-tests`, `sdlc-merge-pr`, plus the reused `create-pr` and
+  `review-pr` handoff skills
 - Skill folder hardening, alignment, and validation: `align-skill`
 - Security review and safe remediation across infra, CI/CD, shell, and app
   code: `apply-security`
@@ -123,8 +130,67 @@ or Agent Skill folders. Use it for named skills, local skill folders,
 multi-skill parent folders, GitHub skill repositories, or GitHub tree URLs when
 `SKILL.md`, trigger metadata, references, assets, scripts, safety guardrails,
 official vendor-doc verification, canonical structure, validation evidence, fast
-authoring practices, and reusable learning capture in local skill source
-materials need to be aligned.
+authoring practices, optional stateful-workflow section profiles, and reusable
+learning capture in local skill source materials need to be aligned.
+
+### Agentic SDLC Skills
+
+The Agentic SDLC skills implement a skill-driven state machine for turning user
+ideas into requirements, design, locked local plans, test-first implementation,
+validation, evaluation, local commits, UAT, PR creation or reuse, PR review,
+and explicit final merge.
+Strictly SDLC-only skills use the `sdlc-` prefix, with the coordinator named
+`sdlc-start`, so tool discovery does not confuse workflow phases such as
+`sdlc-commit` with ordinary Git commands or general-purpose engineering skills.
+The committed product truth is `docs/requirements.md` and `docs/design.md`;
+private run state, plans, evidence, screenshots, transcripts, and steering live
+under `~/.codex/sdlc-runs/<project-id>/<run-id>/` and must not be committed.
+Optional global PreToolUse and Stop hooks can enforce SDLC invariants from that
+local state. Sensitive Git actions use short-lived local authorization files
+under the active run's `permissions/` directory; the skills create those files
+only immediately before the guarded action.
+Keep these SDLC hooks separate from the non-SDLC global-context hooks:
+`SessionStart` is for stable global context and task-state location, and
+`UserPromptSubmit` is only for lightweight prompt-time context, safety, or
+opt-in delegation hints.
+
+- `sdlc-create-requirements`: creates or updates `docs/requirements.md` from user
+  prompts, tickets, or approved change requests while preserving stable
+  `REQ-*` IDs.
+- `sdlc-start`: coordinates the active SDLC run, reads steering and local
+  checkpoints, selects the highest-priority incomplete feature, and chooses one
+  next skill without duplicating history on unchanged resumes.
+- `sdlc-gather-context`: builds compact feature context packs from official docs,
+  internal sources, code, and tests.
+- `sdlc-create-design`: creates or updates `docs/design.md`, maps requirements to
+  stable `FEAT-*` blocks, and defines validation, test, and evaluation plans.
+- `sdlc-create-plan`: creates locked private local execution plans for one feature.
+- `sdlc-tdd`: writes or maps tests before implementation.
+- `sdlc-implement-plan`: implements production code for the current locked feature
+  plan only.
+- `sdlc-validate-codes`: runs syntax, lint, type, import, config, dependency, and
+  build checks where configured.
+- `sdlc-unit-tests`: runs feature behavior, regression, integration, component,
+  contract, or mock-based tests.
+- `sdlc-evaluate`: observes feature behavior against acceptance criteria and routes
+  to GUI, TUI, API, service, or manual evaluation.
+- `sdlc-align-specs`: checks SDLC requirements, design, plans, tests,
+  implementation, and evidence for consistency before commit or PR readiness.
+- `sdlc-classify-failure`: classifies failed phases before retrying and routes to
+  the earliest responsible SDLC phase.
+- `sdlc-gui-test`: controls and evaluates browser UI flows with screenshots or
+  accessibility snapshots when available.
+- `sdlc-tui-test`: controls and evaluates terminal, CLI wizard, or TUI flows with
+  transcripts and exit-code evidence.
+- `sdlc-commit`: creates local feature-scoped Git commits after validation, tests,
+  and evaluation pass; it never pushes and does not replace `commit-push`.
+- `sdlc-uat-tests`: runs product-level user acceptance testing before PR creation.
+- `create-pr`: existing PR skill reused as the SDLC handoff after UAT passes;
+  it opens or reuses the PR and summarizes SDLC evidence.
+- `review-pr`: existing PR review skill reused for SDLC merge-readiness review
+  against specs, checks, reviews, and local evidence.
+- `sdlc-merge-pr`: merges a specific PR only after an explicit user request and
+  final readiness checks.
 
 ### `apply-security`
 
@@ -195,11 +261,13 @@ explicitly authorizes delegation or enables a local hook delegation policy and
 the runtime permits it, closing completed subagent threads after their results
 are consolidated when close controls are available, and reviewing risk before
 final answers. Its public skill files stay generic; local hooks, custom agent
-config, and task-state files belong under `$CODEX_HOME`. The hook setup creates
-task state lazily for complex prompts instead of scaffolding every session; the
-file is meant to be read at task start, resume, or after compaction when prior
-context may matter, then updated with concise decisions, validation status, and
-next action.
+config, and task-state files belong under `$CODEX_HOME`. The hook setup
+advertises session-scoped task-state paths without creating missing state
+files; an existing file is meant to be read at task start, resume, or after
+compaction when prior context may matter, then updated with concise decisions,
+validation status, and next action. This non-SDLC setup owns `SessionStart`
+and `UserPromptSubmit` only; Agentic SDLC guardrails are separate `PreToolUse`
+and `Stop` hooks.
 
 ### `gitignore`
 

--- a/skills/README.md
+++ b/skills/README.md
@@ -9,12 +9,21 @@ has a local `README.md` that explains what the skill does, its architecture,
 core concepts, workflow, and important files. `SKILL.md` remains the runtime
 instruction file Codex loads when the skill is used.
 
+Every reusable skill includes a `## Learning Loop` section in `SKILL.md`. When
+durable, public-safe, evidence-backed knowledge is discovered while using a
+skill, the agent should capture it in the narrowest appropriate source material
+for that skill when the task contract allows source edits. For read-only or
+report-only work, the agent should report why source capture was skipped.
+`align-skill` can add or repair this rule during skill alignment.
+
 For skill-specific release notes, see [CHANGELOG.md](CHANGELOG.md).
 
 ## Included Skills
 
 - End-to-end project alignment: `align`
-- Skill folder alignment and validation: `align-skill`
+- Skill folder hardening, alignment, and validation: `align-skill`
+- Security review and safe remediation across infra, CI/CD, shell, and app
+  code: `apply-security`
 - Disposable Ubuntu project container setup: `attach-ubuntu`
 - Commit and push the current feature branch: `commit-push`
 - Branch-safe GitHub pull request creation with safe check repair: `create-pr`
@@ -59,6 +68,10 @@ $review-pr Review PR #110 against the base branch, fix safe issues on the branch
 $review-pr Review https://github.com/example-org/example-repo/pull/42, resolve straightforward conflicts against main if the branch is writable, and report remaining blockers.
 
 $align-skill Review and standardize skills/foo against the canonical skill structure and official vendor docs.
+
+$align-skill Harden this scaffolded skill folder into a safe, secure, fast Codex skill, then validate it.
+
+$apply-security Scan this repository for infrastructure, CI/CD, shell, and application security issues, then produce a prioritized remediation plan with safe patch candidates.
 
 $code-info Gather read-only project info from this folder or a GitHub repo with LOC by language and component, repo size, test files, CLI commands, modules, artifacts, and coverage.
 ```
@@ -105,11 +118,21 @@ together as a cautious senior code-review style alignment pass.
 
 ### `align-skill`
 
-`align-skill` reviews and improves one or more Codex or Agent Skill folders.
-Use it for named skills, local skill folders, multi-skill parent folders,
-GitHub skill repositories, or GitHub tree URLs when `SKILL.md`, trigger
-metadata, references, assets, scripts, safety guardrails, official vendor-doc
-verification, canonical structure, and validation evidence need to be aligned.
+`align-skill` reviews and hardens one or more existing or newly scaffolded Codex
+or Agent Skill folders. Use it for named skills, local skill folders,
+multi-skill parent folders, GitHub skill repositories, or GitHub tree URLs when
+`SKILL.md`, trigger metadata, references, assets, scripts, safety guardrails,
+official vendor-doc verification, canonical structure, validation evidence, fast
+authoring practices, and reusable learning capture in local skill source
+materials need to be aligned.
+
+### `apply-security`
+
+`apply-security` reviews infrastructure, deployment, Helm, Kubernetes,
+Terraform, CI/CD, Bash, Python, Java, JavaScript, TypeScript, and Rust code for
+security issues, ranks findings by severity, confidence, exploitability, and
+blast radius, plans safe remediations, and applies minimal patches only when
+they preserve intended behavior or have explicit approval.
 
 ### `attach-ubuntu`
 

--- a/skills/README.md
+++ b/skills/README.md
@@ -149,10 +149,15 @@ Optional global PreToolUse and Stop hooks can enforce SDLC invariants from that
 local state. Sensitive Git actions use short-lived local authorization files
 under the active run's `permissions/` directory; the skills create those files
 only immediately before the guarded action.
+The canonical source for those optional SDLC hooks is
+`sdlc-start/assets/hooks/`. Patch that source first, validate it with
+`sdlc-start/assets/hooks/tests/test_sdlc_hooks.py`, and sync reviewed hook
+bundles deliberately with `./install-skills.sh --install-all-hooks`; installed
+copies under `$CODEX_HOME/hooks` are runtime artifacts.
 Keep these SDLC hooks separate from the non-SDLC global-context hooks:
 `SessionStart` is for stable global context and task-state location, and
 `UserPromptSubmit` is only for lightweight prompt-time context, safety, or
-opt-in delegation hints.
+opt-in delegation requests.
 
 - `sdlc-create-requirements`: creates or updates `docs/requirements.md` from user
   prompts, tickets, or approved change requests while preserving stable
@@ -368,18 +373,29 @@ be removed with `--remove-skill` when they are not same-source managed.
 - `bash`
 - `rsync`
 - `git` for GitHub sources
+- standard POSIX-style utilities for hook installation: `install`, `find`,
+  `cmp`, `chmod`, `awk`, `cut`, `sort`, and `mktemp`
 
 ### Usage
 
 ```bash
 ./install-skills.sh [source] [destination_dir]
 ./install-skills.sh --remove-skill <skill_name> [destination_dir]
+./install-skills.sh --install-hooks <source_hook_dir>
+./install-skills.sh --install-all-hooks
 ./install-skills.sh --help
 ```
 
 With no arguments, `./install-skills.sh` uses the directory containing the
 script as the source and installs every sibling skill folder that contains
 `SKILL.md` into the default Codex target, `~/.agents/skills`.
+The `--install-hooks` option is deliberately separate from normal skill
+installation. It copies hook files from an explicit source hook directory into
+`${CODEX_HOME:-$HOME/.codex}/hooks`, stripping `.template` suffixes for
+installed files, without modifying `hooks.json` or trusting hooks.
+The `--install-all-hooks` option is also explicit, but discovers every reviewed
+hook-only `*/assets/hooks` directory under this source skills folder and syncs
+those payload files in one pass. It does not scan mixed `assets/` directories.
 
 ### Supported Sources
 
@@ -423,6 +439,18 @@ script as the source and installs every sibling skill folder that contains
 
 # Remove from a custom destination
 ./install-skills.sh --remove-skill vendor-nebius "~/custom-skills"
+
+# Copy optional Agentic SDLC hooks into the default local Codex home
+./install-skills.sh --install-hooks sdlc-start/assets/hooks
+
+# Copy global context-management hook templates into the default local Codex home
+./install-skills.sh --install-hooks config-codex/assets/hooks
+
+# Copy every reviewed hook-only bundle into the default local Codex home
+./install-skills.sh --install-all-hooks
+
+# Copy hooks into a non-default Codex home
+CODEX_HOME=~/custom-codex ./install-skills.sh --install-all-hooks
 ```
 
 ### Notes
@@ -456,3 +484,11 @@ script as the source and installs every sibling skill folder that contains
   back.
 - Stale skill cleanup only applies to skills previously installed from the same
   source.
+- `--install-hooks <source_hook_dir>` is opt-in because hooks are local runtime
+  guardrails, not skills. Use a hook-only source directory such as
+  `sdlc-start/assets/hooks` or `config-codex/assets/hooks`. After syncing them,
+  restart Codex and review/trust the hook entries in `/hooks`.
+- `--install-all-hooks` discovers only skill-owned hook-only directories named
+  `*/assets/hooks` under this source folder, checks for conflicting installed
+  file names, and syncs all reviewed hook bundles into
+  `${CODEX_HOME:-$HOME/.codex}/hooks`.

--- a/skills/README.md
+++ b/skills/README.md
@@ -263,16 +263,18 @@ monorepo-friendly workflow structure.
 recoverable by using durable task-state files, limiting noisy parent-thread
 exploration, delegating bounded read-only investigation when the user
 explicitly authorizes delegation or enables a local hook delegation policy and
-the runtime permits it, closing completed subagent threads after their results
-are consolidated when close controls are available, and reviewing risk before
-final answers. Its public skill files stay generic; local hooks, custom agent
-config, and task-state files belong under `$CODEX_HOME`. The hook setup
-advertises session-scoped task-state paths without creating missing state
-files; an existing file is meant to be read at task start, resume, or after
-compaction when prior context may matter, then updated with concise decisions,
-validation status, and next action. This non-SDLC setup owns `SessionStart`
-and `UserPromptSubmit` only; Agentic SDLC guardrails are separate `PreToolUse`
-and `Stop` hooks.
+the runtime permits it, choosing targeted helper roles after authorization
+instead of requiring the prompt to name them, closing completed subagent
+threads after their results are consolidated when close controls are available,
+and reviewing risk before final answers. Its public skill files stay generic;
+local hooks, custom agent config, and task-state files belong under
+`$CODEX_HOME`. The hook setup advertises session-scoped task-state paths
+without creating missing state files; an existing file is meant to be read at
+task start, resume, or after compaction when prior context may matter, then
+updated with concise decisions, validation status, and next action. This
+non-SDLC setup owns `SessionStart` and `UserPromptSubmit` only; Agentic SDLC
+skills and guardrails own SDLC phase selection, run state, `PreToolUse`, and
+`Stop`.
 
 ### `gitignore`
 

--- a/skills/align-skill/README.md
+++ b/skills/align-skill/README.md
@@ -67,6 +67,24 @@ align-skill checks structure, safety, docs, and validation
   final-answer-only summaries.
 - Do not claim runtime activation unless the target Codex surface proves it.
 
+## Stateful Workflow Skills
+
+A stateful workflow skill is a skill that must resume, coordinate, or validate
+work from durable state or artifacts instead of only reacting to the current
+prompt. It usually reads a known state file, locked plan, checkpoint, or
+evidence bundle; writes updated state, evidence, or external progress; and
+defines how reruns avoid duplicate work.
+
+Use the stateful-workflow profile when a skill coordinates phases, selects the
+next skill, owns local run state, writes evidence, handles retries, or routes
+failures. Do not use it for simple instruction-only skills that can run from the
+prompt and current files alone.
+
+Concise example: `sdlc-start` is stateful because it reads the active SDLC run
+state, selects the next `sdlc-*` phase, writes checkpoints, and resumes safely
+after retries or compaction. A simple `.gitignore` cleanup skill is not
+stateful if it only inspects files, edits `.gitignore`, and reports the result.
+
 ## Files
 
 - `SKILL.md`: runtime alignment workflow for skills.

--- a/skills/align-skill/README.md
+++ b/skills/align-skill/README.md
@@ -16,6 +16,9 @@ validation, or validation evidence aligned.
 - Verifies vendor-specific claims against official documentation when needed.
 - Adds guardrails for destructive actions, secrets, live systems, and external
   services.
+- Applies an optional stateful-workflow profile for coordinator or
+  state-machine skills that manage local state, locked plans, evidence,
+  retries, or failure routing.
 - Captures durable reusable learnings back into the skill's local source
   materials before completion.
 - Runs static skill validation before reporting readiness.
@@ -44,10 +47,13 @@ align-skill checks structure, safety, docs, and validation
 4. Add or repair the target skill's `## Learning Loop` section.
 5. Apply focused updates to metadata, instructions, references, assets, or
    scripts.
-6. Update local skill source materials with evidence-backed reusable learnings
+6. For stateful workflow skills, use
+   `assets/stateful-workflow-skill-template.md` and validate with
+   `scripts/validate-skill-structure.py --profile stateful-workflow`.
+7. Update local skill source materials with evidence-backed reusable learnings
    discovered during execution.
-7. Run `scripts/validate-skill-structure.py` when available.
-8. Report validation, learning-loop coverage, source-material updates, skipped
+8. Run `scripts/validate-skill-structure.py` when available.
+9. Report validation, learning-loop coverage, source-material updates, skipped
    live checks, and remaining uncertainty.
 
 ## Core Concepts
@@ -67,7 +73,7 @@ align-skill checks structure, safety, docs, and validation
 - `agents/openai.yaml`: UI metadata.
 - `references/`: canonical structure, authoring, safety, vendor, and trigger
   guidance.
-- `assets/`: report and plan templates.
+- `assets/`: report, plan, and stateful-workflow skill templates.
 - `scripts/validate-skill-structure.py`: static skill folder validator.
 - `scripts/test-validate-skill-structure.py`: local fixture self-test for the
   validator.

--- a/skills/align-skill/README.md
+++ b/skills/align-skill/README.md
@@ -1,17 +1,23 @@
 # Align Skill
 
-`align-skill` reviews and improves Codex or Agent Skill folders. Use it when a
-skill needs structure, metadata, references, assets, scripts, trigger behavior,
-vendor-doc grounding, safety guardrails, or validation evidence aligned.
+`align-skill` reviews and hardens existing or newly scaffolded Codex or Agent
+Skill folders. Use it when a skill needs structure, metadata, references,
+assets, scripts, trigger behavior, vendor-doc grounding, safety guardrails, fast
+validation, or validation evidence aligned.
 
 ## What It Does
 
 - Checks `SKILL.md` front matter, scope, trigger quality, and workflow clarity.
-- Validates optional `agents/`, `assets/`, `references/`, and `scripts/`
-  surfaces.
+- Helps refine draft or scaffolded skills with safe, secure, fast authoring
+  practices.
+- Validates optional `agents/`, `assets/`, `evals/`, `references/`, and
+  `scripts/` surfaces.
+- Adds or repairs the standard `## Learning Loop` rule on target skills.
 - Verifies vendor-specific claims against official documentation when needed.
 - Adds guardrails for destructive actions, secrets, live systems, and external
   services.
+- Captures durable reusable learnings back into the skill's local source
+  materials before completion.
 - Runs static skill validation before reporting readiness.
 
 ## Architecture
@@ -23,6 +29,7 @@ Skill folder
   +--> agents/openai.yaml metadata
   +--> references/ detailed docs
   +--> assets/ reusable templates
+  +--> evals/ trigger and quality examples
   `--> scripts/ deterministic helpers
         |
         v
@@ -34,22 +41,33 @@ align-skill checks structure, safety, docs, and validation
 1. Detect the target skill scope.
 2. Inspect current skill files and nearby repository conventions.
 3. Verify relevant product or API claims against official docs.
-4. Apply focused updates to metadata, instructions, references, assets, or
+4. Add or repair the target skill's `## Learning Loop` section.
+5. Apply focused updates to metadata, instructions, references, assets, or
    scripts.
-5. Run `scripts/validate-skill-structure.py` when available.
-6. Report validation, skipped live checks, and remaining uncertainty.
+6. Update local skill source materials with evidence-backed reusable learnings
+   discovered during execution.
+7. Run `scripts/validate-skill-structure.py` when available.
+8. Report validation, learning-loop coverage, source-material updates, skipped
+   live checks, and remaining uncertainty.
 
 ## Core Concepts
 
 - Keep `SKILL.md` concise for progressive disclosure.
 - Move detailed references and templates into supporting folders.
+- Use `skill-creator` for new-skill scaffolding when available, then use
+  `align-skill` for authoring hardening and validation.
 - Do not broaden a skill until its trigger becomes hard to reason about.
+- Capture durable knowledge in reusable skill sources, not in ad hoc notes or
+  final-answer-only summaries.
 - Do not claim runtime activation unless the target Codex surface proves it.
 
 ## Files
 
 - `SKILL.md`: runtime alignment workflow for skills.
 - `agents/openai.yaml`: UI metadata.
-- `references/`: canonical structure, safety, vendor, and trigger guidance.
+- `references/`: canonical structure, authoring, safety, vendor, and trigger
+  guidance.
 - `assets/`: report and plan templates.
 - `scripts/validate-skill-structure.py`: static skill folder validator.
+- `scripts/test-validate-skill-structure.py`: local fixture self-test for the
+  validator.

--- a/skills/align-skill/SKILL.md
+++ b/skills/align-skill/SKILL.md
@@ -1,16 +1,18 @@
 ---
 name: align-skill
-description: "Use for Codex or Agent Skill folder alignment: SKILL.md front matter/YAML metadata, name/description trigger quality, implicit skill detection, duplicate or stale descriptions, canonical structure, official vendor-doc checks, safety guardrails, and validation."
+description: "Use for reviewing, hardening, validating, aligning, and improving existing or newly scaffolded Codex or Agent Skill folders. Use as a skill-writing helper after skill-creator or a manual scaffold/draft exists: refine SKILL.md front matter, description trigger quality, progressive disclosure, canonical structure, safety/security guardrails, fast validation, scripts/references/assets/evals, official vendor-doc checks, and reusable learning capture. Do not replace skill-creator for initial new-skill scaffolding."
 ---
 
 # Align Skill
 
 ## Purpose
 
-Use this skill to inspect, align, harden, validate, and improve one or more
-Codex or Agent Skill folders. The target is skill quality: `SKILL.md`,
-supporting `references/`, `assets/`, `scripts/`, optional `agents/` metadata,
-triggering behavior, safety rules, and validation evidence.
+Use this skill to inspect, review, align, harden, validate, and improve one or
+more Codex or Agent Skill folders. It can help refine skill-writing drafts after
+a target skill folder, scaffold, or `SKILL.md` draft exists. The target is skill
+quality: `SKILL.md`, supporting `references/`, `assets/`, `scripts/`, optional
+`agents/` metadata, optional `evals/` trigger examples, triggering behavior,
+safety/security rules, fast validation, and validation evidence.
 
 This skill is separate from `align`, which is for end-to-end project/codebase
 alignment.
@@ -19,9 +21,13 @@ alignment.
 
 - Aligning a named skill, local skill folder, multi-skill parent folder, GitHub
   repository URL, or GitHub tree URL.
+- Helping refine, harden, or complete a skill draft or newly scaffolded skill
+  folder after the target scope exists.
 - Reviewing or fixing `SKILL.md` front matter, description trigger quality,
   scope, workflow clarity, output contract, and progressive disclosure.
 - Standardizing skill folders against a canonical skill structure.
+- Adding or repairing the standard `## Learning Loop` rule on target skills.
+- Reviewing trigger/evaluation prompts stored under `evals/`.
 - Checking skill guidance, commands, scripts, examples, and vendor-specific
   claims against current official documentation.
 - Adding or hardening safety guardrails before validation or live tests.
@@ -38,6 +44,9 @@ alignment.
 ## Non-Goals
 
 - Do not use this for general codebase alignment; use `align` for that.
+- Do not replace `skill-creator` for initial scaffolding when the user is
+  creating a brand-new skill and the creator is available. Use this skill as the
+  authoring, hardening, and validation helper around that flow.
 - Do not broaden a skill until it becomes hard to trigger correctly.
 - Do not rewrite skills from vague "best practices" without evidence.
 - Do not run live external changes unless a non-production test environment is
@@ -63,10 +72,13 @@ Practical prompts:
 
 ```text
 Use align-skill to review and align `skills/foo`.
+Use align-skill as a helper after skill-creator scaffolded a release-triage skill.
 Align these skills against the canonical structure and official vendor docs.
 Review all skills under this folder and produce an alignment report.
 Validate this GitHub skills repo and propose safe changes.
 Fix the `SKILL.md` for this skill so it follows Codex Skill best practices.
+Help me harden this draft `SKILL.md` into a safe, secure, fast Codex skill.
+Add the standard learning-loop rule to every skill under `skills/`.
 Check whether this skill has safe guardrails before live validation.
 Standardize this multi-skill folder and add missing references, assets, or scripts.
 Review this skill's vendor-specific commands against official documentation.
@@ -87,16 +99,53 @@ For expanded CLI, VS Code-compatible IDE, and Codex app guidance, read
 
 - Evidence-based changes only: use repo evidence, official vendor
   documentation, or explicit user requirements.
+- Continuous source learning: before completion, update the locally cloned
+  source materials associated with the target skill with durable, reusable
+  knowledge discovered during the run. Capture patterns, decisions, best
+  practices, and relevant findings only when they are evidence-backed,
+  public-safe, and in scope.
 - Keep skills scoped to their actual job and keep `SKILL.md` short enough for
   progressive disclosure.
 - Move large checklists, templates, policies, and long examples into
   `references/` or `assets/`.
 - Scripts should be self-contained where possible, have helpful errors, avoid
   network calls unless explicitly needed, and fail safely.
+- Do not persist secrets, private URLs, customer data, raw logs, or one-off
+  environment details into reusable skill sources.
 
 Read `references/canonical-skill-structure.md` and
 `references/alignment-rubric.md` when structure or quality criteria are in
 scope.
+
+For skill draft, scaffold, or update tasks, also read
+`references/skill-authoring-best-practices.md` after the target scope is known.
+
+## Skill Authoring Helper Workflow
+
+When the user asks to refine, harden, complete, or update a skill draft or
+newly scaffolded skill folder:
+
+1. Confirm whether the task is a brand-new skill, an update to an existing
+   skill, or a review of generated skill content.
+2. If creating a brand-new skill and `skill-creator` is available, use it for
+   the initial scaffold or naming workflow, then return here for alignment,
+   safety, trigger quality, and validation.
+3. Start from concrete use cases and should-trigger/should-not-trigger prompts.
+4. Keep the skill focused on one repeatable job and front-load the `description`
+   with user intent, accepted inputs, and boundaries from adjacent skills.
+5. Apply safe, secure, and fast skill guidance from
+   `references/skill-authoring-best-practices.md`.
+6. Validate locally with the narrowest relevant checks, then broaden only when
+   the contract or shared validator changed.
+
+## Learning Loop Enforcement
+
+When aligning target skills, inspect each target `SKILL.md` for a
+`## Learning Loop` section. Add the standard section when it is missing,
+keep existing wording only when it contains the validator-required public-safe
+snippets, and repair stale or unsafe variants that allow raw logs, secrets,
+environment-specific details, or unverified vendor claims. Report which target
+skills were updated, already compliant, skipped, or left uncertain.
 
 ## Evidence and Vendor Verification
 
@@ -108,6 +157,23 @@ tutorials, generated examples, Stack Overflow, or memory.
 If official documentation does not verify a vendor-specific behavior, mark it
 as unverified instead of presenting it as fact. Read
 `references/vendor-research-policy.md` for the full policy.
+
+## Learning Loop
+
+When using this skill, capture durable, reusable, public-safe learnings back
+into this skill's local source materials before completion when the current task
+contract allows source edits. Update the narrowest appropriate surface:
+`SKILL.md` for runtime rules, `references/` for detailed guidance, `assets/`
+for reusable templates, `scripts/` for deterministic helpers, and README or
+changelog entries for human-facing or release-note updates.
+
+If the current task is explicitly read-only/report-only, or source writes are
+outside this skill's task contract, do not edit skill sources; report the
+skipped source update instead.
+
+Do not capture secrets, private URLs, customer data, raw logs, one-off local
+state, or unverified/vendor-specific claims. If a useful learning is not safe,
+not evidence-backed, or outside this skill's scope, report that it was skipped.
 
 ## Safety Guardrails
 
@@ -130,12 +196,15 @@ skill-name/
 |-- SKILL.md
 |-- agents/openai.yaml
 |-- assets/
+|-- evals/
 |-- references/
 `-- scripts/
 ```
 
 Only add optional folders when they serve the skill. Follow existing repository
-conventions when they are clearer or stricter than the generic structure.
+conventions when they are clearer or stricter than the generic structure. In
+this repository, `evals/` is an optional surface for reusable trigger or quality
+evaluation prompts.
 
 ## Alignment Workflow
 
@@ -143,13 +212,21 @@ conventions when they are clearer or stricter than the generic structure.
    GitHub source.
 2. Inspect nearby repository conventions before editing.
 3. Read the target `SKILL.md` files and supporting folders.
-4. Identify products, CLIs, APIs, clouds, frameworks, package managers, and
+4. Add or repair the standard `## Learning Loop` section in target `SKILL.md`
+   files when missing or unsafe.
+5. Identify products, CLIs, APIs, clouds, frameworks, package managers, and
    external services the skill references.
-5. Verify vendor-specific behavior against current official documentation.
-6. Apply focused, evidence-backed improvements across `SKILL.md`, references,
+6. Verify vendor-specific behavior against current official documentation.
+7. Apply focused, evidence-backed improvements across `SKILL.md`, references,
    assets, scripts, metadata, README entries, and changelog entries when those
    surfaces exist and are in scope.
-7. Validate and report what was verified, skipped, or remains uncertain.
+8. Capture newly learned durable knowledge back into the target skill's local
+   source materials. Prefer the narrowest appropriate surface: `SKILL.md` for
+   runtime rules, `references/` for detailed guidance, `assets/` for reusable
+   templates, `scripts/` for deterministic checks, and README or changelog
+   entries for human-facing or release-note updates.
+9. Re-run relevant static validation after source-material updates, then report
+   what was changed, captured, skipped, or remains uncertain.
 
 ## Live Validation Workflow
 
@@ -168,6 +245,10 @@ current user and repository policy. If script execution is not permitted,
 mirror the same static checks manually and report that the validator was
 skipped.
 
+When changing the validator itself, also run
+`python3 scripts/test-validate-skill-structure.py`; it uses temporary local
+fixtures and performs no network or installed-runtime changes.
+
 ## Output Contract
 
 Return:
@@ -178,6 +259,8 @@ Return:
 - Validation run.
 - Live tests run or skipped.
 - Safety decisions.
+- Learning-loop coverage for target skills.
+- Source materials updated with reusable learnings, or why updates were skipped.
 - Remaining uncertainty.
 - Follow-up recommendations.
 
@@ -193,6 +276,11 @@ CI/CD writes unless the user explicitly requests them and safety checks pass.
 
 Stop if vendor documentation cannot verify a proposed vendor-specific behavior;
 report it as unverified instead.
+
+Stop before writing learned material into reusable skill sources when the
+learning is confidential, environment-specific, not evidence-backed, outside
+the target skill's scope, or the user requested report-only work. In that case,
+report the skipped source update and the reason.
 
 ## Remaining Uncertainty
 

--- a/skills/align-skill/SKILL.md
+++ b/skills/align-skill/SKILL.md
@@ -31,6 +31,9 @@ alignment.
 - Checking skill guidance, commands, scripts, examples, and vendor-specific
   claims against current official documentation.
 - Adding or hardening safety guardrails before validation or live tests.
+- Applying the optional stateful-workflow skill profile for skills that manage
+  local state, locked plans, evidence, continuation, retries, or failure
+  routing.
 
 ## Inputs Accepted
 
@@ -119,6 +122,9 @@ scope.
 
 For skill draft, scaffold, or update tasks, also read
 `references/skill-authoring-best-practices.md` after the target scope is known.
+For coordinator or state-machine skills, also use
+`assets/stateful-workflow-skill-template.md` as the optional section template
+and validate with the `stateful-workflow` profile when appropriate.
 
 ## Skill Authoring Helper Workflow
 
@@ -135,7 +141,11 @@ newly scaffolded skill folder:
    with user intent, accepted inputs, and boundaries from adjacent skills.
 5. Apply safe, secure, and fast skill guidance from
    `references/skill-authoring-best-practices.md`.
-6. Validate locally with the narrowest relevant checks, then broaden only when
+6. For stateful workflow skills, add explicit `Required Reads`, `Writes`,
+   `Idempotency`, `Failure Handling`, `Must Not`, and `Completion Criteria`
+   sections. Keep private execution state out of committed project files and
+   keep hooks as invariant guardrails rather than workflow orchestrators.
+7. Validate locally with the narrowest relevant checks, then broaden only when
    the contract or shared validator changed.
 
 ## Learning Loop Enforcement
@@ -206,6 +216,10 @@ conventions when they are clearer or stricter than the generic structure. In
 this repository, `evals/` is an optional surface for reusable trigger or quality
 evaluation prompts.
 
+For stateful workflow skills, use the template in
+`assets/stateful-workflow-skill-template.md`. This profile is opt-in and should
+not be forced onto simple instruction-only skills.
+
 ## Alignment Workflow
 
 1. Detect target scope: single skill, multiple named skills, parent folder, or
@@ -241,9 +255,10 @@ Use the safe validation hierarchy:
 
 Use `python3 scripts/validate-skill-structure.py <target>` when this skill's
 validator is available, relevant, and script execution is permitted by the
-current user and repository policy. If script execution is not permitted,
-mirror the same static checks manually and report that the validator was
-skipped.
+current user and repository policy. For stateful workflow skills, add
+`--profile stateful-workflow` to check the optional state-machine section
+contract. If script execution is not permitted, mirror the same static checks
+manually and report that the validator was skipped.
 
 When changing the validator itself, also run
 `python3 scripts/test-validate-skill-structure.py`; it uses temporary local

--- a/skills/align-skill/agents/openai.yaml
+++ b/skills/align-skill/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Align Skill"
-  short_description: "Review and standardize Codex skill folders"
-  default_prompt: "Use $align-skill to review Codex or Agent skill folders, verify vendor guidance against official docs, apply safe structure fixes, run local validation, and report uncertainty."
+  short_description: "Review and harden Codex skill folders"
+  default_prompt: "Use $align-skill to review, harden, validate, or align an existing or newly scaffolded Codex or Agent skill folder, refine draft SKILL.md content, apply safe, secure, and fast authoring practices, verify vendor guidance against official docs, run local validation, and report uncertainty."

--- a/skills/align-skill/assets/alignment-plan-template.md
+++ b/skills/align-skill/assets/alignment-plan-template.md
@@ -16,6 +16,12 @@
 - Optional folders present:
 - Repository conventions:
 
+## Learning Loop Coverage
+
+- Skills missing `## Learning Loop`:
+- Skills with equivalent wording:
+- Skills needing repair:
+
 ## Risks
 
 - Destructive operations:
@@ -31,6 +37,19 @@
 ## Proposed Changes
 
 - TBD
+
+## Skill Authoring Guidance
+
+- Scaffolded skill, draft skill, or update task:
+- Best-practice reference loaded:
+- Trigger prompt examples to add or revise:
+- Safe/secure/fast hardening concerns:
+
+## Source Materials To Update
+
+- Durable learnings to capture:
+- Local skill sources likely to change:
+- Source updates to skip:
 
 ## Validation Plan
 

--- a/skills/align-skill/assets/alignment-report-template.md
+++ b/skills/align-skill/assets/alignment-report-template.md
@@ -10,6 +10,25 @@
 
 - TBD
 
+## Learning Loop Coverage
+
+- Skills updated:
+- Skills already compliant:
+- Skills skipped or uncertain:
+
+## Source Materials Updated
+
+- Durable learnings captured:
+- Local skill sources updated:
+- Source updates skipped and why:
+
+## Skill Authoring Review
+
+- Scaffolded skill, draft skill, or update task:
+- Best-practice reference used:
+- Trigger quality changes:
+- Safe/secure/fast hardening guidance applied:
+
 ## Evidence Used
 
 - Repo evidence:

--- a/skills/align-skill/assets/stateful-workflow-skill-template.md
+++ b/skills/align-skill/assets/stateful-workflow-skill-template.md
@@ -1,0 +1,76 @@
+---
+name: {skill-name}
+description: "{Front-load the workflow trigger, accepted inputs, state boundary, and adjacent-skill boundary.}"
+---
+
+# {Skill Name}
+
+## Purpose
+
+{One concise statement of the stateful workflow step this skill owns.}
+
+## When To Use
+
+- {Concrete user or coordinator prompt that should trigger this skill.}
+
+## When Not To Use
+
+- {Adjacent workflow, simpler skill, or unsafe condition that should not trigger this skill.}
+
+## Inputs
+
+- {Prompt, spec, state file, artifact, or external context accepted by this skill.}
+
+## Required Reads
+
+- {Files, local state, docs, references, or MCP resources that must be read first.}
+
+## Writes
+
+- {Committed files, local private state, evidence, or external artifacts this skill may write.}
+
+## Process
+
+- {Ordered workflow step.}
+
+## Idempotency
+
+- {How reruns avoid duplicate state, repeated side effects, or stale evidence.}
+
+## Failure Handling
+
+- {How failures are classified, retried, routed, or stopped for human input.}
+
+## Must Not
+
+- {Destructive, unsafe, out-of-scope, or adjacent-skill behavior to avoid.}
+
+## Completion Criteria
+
+- {Observable final state that means this skill is done.}
+
+## Learning Loop
+
+When using this skill, capture durable, reusable, public-safe learnings back
+into this skill's local source materials before completion when the current task
+contract allows source edits. Update the narrowest appropriate surface:
+`SKILL.md` for runtime rules, `references/` for detailed guidance, `assets/`
+for reusable templates, `scripts/` for deterministic helpers, and README or
+changelog entries for human-facing or release-note updates.
+
+If the current task is explicitly read-only/report-only, or source writes are
+outside this skill's task contract, do not edit skill sources; report the
+skipped source update instead.
+
+Do not capture secrets, private URLs, customer data, raw logs, one-off local
+state, or unverified/vendor-specific claims. If a useful learning is not safe,
+not evidence-backed, or outside this skill's scope, report that it was skipped.
+
+## Output Contract
+
+Return:
+
+- Scope handled.
+- State or artifacts written.
+- Evidence created or checked.
+- Failure classification and next action when blocked.

--- a/skills/align-skill/references/alignment-rubric.md
+++ b/skills/align-skill/references/alignment-rubric.md
@@ -16,6 +16,7 @@ Source basis:
 | Area | Check |
 | --- | --- |
 | Name and folder consistency | `name` is lowercase hyphenated, valid, and matches the parent folder. |
+| SDLC-only naming | Skills used only inside the Agentic SDLC state machine use `sdlc-*` names and start descriptions with `Use only as part of the Agentic SDLC workflow;`. |
 | Description specificity | Description says what the skill does and when to use it. |
 | Trigger quality | Description includes realistic user intent terms and avoids over-broad claims. |
 | Authoring helper fit | For scaffolded skill folders or draft skill content, guidance defers initial scaffolding to `skill-creator` and then hardens trigger, structure, safety, speed, and validation. |
@@ -32,6 +33,9 @@ Source basis:
 | Output contract | Final answer shape is explicit and matches the task. |
 | Testability | Static checks, linting, dry runs, unit tests, or eval prompts are available where useful. |
 | Security posture | No secrets, private endpoints, customer data, or unsafe defaults are introduced. |
+| Stateful workflow profile | State-machine skills define required reads, writes, idempotency, failure handling, must-not rules, and completion criteria. |
+| Private state boundary | Workflow execution state, locked plans, evidence, screenshots, transcripts, and steering files are kept out of committed project files unless explicitly intended. |
+| Hook boundary | Hooks enforce invariants only and do not become the workflow orchestrator. |
 | Learning loop coverage | Each target `SKILL.md` has a `## Learning Loop` section containing the validator-required public-safe source-learning text. |
 | Learning capture | Durable, reusable knowledge discovered during execution is captured in the local skill source materials when evidence-backed and in scope. |
 | Maintainability | Instructions are concise, non-duplicative, and easy to update. |
@@ -57,18 +61,21 @@ Source basis:
 4. For scaffolded skill folders, draft skill content, or update tasks, read
    `references/skill-authoring-best-practices.md` and check the target against
    safe, secure, and fast authoring guidance.
-5. Confirm the target `SKILL.md` has a `## Learning Loop` section, add the
+5. For state-machine or coordinator skills, decide whether the optional
+   stateful-workflow profile applies. If it applies, check the profile sections
+   manually or run `validate-skill-structure.py --profile stateful-workflow`.
+6. Confirm the target `SKILL.md` has a `## Learning Loop` section, add the
    standard section when missing, and repair variants that do not include the
    validator-required snippets.
-6. Search the skill for vendor names, CLI commands, APIs, cloud services,
+7. Search the skill for vendor names, CLI commands, APIs, cloud services,
    package managers, auth flows, publishing steps, Kubernetes, Terraform, Helm,
    GitHub Actions, databases, and CI/CD behavior.
-7. Verify vendor-specific details against official docs.
-8. Apply only evidence-backed changes.
-9. Capture newly learned durable patterns, decisions, best practices, or
+8. Verify vendor-specific details against official docs.
+9. Apply only evidence-backed changes.
+10. Capture newly learned durable patterns, decisions, best practices, or
    relevant findings in the target skill's local sources when they are
    reusable, public-safe, and in scope.
-10. Run safe validation and record remaining uncertainty.
+11. Run safe validation and record remaining uncertainty.
 
 Do not capture raw logs, secrets, customer data, private URLs, transient local
 state, or one-off environment details. If a useful learning is not safe or

--- a/skills/align-skill/references/alignment-rubric.md
+++ b/skills/align-skill/references/alignment-rubric.md
@@ -18,6 +18,7 @@ Source basis:
 | Name and folder consistency | `name` is lowercase hyphenated, valid, and matches the parent folder. |
 | Description specificity | Description says what the skill does and when to use it. |
 | Trigger quality | Description includes realistic user intent terms and avoids over-broad claims. |
+| Authoring helper fit | For scaffolded skill folders or draft skill content, guidance defers initial scaffolding to `skill-creator` and then hardens trigger, structure, safety, speed, and validation. |
 | Scope and non-goals | Skill has a clear job and boundaries from adjacent skills. |
 | Progressive disclosure | `SKILL.md` stays focused; long material moves to `references/` or `assets/`. |
 | Official vendor evidence | Product-specific commands and claims are checked against official docs. |
@@ -25,11 +26,14 @@ Source basis:
 | Environment assumptions | Required tools, access, credentials, and test-environment assumptions are explicit. |
 | Live validation policy | Live tests require confirmed non-production context and report skipped work. |
 | Script quality | Scripts are self-contained where possible, documented with `--help`, and fail safely. |
+| Script speed and ergonomics | Scripts are non-interactive, idempotent where possible, version-pinned when using package runners, and produce bounded structured output. |
 | Reference quality | Reference files are focused, current, and loaded only when needed. |
 | Asset/template quality | Assets are reusable, generic, and free of secrets or environment-specific values. |
 | Output contract | Final answer shape is explicit and matches the task. |
 | Testability | Static checks, linting, dry runs, unit tests, or eval prompts are available where useful. |
 | Security posture | No secrets, private endpoints, customer data, or unsafe defaults are introduced. |
+| Learning loop coverage | Each target `SKILL.md` has a `## Learning Loop` section containing the validator-required public-safe source-learning text. |
+| Learning capture | Durable, reusable knowledge discovered during execution is captured in the local skill source materials when evidence-backed and in scope. |
 | Maintainability | Instructions are concise, non-duplicative, and easy to update. |
 | Repository conventions | Skill follows local folder, README, metadata, lint, and changelog conventions. |
 
@@ -50,9 +54,22 @@ Source basis:
 2. Validate structure before reading for style.
 3. Compare `description` against likely should-trigger and should-not-trigger
    prompts.
-4. Search the skill for vendor names, CLI commands, APIs, cloud services,
+4. For scaffolded skill folders, draft skill content, or update tasks, read
+   `references/skill-authoring-best-practices.md` and check the target against
+   safe, secure, and fast authoring guidance.
+5. Confirm the target `SKILL.md` has a `## Learning Loop` section, add the
+   standard section when missing, and repair variants that do not include the
+   validator-required snippets.
+6. Search the skill for vendor names, CLI commands, APIs, cloud services,
    package managers, auth flows, publishing steps, Kubernetes, Terraform, Helm,
    GitHub Actions, databases, and CI/CD behavior.
-5. Verify vendor-specific details against official docs.
-6. Apply only evidence-backed changes.
-7. Run safe validation and record remaining uncertainty.
+7. Verify vendor-specific details against official docs.
+8. Apply only evidence-backed changes.
+9. Capture newly learned durable patterns, decisions, best practices, or
+   relevant findings in the target skill's local sources when they are
+   reusable, public-safe, and in scope.
+10. Run safe validation and record remaining uncertainty.
+
+Do not capture raw logs, secrets, customer data, private URLs, transient local
+state, or one-off environment details. If a useful learning is not safe or
+appropriate to persist, report that the source update was skipped and why.

--- a/skills/align-skill/references/canonical-skill-structure.md
+++ b/skills/align-skill/references/canonical-skill-structure.md
@@ -1,11 +1,13 @@
 # Canonical Skill Structure
 
 Use this structure unless the local repository has a clearer convention.
-This structure is based on the OpenAI Codex Agent Skills documentation and the
-open Agent Skills specification:
+This structure is based on the OpenAI Codex Agent Skills documentation, Codex
+best practices, and the open Agent Skills specification:
 
 - [OpenAI Codex Agent Skills](https://developers.openai.com/codex/skills)
+- [OpenAI Codex best practices](https://developers.openai.com/codex/learn/best-practices)
 - [Agent Skills specification](https://agentskills.io/specification)
+- [Agent Skills best practices](https://agentskills.io/skill-creation/best-practices)
 
 ```text
 skill-name/
@@ -13,6 +15,7 @@ skill-name/
 |-- agents/
 |   `-- openai.yaml
 |-- assets/
+|-- evals/
 |-- references/
 `-- scripts/
 ```
@@ -36,6 +39,9 @@ The `name` should match the parent folder.
   references loaded only when needed.
 - `assets/`: templates, examples, schemas, starter files, and static resources
   used as inputs or output scaffolds.
+- `evals/`: reusable trigger prompts or quality-evaluation examples. Use when
+  activation behavior needs repeatable evidence; keep examples public-safe and
+  free of secrets or customer data.
 - `agents/`: agent-specific metadata only when needed by the local repository
   convention. In this repository, use `agents/openai.yaml` for UI metadata.
 
@@ -63,6 +69,8 @@ description: Use this skill when...
 
 ## Guardrails
 
+## Learning Loop
+
 ## Validation
 
 ## Output Contract
@@ -72,6 +80,8 @@ description: Use this skill when...
 
 For larger skills, keep only core routing and workflow instructions in
 `SKILL.md`; move long checklists and examples into `references/` or `assets/`.
+For scaffolded skill folders, draft skill content, or update work, read
+`references/skill-authoring-best-practices.md` after target scope is known.
 
 ## Naming Rules
 
@@ -86,10 +96,13 @@ For larger skills, keep only core routing and workflow instructions in
 
 - Put always-needed routing, scope, workflow, guardrails, and output contract in
   `SKILL.md`.
+- Put the standard `## Learning Loop` section in every `SKILL.md` so durable
+  public-safe source learning is active whenever that skill loads.
 - Put long rubrics, policy details, vendor research rules, troubleshooting, and
   detailed examples in `references/`.
 - Put templates, starter files, report outlines, schemas, or sample payloads in
   `assets/`.
+- Put reusable trigger prompts and quality-evaluation examples in `evals/`.
 - Put deterministic checks or reusable helpers in `scripts/`.
 
 Avoid duplicating the same rule in multiple files. Link from `SKILL.md` to the
@@ -120,6 +133,8 @@ skill-name/
 |-- SKILL.md
 |-- assets/
 |   `-- report-template.md
+|-- evals/
+|   `-- trigger-prompts.csv
 |-- references/
 |   `-- policy.md
 `-- scripts/

--- a/skills/align-skill/references/canonical-skill-structure.md
+++ b/skills/align-skill/references/canonical-skill-structure.md
@@ -83,6 +83,41 @@ For larger skills, keep only core routing and workflow instructions in
 For scaffolded skill folders, draft skill content, or update work, read
 `references/skill-authoring-best-practices.md` after target scope is known.
 
+## Stateful Workflow Skill Profile
+
+Use this opt-in profile for skills that manage local state, locked plans,
+evidence, continuation prompts, retries, or failure routing. Do not force this
+profile onto simple instruction-only skills.
+
+Template: `assets/stateful-workflow-skill-template.md`
+
+Required sections for the `stateful-workflow` validation profile:
+
+- `## Purpose`
+- `## When To Use`
+- `## When Not To Use`
+- `## Inputs`
+- `## Required Reads`
+- `## Writes`
+- `## Process`
+- `## Idempotency`
+- `## Failure Handling`
+- `## Must Not`
+- `## Completion Criteria`
+- `## Output Contract`
+
+For this profile:
+
+- State whether execution artifacts are committed project truth or private
+  local state.
+- Describe rerun behavior so agents do not duplicate plans, evidence, commits,
+  or external resources.
+- Classify failures before retrying or routing backward.
+- Keep hooks as invariant guardrails; do not make hooks own workflow
+  orchestration.
+- Use MCP servers for external capabilities when available, while preserving
+  explicit safety checks for write operations.
+
 ## Naming Rules
 
 - Use lowercase letters, numbers, and hyphens.
@@ -91,6 +126,15 @@ For scaffolded skill folders, draft skill content, or update work, read
 - Keep the folder name and front matter `name` identical.
 - Prefer specific names that describe the job, not broad names such as
   `helper`, `tools`, or `automation`.
+- For skills that are only valid inside the Agentic SDLC state machine, use an
+  `sdlc-` prefix in the folder and front matter name. The coordinator uses
+  `sdlc-start`, and phase skills use names such as `sdlc-commit` instead of
+  broad generic names like `commit`.
+- SDLC-only skill descriptions must start with
+  `Use only as part of the Agentic SDLC workflow;` so tool discovery makes the
+  workflow boundary explicit.
+- Do not keep unprefixed aliases or compatibility wrapper folders for renamed
+  SDLC-only skills unless the user explicitly requests a compatibility layer.
 
 ## Content Placement
 

--- a/skills/align-skill/references/safety-and-live-validation.md
+++ b/skills/align-skill/references/safety-and-live-validation.md
@@ -54,6 +54,18 @@ acceptable blast radius.
 - If a validation command would expose secrets in output, do not run it. Explain
   the safer alternative.
 
+## Skill Authoring Safety
+
+- Generated or revised skills must remain public-safe and reusable; use
+  placeholders for environment-specific values.
+- Do not add scripts that prompt for secrets, persist credentials, call external
+  write APIs, publish artifacts, or mutate production systems unless the skill
+  also requires explicit user authorization and a confirmed safe target.
+- Require dry-run, plan, local validation, or static inspection paths before
+  live external operations.
+- Keep high-output scripts bounded by default so validation output cannot bury
+  important warnings or leak unexpected data.
+
 ## Safe Validation Hierarchy
 
 1. Static checks.

--- a/skills/align-skill/references/skill-authoring-best-practices.md
+++ b/skills/align-skill/references/skill-authoring-best-practices.md
@@ -1,0 +1,113 @@
+# Skill Authoring Best Practices
+
+Use this reference when `align-skill` is helping refine, harden, validate,
+complete, or update a scaffolded Codex or Agent Skill folder or draft
+`SKILL.md` file.
+
+Source basis:
+
+- [OpenAI Codex Agent Skills](https://developers.openai.com/codex/skills)
+- [OpenAI Codex best practices](https://developers.openai.com/codex/learn/best-practices)
+- [OpenAI Codex customization](https://developers.openai.com/codex/concepts/customization)
+- [Agent Skills specification](https://agentskills.io/specification)
+- [Agent Skills best practices](https://agentskills.io/skill-creation/best-practices)
+- [Optimizing skill descriptions](https://agentskills.io/skill-creation/optimizing-descriptions)
+- [Using scripts in skills](https://agentskills.io/skill-creation/using-scripts)
+
+## Authoring Flow
+
+1. Start from 2-3 concrete use cases, not generic best practices.
+2. Identify the repeatable workflow, inputs, expected outputs, gotchas, and
+   validation gates that another agent would otherwise miss.
+3. For a brand-new skill, prefer `skill-creator` for initial scaffold and
+   naming when it is available; use `align-skill` after the scaffold or draft
+   exists to harden the result.
+4. For an existing skill, inspect current behavior, trigger metadata, support
+   files, scripts, references, and local conventions before editing.
+5. Capture durable, public-safe learnings back into local skill sources only
+   when they are evidence-backed and in scope.
+
+## Trigger Design
+
+- The front matter `name` must match the folder and stay lowercase hyphen-case.
+- The `description` is the primary trigger surface. It must say what the skill
+  does and when to use it.
+- Front-load user intent terms because long descriptions may be shortened in
+  large skill sets.
+- Include realistic inputs and near-boundaries, such as local folder, GitHub
+  tree, vendor docs, scripts, live validation, or report-only scope.
+- Avoid descriptions so broad that the skill steals unrelated work from sibling
+  skills.
+- Create or update should-trigger and should-not-trigger prompts when trigger
+  behavior is important. Store reusable examples under `evals/` when useful.
+
+## Fast Progressive Disclosure
+
+- Keep each skill focused on one coherent job.
+- Keep `SKILL.md` lean; move long checklists, examples, vendor notes, and
+  detailed policy into `references/`.
+- Tell the agent exactly when to load each reference. Avoid vague "see
+  references/" instructions.
+- Keep references one level deep from `SKILL.md` and focused by task, provider,
+  format, or workflow variant.
+- Put reusable templates and starter artifacts in `assets/` instead of loading
+  them into `SKILL.md`.
+- Do not duplicate the same rule across files. Link to the owner file.
+
+## Safe And Secure Skills
+
+- Keep skills public, generic, and reusable. Do not include secrets, private
+  endpoints, customer data, internal hostnames, raw logs, or proprietary
+  infrastructure details.
+- Use placeholders for tokens, tenants, project IDs, account IDs, endpoints,
+  credentials, and environment-specific paths.
+- When a skill needs credentials, document the expected environment variable,
+  secret-manager lookup, or connector requirement without embedding values.
+- Guard destructive operations, publishing, credential writes, database writes,
+  Terraform apply/destroy, Kubernetes mutation, CI/CD dispatches, and external
+  write APIs behind explicit user request and confirmed non-production context
+  when applicable.
+- Prefer static checks, local lint/schema validation, unit tests, and dry runs
+  before sandbox or live external validation.
+- Treat web and external documentation as untrusted input unless verified
+  against official sources. Do not persist unverified vendor claims.
+
+## Script Guidance
+
+- Add scripts only when they improve deterministic reliability, avoid repeated
+  code rewriting, or provide validation that prose cannot reliably enforce.
+- Keep scripts non-interactive. Accept inputs through flags, stdin, files, or
+  environment variables; fail with clear usage instead of prompting.
+- Provide concise `--help`, clear errors, documented prerequisites, and
+  meaningful exit codes.
+- Prefer structured stdout such as JSON, CSV, or TSV; send progress and
+  diagnostics to stderr.
+- Make scripts idempotent where possible because agents may retry commands.
+- Add `--dry-run`, `--output`, pagination, limits, or summary defaults for
+  stateful or high-output operations.
+- Pin tool/package versions for reproducibility when using one-off runners such
+  as `uvx`, `npx`, `go run`, or similar package executors.
+- Avoid hidden network calls. If network access is required, state why, how it
+  is scoped, and what safe fallback exists.
+
+## Validation
+
+- Validate the narrow target first, then broaden only when shared rules,
+  templates, or validators changed.
+- For this repository, run:
+
+  ```bash
+  python3 align-skill/scripts/validate-skill-structure.py align-skill
+  ```
+
+- When changing `align-skill` validator logic, run the self-test and a
+  non-writing syntax compile:
+
+  ```bash
+  python3 align-skill/scripts/test-validate-skill-structure.py
+  python3 -c 'from pathlib import Path; [compile(p.read_text(encoding="utf-8"), str(p), "exec") for p in (Path("align-skill/scripts/validate-skill-structure.py"), Path("align-skill/scripts/test-validate-skill-structure.py"))]'
+  ```
+
+- Use Markdown linting for changed docs when available.
+- Report runtime trigger readiness from metadata inspection only unless you
+  actually observe the target Codex surface loading the skill.

--- a/skills/align-skill/references/skill-authoring-best-practices.md
+++ b/skills/align-skill/references/skill-authoring-best-practices.md
@@ -32,6 +32,9 @@ Source basis:
 - The front matter `name` must match the folder and stay lowercase hyphen-case.
 - The `description` is the primary trigger surface. It must say what the skill
   does and when to use it.
+- Prefix skills that are strictly internal to the Agentic SDLC workflow with
+  `sdlc-`; use `sdlc-start` for the coordinator. Their descriptions must start
+  with `Use only as part of the Agentic SDLC workflow;`.
 - Front-load user intent terms because long descriptions may be shortened in
   large skill sets.
 - Include realistic inputs and near-boundaries, such as local folder, GitHub
@@ -53,6 +56,31 @@ Source basis:
 - Put reusable templates and starter artifacts in `assets/` instead of loading
   them into `SKILL.md`.
 - Do not duplicate the same rule across files. Link to the owner file.
+
+## Stateful Workflow Skills
+
+Use the optional stateful-workflow profile when a skill is part of a
+state-machine workflow, coordinates another skill, updates local run state,
+locks plans, writes evidence, consumes continuation prompts, or owns retry and
+failure routing. Use `assets/stateful-workflow-skill-template.md` as the
+template.
+
+For these skills:
+
+- Define `Required Reads` before `Writes` so the agent reloads durable state
+  instead of relying on conversation memory.
+- Make every write surface explicit: committed product files, private local
+  state, evidence, external systems, or Git state.
+- Describe idempotency for reruns, stale fingerprints, locked artifacts,
+  duplicated evidence, and external side effects.
+- Classify failures before retrying, and route to the earliest responsible
+  phase instead of repeatedly attempting the last command.
+- Keep private execution state out of committed repositories unless the user
+  explicitly requests a committed artifact.
+- Treat hooks as non-negotiable guardrails only; keep workflow decisions in the
+  skill.
+- Prefer MCP servers for external context or control when available, but keep
+  write operations behind explicit user authorization and safety checks.
 
 ## Safe And Secure Skills
 
@@ -98,6 +126,12 @@ Source basis:
 
   ```bash
   python3 align-skill/scripts/validate-skill-structure.py align-skill
+  ```
+
+- For stateful workflow skills, also run:
+
+  ```bash
+  python3 align-skill/scripts/validate-skill-structure.py --profile stateful-workflow <skill-or-parent>
   ```
 
 - When changing `align-skill` validator logic, run the self-test and a

--- a/skills/align-skill/references/triggering-guide.md
+++ b/skills/align-skill/references/triggering-guide.md
@@ -10,6 +10,8 @@ Docs reviewed:
 - [OpenAI Codex IDE extension](https://developers.openai.com/codex/ide)
 - [OpenAI Codex app](https://developers.openai.com/codex/app)
 - [Agent Skills specification](https://agentskills.io/specification)
+- [Agent Skills best practices](https://agentskills.io/skill-creation/best-practices)
+- [Optimizing skill descriptions](https://agentskills.io/skill-creation/optimizing-descriptions)
 
 ## Confirmed Behavior
 
@@ -36,8 +38,10 @@ The best trigger strategy is a precise, trigger-rich `description` field:
 - Include user phrases that should activate the skill.
 - Include accepted inputs such as skill names, local folders, multi-skill
   folders, GitHub repositories, and GitHub tree URLs.
+- Include authoring-helper intents such as refining, hardening, validating, or
+  updating a draft or scaffolded skill.
 - Include boundaries so the skill does not steal general codebase alignment
-  tasks from `align`.
+  tasks from `align` or initial scaffolding tasks from `skill-creator`.
 
 ## Codex CLI
 
@@ -100,10 +104,12 @@ report trigger readiness from metadata inspection only.
 
 ```text
 Use align-skill to review and align `skills/foo`.
+Use align-skill as a helper after skill-creator scaffolded a release-triage skill.
 Align these skills against the canonical structure and official vendor docs.
 Review all skills under this folder and produce an alignment report.
 Validate this GitHub skills repo and propose safe changes.
 Fix the `SKILL.md` for this skill so it follows Codex Skill best practices.
+Help me harden this draft `SKILL.md` into a safe, secure, fast Codex skill.
 Check whether this skill has safe guardrails before live validation.
 Standardize this multi-skill folder and add missing references, assets, or scripts.
 Review this skill's vendor-specific commands against official documentation.

--- a/skills/align-skill/scripts/test-validate-skill-structure.py
+++ b/skills/align-skill/scripts/test-validate-skill-structure.py
@@ -33,18 +33,21 @@ def write_skill(
     name: str,
     body: str = "",
     *,
+    description: str | None = None,
     include_learning_loop: bool = True,
 ) -> None:
     skill_dir.mkdir(parents=True, exist_ok=True)
     sections = [body]
     if include_learning_loop:
         sections.append(LEARNING_LOOP)
+    if description is None:
+        description = f"Test fixture for {name}."
     (skill_dir / "SKILL.md").write_text(
         "\n".join(
             [
                 "---",
                 f"name: {name}",
-                f"description: Test fixture for {name}.",
+                f"description: {description}",
                 "---",
                 "",
                 f"# {name}",
@@ -56,10 +59,18 @@ def write_skill(
     )
 
 
-def run_validator(target: Path) -> subprocess.CompletedProcess[str]:
+def run_validator(
+    target: Path,
+    *,
+    profile: str | None = None,
+) -> subprocess.CompletedProcess[str]:
     validator = Path(__file__).with_name("validate-skill-structure.py")
+    command = [sys.executable, "-B", str(validator)]
+    if profile:
+        command.extend(["--profile", profile])
+    command.append(str(target))
     return subprocess.run(
-        [sys.executable, "-B", str(validator), str(target)],
+        command,
         check=False,
         capture_output=True,
         text=True,
@@ -165,12 +176,146 @@ def test_heading_only_learning_loop_fails() -> None:
         )
 
 
+def stateful_workflow_body() -> str:
+    return """
+## Purpose
+
+Coordinate one stateful workflow step.
+
+## When To Use
+
+- Use for stateful workflow tasks.
+
+## When Not To Use
+
+- Do not use for simple one-shot tasks.
+
+## Inputs
+
+- Input state.
+
+## Required Reads
+
+- Current state.
+
+## Writes
+
+- Updated state.
+
+## Process
+
+- Read, act, record.
+
+## Idempotency
+
+- Reruns converge.
+
+## Failure Handling
+
+- Classify before retrying.
+
+## Must Not
+
+- Do not hide failures.
+
+## Completion Criteria
+
+- State and evidence are updated.
+
+## Output Contract
+
+- Report state, evidence, and next action.
+"""
+
+
+def test_stateful_workflow_profile_passes_complete_sections() -> None:
+    with TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        write_skill(
+            root / "workflow-skill",
+            "workflow-skill",
+            stateful_workflow_body(),
+        )
+
+        result = run_validator(root, profile="stateful-workflow")
+        output = result.stdout + result.stderr
+        if result.returncode != 0:
+            raise AssertionError(output)
+
+        assert_contains(output, "Validated 1 skill(s): 0 failure(s), 0 warning(s)")
+
+
+def test_stateful_workflow_profile_missing_heading_fails() -> None:
+    with TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        write_skill(
+            root / "workflow-skill",
+            "workflow-skill",
+            stateful_workflow_body().replace("## Writes\n\n- Updated state.\n\n", ""),
+        )
+
+        basic_result = run_validator(root)
+        basic_output = basic_result.stdout + basic_result.stderr
+        if basic_result.returncode != 0:
+            raise AssertionError(basic_output)
+
+        profile_result = run_validator(root, profile="stateful-workflow")
+        profile_output = profile_result.stdout + profile_result.stderr
+        if profile_result.returncode == 0:
+            raise AssertionError(f"expected profile failure\n{profile_output}")
+
+        assert_contains(
+            profile_output,
+            "stateful-workflow profile missing required heading: ## Writes",
+        )
+
+
+def test_sdlc_only_name_and_description_contract() -> None:
+    with TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        prefix = "Use only as part of the Agentic SDLC workflow;"
+
+        write_skill(
+            root / "sdlc-good",
+            "sdlc-good",
+            description=f"{prefix} use for a workflow phase.",
+        )
+        write_skill(
+            root / "plain-skill",
+            "plain-skill",
+            description=f"{prefix} use for a workflow phase.",
+        )
+        write_skill(
+            root / "sdlc-missing-prefix",
+            "sdlc-missing-prefix",
+            description="Use for a workflow phase.",
+        )
+
+        result = run_validator(root)
+        output = result.stdout + result.stderr
+        if result.returncode == 0:
+            raise AssertionError(f"expected validator failure\n{output}")
+
+        assert_contains(
+            output,
+            "skills with the SDLC-only description prefix must use an sdlc-* name",
+        )
+        assert_contains(
+            output,
+            "SDLC-only skills must start the description with: "
+            "Use only as part of the Agentic SDLC workflow;",
+        )
+
+
 def main() -> int:
     tests = [
         test_evals_folder_and_unknown_folder_warning,
         test_missing_evals_reference_fails,
         test_missing_learning_loop_fails,
         test_heading_only_learning_loop_fails,
+        test_stateful_workflow_profile_passes_complete_sections,
+        test_stateful_workflow_profile_missing_heading_fails,
+        test_sdlc_only_name_and_description_contract,
     ]
     for test in tests:
         test()

--- a/skills/align-skill/scripts/test-validate-skill-structure.py
+++ b/skills/align-skill/scripts/test-validate-skill-structure.py
@@ -1,0 +1,182 @@
+#!/usr/bin/env python3
+"""Self-test the skill structure validator against temporary fixtures."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+
+LEARNING_LOOP = """## Learning Loop
+
+When using this skill, capture durable, reusable, public-safe learnings back
+into this skill's local source materials before completion when the current task
+contract allows source edits. Update the narrowest appropriate surface:
+`SKILL.md` for runtime rules, `references/` for detailed guidance, `assets/`
+for reusable templates, `scripts/` for deterministic helpers, and README or
+changelog entries for human-facing or release-note updates.
+
+If the current task is explicitly read-only/report-only, or source writes are
+outside this skill's task contract, do not edit skill sources; report the
+skipped source update instead.
+
+Do not capture secrets, private URLs, customer data, raw logs, one-off local
+state, or unverified/vendor-specific claims. If a useful learning is not safe,
+not evidence-backed, or outside this skill's scope, report that it was skipped.
+"""
+
+
+def write_skill(
+    skill_dir: Path,
+    name: str,
+    body: str = "",
+    *,
+    include_learning_loop: bool = True,
+) -> None:
+    skill_dir.mkdir(parents=True, exist_ok=True)
+    sections = [body]
+    if include_learning_loop:
+        sections.append(LEARNING_LOOP)
+    (skill_dir / "SKILL.md").write_text(
+        "\n".join(
+            [
+                "---",
+                f"name: {name}",
+                f"description: Test fixture for {name}.",
+                "---",
+                "",
+                f"# {name}",
+                "",
+                "\n\n".join(section for section in sections if section),
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+
+def run_validator(target: Path) -> subprocess.CompletedProcess[str]:
+    validator = Path(__file__).with_name("validate-skill-structure.py")
+    return subprocess.run(
+        [sys.executable, "-B", str(validator), str(target)],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+
+def assert_contains(text: str, expected: str) -> None:
+    if expected not in text:
+        raise AssertionError(f"expected output to contain {expected!r}\n{text}")
+
+
+def assert_not_contains(text: str, unexpected: str) -> None:
+    if unexpected in text:
+        raise AssertionError(f"did not expect output to contain {unexpected!r}\n{text}")
+
+
+def test_evals_folder_and_unknown_folder_warning() -> None:
+    with TemporaryDirectory() as tmp:
+        root = Path(tmp)
+
+        good_skill = root / "good-skill"
+        write_skill(
+            good_skill,
+            "good-skill",
+            "Use `evals/trigger-prompts.csv` for trigger examples.",
+        )
+        (good_skill / "evals").mkdir()
+        (good_skill / "evals" / "trigger-prompts.csv").write_text(
+            "prompt,should_trigger\n",
+            encoding="utf-8",
+        )
+
+        warning_skill = root / "warning-skill"
+        write_skill(warning_skill, "warning-skill")
+        (warning_skill / "experiments").mkdir()
+
+        result = run_validator(root)
+        output = result.stdout + result.stderr
+        if result.returncode != 0:
+            raise AssertionError(output)
+
+        assert_contains(output, "Validated 2 skill(s): 0 failure(s), 1 warning(s)")
+        assert_contains(output, "non-canonical folder reported for review: experiments/")
+        assert_not_contains(output, "non-canonical folder reported for review: evals/")
+
+
+def test_missing_evals_reference_fails() -> None:
+    with TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        write_skill(
+            root / "bad-skill",
+            "bad-skill",
+            "Use `evals/missing.csv` for trigger examples.",
+        )
+
+        result = run_validator(root)
+        output = result.stdout + result.stderr
+        if result.returncode == 0:
+            raise AssertionError(f"expected validator failure\n{output}")
+
+        assert_contains(
+            output,
+            "referenced local path does not exist: evals/missing.csv",
+        )
+
+
+def test_missing_learning_loop_fails() -> None:
+    with TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        write_skill(
+            root / "missing-loop",
+            "missing-loop",
+            include_learning_loop=False,
+        )
+
+        result = run_validator(root)
+        output = result.stdout + result.stderr
+        if result.returncode == 0:
+            raise AssertionError(f"expected validator failure\n{output}")
+
+        assert_contains(output, "SKILL.md is missing ## Learning Loop")
+
+
+def test_heading_only_learning_loop_fails() -> None:
+    with TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        write_skill(
+            root / "empty-loop",
+            "empty-loop",
+            "## Learning Loop\n",
+            include_learning_loop=False,
+        )
+
+        result = run_validator(root)
+        output = result.stdout + result.stderr
+        if result.returncode == 0:
+            raise AssertionError(f"expected validator failure\n{output}")
+
+        assert_contains(
+            output,
+            "## Learning Loop is missing required text: "
+            "capture durable, reusable, public-safe learnings",
+        )
+
+
+def main() -> int:
+    tests = [
+        test_evals_folder_and_unknown_folder_warning,
+        test_missing_evals_reference_fails,
+        test_missing_learning_loop_fails,
+        test_heading_only_learning_loop_fails,
+    ]
+    for test in tests:
+        test()
+    print(f"OK {len(tests)} validator self-test(s)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/align-skill/scripts/validate-skill-structure.py
+++ b/skills/align-skill/scripts/validate-skill-structure.py
@@ -28,6 +28,21 @@ LEARNING_LOOP_REQUIRED_SNIPPETS = (
     "unverified/vendor-specific claims",
     "report that it was skipped",
 )
+STATEFUL_WORKFLOW_REQUIRED_HEADINGS = (
+    "## Purpose",
+    "## When To Use",
+    "## When Not To Use",
+    "## Inputs",
+    "## Required Reads",
+    "## Writes",
+    "## Process",
+    "## Idempotency",
+    "## Failure Handling",
+    "## Must Not",
+    "## Completion Criteria",
+    "## Output Contract",
+)
+SDLC_ONLY_DESCRIPTION_PREFIX = "Use only as part of the Agentic SDLC workflow;"
 
 
 @dataclass
@@ -61,6 +76,16 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
         nargs="+",
         type=Path,
         help="Skill folder or parent folder containing skill folders.",
+    )
+    parser.add_argument(
+        "--profile",
+        choices=("basic", "stateful-workflow"),
+        default="basic",
+        help=(
+            "Optional validation profile. The default basic profile checks "
+            "generic skill structure only. stateful-workflow additionally "
+            "requires the standard state-machine skill sections."
+        ),
     )
     return parser.parse_args(argv)
 
@@ -166,7 +191,15 @@ def extract_learning_loop_section(skill_text: str) -> str | None:
     return skill_text[section_start:next_heading]
 
 
-def validate_skill(skill_dir: Path) -> SkillResult:
+def validate_stateful_workflow_profile(skill_text: str, result: SkillResult) -> None:
+    for heading in STATEFUL_WORKFLOW_REQUIRED_HEADINGS:
+        if f"\n{heading}\n" not in f"\n{skill_text}\n":
+            result.failures.append(
+                f"stateful-workflow profile missing required heading: {heading}"
+            )
+
+
+def validate_skill(skill_dir: Path, *, profile: str = "basic") -> SkillResult:
     result = SkillResult(path=skill_dir)
     skill_md = skill_dir / "SKILL.md"
 
@@ -197,6 +230,19 @@ def validate_skill(skill_dir: Path) -> SkillResult:
         result.failures.append("front matter is missing description")
     elif len(description) > 1024:
         result.failures.append("description exceeds 1024 characters")
+    elif name.startswith("sdlc-") and not description.startswith(
+        SDLC_ONLY_DESCRIPTION_PREFIX
+    ):
+        result.failures.append(
+            "SDLC-only skills must start the description with: "
+            f"{SDLC_ONLY_DESCRIPTION_PREFIX}"
+        )
+    elif description.startswith(SDLC_ONLY_DESCRIPTION_PREFIX) and not name.startswith(
+        "sdlc-"
+    ):
+        result.failures.append(
+            "skills with the SDLC-only description prefix must use an sdlc-* name"
+        )
 
     try:
         skill_text = skill_md.read_text(encoding="utf-8")
@@ -213,6 +259,9 @@ def validate_skill(skill_dir: Path) -> SkillResult:
                 result.failures.append(
                     f"## Learning Loop is missing required text: {snippet}"
                 )
+
+    if profile == "stateful-workflow" and skill_text:
+        validate_stateful_workflow_profile(skill_text, result)
 
     for child in sorted(skill_dir.iterdir()):
         if not child.is_dir() or child.name.startswith("."):
@@ -279,7 +328,7 @@ def main(argv: list[str]) -> int:
     for target in args.targets:
         skills, warnings = discover_skills(target)
         discovery_warnings.extend(warnings)
-        all_results.extend(validate_skill(skill) for skill in skills)
+        all_results.extend(validate_skill(skill, profile=args.profile) for skill in skills)
 
     for warning in discovery_warnings:
         print(f"WARN: {warning}")

--- a/skills/align-skill/scripts/validate-skill-structure.py
+++ b/skills/align-skill/scripts/validate-skill-structure.py
@@ -10,12 +10,24 @@ from dataclasses import dataclass, field
 from pathlib import Path
 
 
-KNOWN_OPTIONAL_DIRS = {"agents", "assets", "references", "scripts"}
+KNOWN_OPTIONAL_DIRS = {"agents", "assets", "evals", "references", "scripts"}
 NAME_RE = re.compile(r"^[a-z0-9](?:[a-z0-9-]{0,62}[a-z0-9])?$")
 LOCAL_REF_RE = re.compile(
-    r"(?P<path>(?:agents|assets|references|scripts)/[A-Za-z0-9._/@%+=:,~/-]+)"
+    r"(?P<path>"
+    r"(?:agents|assets|evals|references|scripts)/[A-Za-z0-9._/@%+=:,~/-]+"
+    r")"
 )
 MARKDOWN_LINK_RE = re.compile(r"\[[^\]]+\]\((?P<target>[^)]+)\)")
+LEARNING_LOOP_HEADING = "\n## Learning Loop\n"
+LEARNING_LOOP_REQUIRED_SNIPPETS = (
+    "capture durable, reusable, public-safe learnings",
+    "contract allows source edits",
+    "narrowest appropriate surface",
+    "read-only/report-only",
+    "Do not capture secrets",
+    "unverified/vendor-specific claims",
+    "report that it was skipped",
+)
 
 
 @dataclass
@@ -116,7 +128,9 @@ def clean_reference(raw: str) -> str | None:
         return None
     if "#" in target:
         target = target.split("#", 1)[0]
-    if target.startswith(("agents/", "assets/", "references/", "scripts/")):
+    if target.startswith(
+        ("agents/", "assets/", "evals/", "references/", "scripts/")
+    ):
         name = target.rstrip("/").rsplit("/", 1)[-1]
         if not target.endswith("/") and "." not in name:
             return None
@@ -138,6 +152,18 @@ def referenced_paths(skill_md: Path) -> set[str]:
             refs.add(target)
 
     return refs
+
+
+def extract_learning_loop_section(skill_text: str) -> str | None:
+    start = skill_text.find(LEARNING_LOOP_HEADING)
+    if start == -1:
+        return None
+
+    section_start = start + len(LEARNING_LOOP_HEADING)
+    next_heading = skill_text.find("\n## ", section_start)
+    if next_heading == -1:
+        return skill_text[section_start:]
+    return skill_text[section_start:next_heading]
 
 
 def validate_skill(skill_dir: Path) -> SkillResult:
@@ -171,6 +197,22 @@ def validate_skill(skill_dir: Path) -> SkillResult:
         result.failures.append("front matter is missing description")
     elif len(description) > 1024:
         result.failures.append("description exceeds 1024 characters")
+
+    try:
+        skill_text = skill_md.read_text(encoding="utf-8")
+    except OSError as exc:
+        result.failures.append(f"cannot read SKILL.md for learning loop: {exc}")
+        skill_text = ""
+
+    learning_loop = extract_learning_loop_section(skill_text)
+    if skill_text and learning_loop is None:
+        result.failures.append("SKILL.md is missing ## Learning Loop")
+    elif learning_loop is not None:
+        for snippet in LEARNING_LOOP_REQUIRED_SNIPPETS:
+            if snippet not in learning_loop:
+                result.failures.append(
+                    f"## Learning Loop is missing required text: {snippet}"
+                )
 
     for child in sorted(skill_dir.iterdir()):
         if not child.is_dir() or child.name.startswith("."):

--- a/skills/align/SKILL.md
+++ b/skills/align/SKILL.md
@@ -224,6 +224,23 @@ Do not:
 - claim validation passed when it was not run
 - claim complete alignment if important areas were not inspected
 
+## Learning Loop
+
+When using this skill, capture durable, reusable, public-safe learnings back
+into this skill's local source materials before completion when the current task
+contract allows source edits. Update the narrowest appropriate surface:
+`SKILL.md` for runtime rules, `references/` for detailed guidance, `assets/`
+for reusable templates, `scripts/` for deterministic helpers, and README or
+changelog entries for human-facing or release-note updates.
+
+If the current task is explicitly read-only/report-only, or source writes are
+outside this skill's task contract, do not edit skill sources; report the
+skipped source update instead.
+
+Do not capture secrets, private URLs, customer data, raw logs, one-off local
+state, or unverified/vendor-specific claims. If a useful learning is not safe,
+not evidence-backed, or outside this skill's scope, report that it was skipped.
+
 ## Output Contract
 
 When using this skill:

--- a/skills/apply-security/README.md
+++ b/skills/apply-security/README.md
@@ -1,0 +1,34 @@
+# Apply Security
+
+`apply-security` is the reusable security review and remediation skill for
+codebases that mix infrastructure, deployment, CI/CD, shell, and application
+code. It is built for conservative security engineering: find real risk, rank
+it clearly, and apply small patches only when they preserve intended behavior.
+
+## Core Workflow
+
+1. Select a mode: `scan`, `plan`, `patch`, `verify`, or `explain`.
+2. Inspect repository evidence before asserting framework or cloud behavior.
+3. Classify findings by severity, confidence, exploitability, and blast radius.
+4. Patch only safe, local changes directly. Plan changes that can affect
+   availability, auth, authz, crypto, data retention, or public exposure.
+5. Verify with repository-native commands and report skipped checks.
+
+## Important Files
+
+- `SKILL.md`: runtime routing, workflow, guardrails, output contract, and
+  learning-loop rule.
+- `references/rulebook.md`: security review matrix and auto-fix policy.
+- `references/examples.md`: before/after remediation examples for every
+  supported area.
+- `references/reporting-and-validation.md`: report formats, validation command
+  selection, limitations, rollout guidance, and merge checklist.
+- `agents/openai.yaml`: UI metadata and default prompt.
+
+## Safety Model
+
+The skill does not rotate credentials, rewrite history, delete resources,
+disable features, change public APIs, change database schemas, replace
+serialization protocols, change auth algorithms, or alter externally visible
+routes without explicit approval. It uses explicit exceptions with owner,
+reason, scope, and `reviewBy` date when risky behavior must remain.

--- a/skills/apply-security/SKILL.md
+++ b/skills/apply-security/SKILL.md
@@ -1,0 +1,186 @@
+---
+name: apply-security
+description: "Use when reviewing or fixing security issues in infrastructure, deployment, Helm, Kubernetes, Terraform, CI/CD workflows, Bash scripts, and application code in Python, Java, JavaScript, TypeScript, or Rust. Use for security scan reports, remediation plans, safe patching, verification, SARIF/JSON/Markdown findings, secret leakage, public exposure, IAM/RBAC, injection, deserialization, crypto, and supply-chain risks."
+---
+
+# Apply Security
+
+## Purpose
+
+Review codebases for practical security risk and apply minimal,
+behavior-preserving remediations. Prefer secure defaults, controlled opt-ins,
+and clear exceptions over removing features or rewriting unrelated code.
+
+## Use This Skill For
+
+- Security scans across Terraform, Kubernetes manifests, Helm charts, CI/CD
+  workflows, shell scripts, and application code.
+- Remediation plans that identify exact files, risk, fix strategy, expected
+  feature impact, and validation.
+- Safe patching for small, reviewable changes such as redaction, least
+  privilege workflow permissions, non-breaking Helm values, compatible
+  security contexts, and obvious shell quoting fixes.
+- Verification of security patches with repository-native checks.
+- Explaining findings, tradeoffs, exceptions, and safe override designs.
+
+## Non-Goals
+
+- Do not treat this skill as a replacement for threat modeling, penetration
+  testing, formal compliance attestation, or project-specific security policy.
+- Do not rotate credentials, rewrite history, delete resources, disable
+  features, change auth flows, or alter externally visible behavior without
+  explicit user approval.
+- Do not invent cloud, framework, CLI, package-manager, or scanner behavior.
+  Verify version-sensitive behavior against current official docs or mark it
+  unverified.
+
+## Inputs Accepted
+
+- A repository, branch, PR, diff, directory, file list, chart, module, workflow,
+  or pasted code.
+- Optional mode: `scan`, `plan`, `patch`, `verify`, or `explain`.
+- Optional output format: Markdown, JSON, or SARIF-style findings.
+- Optional constraints: target environment, production sensitivity, approved
+  scanners, files to exclude, or changes the user explicitly approves.
+
+Default to `scan` when the user asks for a review and does not ask for edits.
+Default to `plan` when the user asks what should be fixed. Use `patch` only
+when the user asks to fix, harden, remediate, or apply changes.
+
+## Required References
+
+- Read `references/rulebook.md` before scanning, planning, or patching.
+- Read `references/examples.md` before writing remediations that need concrete
+  implementation patterns or before explaining safe alternatives.
+- Read `references/reporting-and-validation.md` before producing JSON/SARIF,
+  running verification, listing limitations, or giving the final merge
+  checklist.
+
+If a finding or fix depends on a product, cloud, API, CLI, framework, package
+manager, or version-specific behavior, verify the current official vendor
+documentation before recommending or changing it. If the repository evidence or
+official docs do not confirm the behavior, lower confidence and explain what is
+missing.
+
+## Workflow
+
+1. Establish scope and mode.
+   - Inspect the requested paths, current diff, relevant manifests, lockfiles,
+     package manifests, workflow files, and existing scanner configuration.
+   - Preserve unrelated user changes. Do not refactor unrelated code.
+   - Do not print, persist, or copy secrets. Redact suspicious values.
+
+2. Review by risk area.
+   - Use stable finding IDs such as `TF-IAM-001`, `K8S-RUN-001`,
+     `HELM-IMG-001`, `CI-PERM-001`, `PY-CMD-001`, `JAVA-DESER-001`,
+     `JS-EVAL-001`, `TS-TYPE-001`, `RS-UNSAFE-001`, and `SH-EVAL-001`.
+   - Classify each finding by severity, confidence, exploitability, and blast
+     radius.
+   - When runtime context matters, mark confidence `Medium` or `Low` and name
+     the missing evidence.
+
+3. Choose the safest remediation path.
+   - Prefer minimal diffs that remove or reduce risk without changing intended
+     behavior.
+   - Replace unsafe hardcoded behavior with secure configurable defaults,
+     explicit opt-ins, and documented exceptions.
+   - Keep public APIs, auth flows, serialization formats, schemas, externally
+     visible routes, and production availability unchanged unless the user
+     explicitly approves a breaking change.
+   - Do not add dependencies, scanners, new services, or compatibility shims
+     unless the repository already uses them or the user approves them.
+
+4. Apply changes only inside the approved boundary.
+   - Safe to patch directly: obvious log redaction, missing
+     `sensitive = true`, least-privilege workflow `permissions` when compatible,
+     non-breaking Helm values, compatible pod/container security contexts,
+     simple path validation, and Bash quoting where no word splitting is
+     intended.
+   - Plan first: public exposure, IAM/RBAC narrowing, NetworkPolicy default
+     deny, TypeScript strictness, crypto, auth, CORS, deserialization, data
+     retention, external network access, shell strict mode, or anything that
+     may affect availability.
+   - Never auto-fix without explicit approval: credential rotation, git history
+     rewriting, deleting resources, disabling features, changing public APIs,
+     changing database schemas, replacing serialization protocols, changing
+     auth algorithms, or changing externally visible routes.
+
+5. Verify and report.
+   - Run the narrowest repository-native checks available. Missing tools are a
+     limitation, not an automatic failure.
+   - Avoid validation commands that mutate files, create cache/build
+     directories, contact external registries, install missing tools, or use
+     live credentials unless that behavior is explicitly approved and safe for
+     the target scope.
+   - Do not claim a finding is fixed unless validation passed or the limitation
+     is explicitly documented.
+   - Explain every change with risk, change, compatibility note, verification,
+     remaining risk, and safe override where applicable.
+
+## Safe Override Design
+
+When risky behavior is required, prefer an explicit, narrow exception:
+
+- explicit opt-in value such as `allowPrivileged`, `allowPublicExposure`,
+  `allowUnsafeDeserialization`, `allowShellExecution`, or `allowInsecureTls`
+- `securityException.owner`
+- `securityException.reason`
+- `securityException.scope`
+- `securityException.reviewBy`
+- visible warning in scan reports
+
+Do not hide exceptions in broad global toggles. Apply exceptions only to the
+specific resource, function, workflow, or chart value.
+
+## Output Contract
+
+For `scan`, return prioritized findings with:
+
+- finding ID
+- area
+- file and line
+- severity
+- confidence
+- exploitability
+- blast radius
+- risk
+- root cause
+- recommended fix
+- feature impact
+- safe override
+
+For `patch`, return:
+
+- summary of each change
+- reason and risk addressed
+- compatibility note
+- verification commands and results
+- remaining risks
+
+Use Markdown by default. Provide JSON or SARIF-style output when requested.
+
+## Learning Loop
+
+When using this skill, capture durable, reusable, public-safe learnings back
+into this skill's local source materials before completion when the current task
+contract allows source edits. Update the narrowest appropriate surface:
+`SKILL.md` for runtime rules, `references/` for detailed guidance, `assets/`
+for reusable templates, `scripts/` for deterministic helpers, and README or
+changelog entries for human-facing or release-note updates.
+
+If the current task is explicitly read-only/report-only, or source writes are
+outside this skill's task contract, do not edit skill sources; report why source
+capture was skipped.
+
+Do not capture secrets, private URLs, customer data, raw logs, one-off local
+state, or unverified/vendor-specific claims. If a useful learning is not safe,
+not evidence-backed, or outside this skill's scope, report that it was skipped.
+
+## Resources
+
+- `references/rulebook.md`: review areas, severity guidance, auto-fix policy,
+  safe override requirements, and no-auto-fix boundaries.
+- `references/examples.md`: before/after remediation snippets for Terraform,
+  Kubernetes, Helm, CI/CD, Python, Java, JavaScript, TypeScript, Rust, and Bash.
+- `references/reporting-and-validation.md`: output schemas, validation command
+  selection, limitations, staged rollout guidance, and final merge checklist.

--- a/skills/apply-security/agents/openai.yaml
+++ b/skills/apply-security/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Apply Security"
+  short_description: "Review and patch codebase security risks"
+  default_prompt: "Use $apply-security to scan this repository for infrastructure, CI/CD, and application security issues, then plan safe minimal remediations."

--- a/skills/apply-security/references/examples.md
+++ b/skills/apply-security/references/examples.md
@@ -1,0 +1,303 @@
+# Apply Security Examples
+
+## Contents
+
+- Terraform
+- Kubernetes
+- Helm
+- CI/CD
+- Python
+- Java
+- JavaScript
+- TypeScript
+- Rust
+- Bash
+
+Use these as patterns, not templates to paste blindly. Preserve local style,
+existing helper APIs, and intended behavior.
+
+## Terraform
+
+Risk: public ingress lacks an explicit exception.
+
+Before:
+
+```hcl
+resource "aws_security_group_rule" "web" {
+  type        = "ingress"
+  from_port   = 443
+  to_port     = 443
+  protocol    = "tcp"
+  cidr_blocks = ["0.0.0.0/0"]
+}
+```
+
+After:
+
+```hcl
+variable "allow_public_web_ingress" {
+  type        = bool
+  description = "Allow public HTTPS ingress for the web endpoint."
+  default     = false
+}
+
+resource "aws_security_group_rule" "web" {
+  count       = var.allow_public_web_ingress ? 1 : 0
+  type        = "ingress"
+  from_port   = 443
+  to_port     = 443
+  protocol    = "tcp"
+  cidr_blocks = ["0.0.0.0/0"]
+}
+```
+
+Compatibility note: plan first for existing public endpoints because disabling
+the rule can affect availability.
+
+## Kubernetes
+
+Risk: container can gain extra privileges and lacks default runtime hardening.
+
+Before:
+
+```yaml
+containers:
+  - name: app
+    image: example/app:1.2.3
+```
+
+After:
+
+```yaml
+securityContext:
+  runAsNonRoot: true
+  seccompProfile:
+    type: RuntimeDefault
+containers:
+  - name: app
+    image: example/app:1.2.3
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+          - ALL
+```
+
+Compatibility note: verify image user and write paths before adding
+`readOnlyRootFilesystem: true`.
+
+## Helm
+
+Risk: chart lacks digest support and hardcodes a mutable tag.
+
+Before:
+
+```yaml
+image:
+  repository: example/app
+  tag: latest
+```
+
+After:
+
+```yaml
+image:
+  repository: example/app
+  tag: "1.2.3"
+  digest: ""
+```
+
+Template pattern:
+
+```gotemplate
+{{- $image := printf "%s:%s" .Values.image.repository .Values.image.tag -}}
+{{- if .Values.image.digest -}}
+{{- $image = printf "%s@%s" .Values.image.repository .Values.image.digest -}}
+{{- end -}}
+image: {{ $image | quote }}
+```
+
+Compatibility note: keep tag override flexibility unless the user requires
+digest-only deployment.
+
+## CI/CD
+
+Risk: workflow gets broad default token permissions.
+
+Before:
+
+```yaml
+name: ci
+on: [pull_request]
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+```
+
+After:
+
+```yaml
+name: ci
+on: [pull_request]
+permissions: read-all
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+```
+
+Compatibility note: add per-job write permissions only for jobs that need
+them. Do not grant secrets or write tokens to untrusted PR code.
+
+## Python
+
+Risk: shell command construction can execute attacker-controlled input.
+
+Before:
+
+```python
+subprocess.run(f"tar -tf {archive_path}", shell=True, check=True)
+```
+
+After:
+
+```python
+subprocess.run(["tar", "-tf", str(archive_path)], check=True)
+```
+
+Compatibility note: only auto-fix when the command has an obvious argument
+array equivalent. Preserve shell behavior only with an explicit, justified
+exception.
+
+## Java
+
+Risk: SQL query uses string concatenation with untrusted input.
+
+Before:
+
+```java
+String sql = "select * from users where email = '" + email + "'";
+ResultSet rs = connection.createStatement().executeQuery(sql);
+```
+
+After:
+
+```java
+String sql = "select * from users where email = ?";
+try (PreparedStatement stmt = connection.prepareStatement(sql)) {
+    stmt.setString(1, email);
+    try (ResultSet rs = stmt.executeQuery()) {
+        // Existing result handling.
+    }
+}
+```
+
+Compatibility note: preserve query semantics. Do not change authentication or
+authorization behavior as part of an injection fix.
+
+## JavaScript
+
+Risk: shell execution with user-controlled input.
+
+Before:
+
+```javascript
+const { exec } = require("node:child_process");
+exec(`git show ${ref}`, callback);
+```
+
+After:
+
+```javascript
+const { execFile } = require("node:child_process");
+execFile("git", ["show", ref], callback);
+```
+
+Compatibility note: validate `ref` separately if the command accepts values
+that could change operation semantics.
+
+## TypeScript
+
+Risk: external input is trusted because of a type assertion.
+
+Before:
+
+```typescript
+const body = req.body as CreateUserRequest;
+await createUser(body.email, body.role);
+```
+
+After:
+
+```typescript
+function isCreateUserRequest(value: unknown): value is CreateUserRequest {
+  if (!value || typeof value !== "object") return false;
+  const candidate = value as Record<string, unknown>;
+  return typeof candidate.email === "string" && candidate.role === "user";
+}
+
+if (!isCreateUserRequest(req.body)) {
+  throw new Error("Invalid request");
+}
+
+await createUser(req.body.email, req.body.role);
+```
+
+Compatibility note: prefer local runtime guards on trust boundaries before
+proposing project-wide strict mode changes.
+
+## Rust
+
+Risk: untrusted input can trigger a panic.
+
+Before:
+
+```rust
+let user_id = parts[1].parse::<u64>().unwrap();
+```
+
+After:
+
+```rust
+let user_id = parts
+    .get(1)
+    .ok_or_else(|| Error::InvalidInput("missing user id".into()))?
+    .parse::<u64>()
+    .map_err(|_| Error::InvalidInput("invalid user id".into()))?;
+```
+
+Compatibility note: use the repository's existing error type and style. Do not
+remove `unsafe` automatically unless the replacement is local and validated.
+
+## Bash
+
+Risk: `eval` executes user-controlled text.
+
+Before:
+
+```bash
+eval "$command"
+```
+
+After:
+
+```bash
+case "$command" in
+  status)
+    run_status
+    ;;
+  deploy)
+    run_deploy
+    ;;
+  *)
+    printf 'unsupported command: %s\n' "$command" >&2
+    exit 2
+    ;;
+esac
+```
+
+Compatibility note: do not rewrite command dispatch if it changes supported
+behavior. Plan first when the command language is part of the public interface.

--- a/skills/apply-security/references/reporting-and-validation.md
+++ b/skills/apply-security/references/reporting-and-validation.md
@@ -1,0 +1,248 @@
+# Reporting and Validation
+
+## Contents
+
+- Scan report
+- Patch report
+- JSON findings
+- SARIF-style findings
+- Validation commands
+- Limitations
+- Staged rollout guidance
+- Final merge checklist
+
+## Scan Report
+
+Use this shape for Markdown scan output:
+
+```markdown
+## Findings
+
+### TF-IAM-001: Wildcard IAM write permissions
+
+- Area: Terraform
+- File and line: `modules/app/iam.tf:42`
+- Severity: High
+- Confidence: High
+- Exploitability: Medium
+- Blast radius: Project-wide cloud resources
+- Risk: The role can modify all resources in the account.
+- Root cause: Policy action and resource are both wildcarded.
+- Recommended fix: Narrow actions and resources to the specific service calls
+  and ARNs required by the module.
+- Feature impact: May require adding explicit permissions for currently
+  undocumented operations.
+- Safe override: Keep only with `securityException.owner`, `reason`, `scope`,
+  and `reviewBy`.
+```
+
+Sort by severity, exploitability, blast radius, then confidence. Keep
+speculative findings separate from confirmed findings.
+
+## Patch Report
+
+Use this shape after edits:
+
+```markdown
+## Changes
+
+### CI-PERM-001: Added workflow token permissions
+
+- Summary: Added top-level `permissions: read-all`.
+- Reason: The workflow did not need write access for PR tests.
+- Compatibility note: Jobs that publish artifacts or comments may need explicit
+  per-job write permissions.
+- Verification: `python -c 'import yaml, pathlib; ...'` passed.
+- Remaining risks: Third-party action pinning was not changed.
+```
+
+Show exact diffs when the user asks for them or when the patch is difficult to
+review from the summary alone. In normal Codex code-editing flows, the local
+Git diff is already available, so summarize the high-signal changes.
+
+## JSON Findings
+
+When the user asks for JSON, emit an array of findings:
+
+```json
+[
+  {
+    "id": "K8S-RUN-001",
+    "area": "Kubernetes",
+    "file": "deploy/app.yaml",
+    "line": 31,
+    "severity": "High",
+    "confidence": "High",
+    "exploitability": "Medium",
+    "blast_radius": "Pod privilege escalation",
+    "risk": "Container allows privilege escalation.",
+    "root_cause": "allowPrivilegeEscalation is true.",
+    "recommended_fix": "Set allowPrivilegeEscalation false and drop capabilities if compatible.",
+    "feature_impact": "May break workloads that intentionally need elevated privileges.",
+    "safe_override": "Require allowPrivileged plus owner, reason, scope, and reviewBy."
+  }
+]
+```
+
+Do not include raw secret values in JSON. Redact suspicious values and report
+only the file, line, key name, and secret class.
+
+## SARIF-Style Findings
+
+When the user asks for SARIF, produce valid SARIF 2.1.0 when feasible. At
+minimum, map:
+
+- finding ID to `ruleId`
+- severity to `level`
+- file/line to `locations[].physicalLocation.artifactLocation.uri` and
+  `region.startLine`
+- risk and remediation to `message.text`
+- confidence, exploitability, blast radius, and safe override to rule or result
+  properties
+
+If a full SARIF writer is not practical in the current task, state that the
+output is SARIF-style JSON and identify the missing fields.
+
+## Validation Commands
+
+Use repository-native checks first. Do not fail the task only because a tool is
+missing; report missing tools as limitations.
+
+Before running a command, check whether it can mutate files, create cache or
+build directories, contact an external service, install missing tools, submit
+dependency data, or use live credentials. Run those commands only when that
+behavior is acceptable for the task and target environment. Prefer configured
+package scripts and local binaries over package-manager auto-install behavior.
+
+Terraform:
+
+```bash
+terraform fmt -check
+terraform validate
+terraform init -lockfile=readonly
+# Only when lockfile maintenance is approved or explicitly in scope:
+terraform providers lock -platform=<os_arch>
+```
+
+Kubernetes:
+
+```bash
+kubectl apply --dry-run=client -f <file-or-dir>
+kubeconform <file-or-dir>
+kubeval <file-or-dir>
+```
+
+Helm:
+
+```bash
+helm lint <chart-dir>
+helm template <release-name> <chart-dir>
+```
+
+CI/CD:
+
+```bash
+python -c 'import sys, yaml; [yaml.safe_load(open(p)) for p in sys.argv[1:]]' .github/workflows/*.yml
+bash -n <script>
+shellcheck <script>
+```
+
+Python:
+
+```bash
+python -m compileall <package-or-dir>
+pytest
+ruff check
+mypy
+```
+
+Java:
+
+```bash
+mvn test
+gradle test
+javac <files>
+```
+
+JavaScript and TypeScript:
+
+```bash
+npm test
+yarn test
+pnpm test
+npm audit
+./node_modules/.bin/tsc --noEmit
+./node_modules/.bin/eslint .
+```
+
+Rust:
+
+```bash
+cargo fmt --check
+cargo clippy
+cargo test
+cargo check
+```
+
+Bash:
+
+```bash
+bash -n <script>
+shellcheck <script>
+```
+
+Use only commands that are present or commonly expected for the repository.
+Prefer configured package scripts over generic commands when available. Treat
+`npm audit` as an external registry submission, and do not run package-manager
+commands that install missing tools unless dependency installation is already
+approved for the task.
+
+## Limitations
+
+This skill cannot safely infer:
+
+- whether a public endpoint is intentionally exposed without environment,
+  threat model, and owner context
+- whether IAM/RBAC permissions are all required without runtime call evidence
+- whether NetworkPolicy default-deny will break traffic without service-flow
+  knowledge
+- whether changing auth, crypto, serialization, or CORS behavior is safe
+  without product requirements and compatibility tests
+- whether a secret-like value is active, expired, fake, or already rotated
+- whether generated manifests match live cluster admission policy unless live
+  validation is explicitly approved in a non-production environment
+- whether framework-specific security behavior exists unless repository code
+  or current official docs confirm it
+
+Lower confidence and ask for approval rather than guessing in these cases.
+
+## Staged Rollout Guidance
+
+Use staged plans for changes that can break production behavior:
+
+- TypeScript strictness: add local runtime guards first, then enable stricter
+  compiler flags per package or folder.
+- NetworkPolicy: start with observed traffic inventory, add namespace labels,
+  test allow rules, then enable default-deny.
+- IAM/RBAC: add audit logging or dry-run policy simulation where available,
+  narrow read permissions before write permissions, then remove wildcards.
+- Runtime security: add non-root, seccomp, and dropped capabilities first;
+  only add read-only root filesystems after write paths are known.
+
+## Final Merge Checklist
+
+- Findings are prioritized by severity, confidence, exploitability, and blast
+  radius.
+- Every patch explains risk, change, feature impact, verification, and
+  remaining risk.
+- No secrets, fake secrets, internal hostnames, private endpoints, or customer
+  data were added to files or output.
+- No destructive, availability-impacting, auth, authz, crypto, data-retention,
+  or external-network change was applied without approval.
+- Exceptions include owner, reason, scope, and `reviewBy` date.
+- Repository-native validation ran, or missing tools and skipped checks are
+  explicitly documented.
+- Public APIs, auth flows, serialization formats, schemas, and externally
+  visible routes are unchanged unless approved.
+- Third-party dependencies or scanners were not added unless approved or
+  already used by the repository.

--- a/skills/apply-security/references/rulebook.md
+++ b/skills/apply-security/references/rulebook.md
@@ -1,0 +1,358 @@
+# Apply Security Rulebook
+
+## Contents
+
+- Review mindset
+- Area rule matrix
+- Severity and confidence
+- Safe auto-fix policy
+- Safe override policy
+- Production hardening extension
+- Policy-as-code compatibility
+
+## Review Mindset
+
+- Safety first: prevent credential exposure, privilege escalation, public
+  exposure, supply-chain tampering, unsafe deserialization, injection, command
+  execution abuse, insecure crypto, and secret leakage.
+- Preserve flexibility: prefer secure configurable defaults, explicit opt-ins,
+  and documented exceptions over deleting features.
+- Minimal diffs: change only what is needed to remove or reduce the risk.
+- Secure by default: new defaults should be restrictive and controlled
+  overrides should be explicit.
+- Evidence based: classify by severity, confidence, exploitability, and blast
+  radius. Lower confidence when runtime context is unknown.
+- Framework aware: detect common frameworks from repository evidence, but do
+  not invent framework-specific behavior.
+
+## Area Rule Matrix
+
+### Terraform
+
+Review `.tf`, `.tfvars.example`, `providers.tf`, `backend.tf`, `versions.tf`,
+environment roots, and modules.
+
+- Provider pinning: require `required_providers` with source and version
+  constraints. Prefer committed dependency lock files for roots where
+  `terraform init` runs. Avoid unbounded or floating provider versions.
+- Least privilege IAM: flag wildcard actions, wildcard resources, broad
+  managed policies, admin policies, cross-account assumptions without
+  conditions, and missing conditions where applicable.
+- Secrets in state: flag inline secrets, sensitive values, hardcoded tokens,
+  generated passwords stored in state, backend credentials in configuration,
+  and unsafe outputs.
+- Public endpoints: flag public security group ingress, public load balancers,
+  public buckets, public databases, open CIDR ranges, and public IP assignment.
+- Preferred fixes: variables with safe defaults, explicit `allow_public_*`
+  flags, narrow IAM actions/resources, condition blocks, `sensitive = true`,
+  external secret managers, dynamic or short-lived credentials, and remote
+  backends with access control.
+
+### Kubernetes
+
+Review `.yaml`, `.yml`, base manifests, overlays, generated manifests when
+committed, service accounts, roles, bindings, pods, controllers, services, and
+network policies.
+
+- Privilege: flag `privileged: true`, `hostPID`, `hostIPC`, `hostNetwork`,
+  broad capabilities, `allowPrivilegeEscalation: true`, and missing seccomp
+  where a workload can reasonably support it.
+- `hostPath`: allow only documented, narrow, read-only paths with explicit
+  justification.
+- RBAC: flag `cluster-admin`, wildcard verbs/resources, broad
+  `ClusterRoleBinding`, default service account use, and unnecessary
+  cross-namespace permissions.
+- NetworkPolicy: flag namespaces or workloads with no ingress or egress
+  controls. Default-deny is usually a plan-first change because it can break
+  traffic.
+- `securityContext`: prefer non-root execution, read-only root filesystems
+  where compatible, dropped capabilities, `seccompProfile: RuntimeDefault`,
+  `runAsNonRoot`, and controlled `fsGroup`/`runAsUser` settings.
+- Preferred fixes: add pod/container security context without breaking write
+  paths. If the app writes to disk, preserve required writable mounts with
+  `emptyDir` or explicitly documented paths.
+
+### Helm
+
+Review `Chart.yaml`, `values.yaml`, `values*.yaml`, templates, helpers,
+NOTES.txt, schema files, and rendered output when available.
+
+- Secrets: flag values, templates, NOTES, ConfigMaps, annotations, and env vars
+  containing secret-like values. Replace with `existingSecret`, `secretKeyRef`,
+  ExternalSecret patterns already used by the repo, or required value
+  references.
+- Images: flag `latest`, mutable tags, missing digest support, and missing
+  image pull policy logic. Prefer digest support while keeping tag override
+  flexibility.
+- Exposure: flag `LoadBalancer`, `NodePort`, public ingress, wildcard hosts,
+  insecure annotations, and missing TLS controls.
+- Preferred fixes: add values such as `service.type`, `ingress.enabled`,
+  `ingress.tls`, `existingSecret`, `image.digest`, `image.tag`,
+  `securityContext`, `podSecurityContext`, `networkPolicy.enabled`, and
+  `allowPublicExposure` with safe defaults.
+
+### CI/CD
+
+Review GitHub Actions, GitLab CI, CircleCI, Buildkite, Jenkinsfile, reusable
+workflows, and shell scripts used by workflows.
+
+- Token leakage: flag echoing secrets, `set -x` near secrets, printing env,
+  uploading secret-containing artifacts, secrets in command arguments, and
+  long-lived cloud keys.
+- Event trust: flag unsafe `pull_request_target` usage and privileged workflows
+  that execute untrusted code.
+- Permissions: flag missing permission blocks, `write-all`, broad
+  `contents: write`, `id-token: write`, `packages: write`, `actions: write`,
+  and `pull-requests: write` when not needed.
+- Supply chain: flag unpinned or mutable third-party actions, curl-pipe-shell,
+  unverified downloads, and package install scripts in privileged contexts.
+- Preferred fixes: top-level `permissions: read-all` when compatible, per-job
+  overrides only when required, OIDC for cloud authentication, action pinning
+  when feasible, no untrusted script injection, and separate privileged release
+  workflows from untrusted PR workflows.
+- Do not add third-party scanners unless the repository already uses them or
+  the user approves them.
+
+### Application Baseline
+
+Review language source, dependency manifests, lockfiles, config files, tests,
+and framework routes/middleware when present.
+
+- Secrets: hardcoded credentials, tokens, API keys, private keys, passwords,
+  connection strings, env dumps, and secret-bearing logs.
+- Input validation: untrusted input reaching commands, file paths, SQL/NoSQL,
+  LDAP, templates, HTML, URLs, HTTP clients, deserialization, or dynamic code.
+- Injection: SQL, shell, template, path traversal, log injection, LDAP, XXE,
+  unsafe dynamic evaluation, and unsafe URL handling.
+- Deserialization: unsafe parsing of untrusted serialized objects, YAML,
+  pickle-like formats, Java serialization, JSON-to-object binding risks, and
+  custom parsers without validation.
+- Crypto: weak algorithms, insecure randomness for security tokens, static
+  IVs, hardcoded keys, disabled certificate validation, and custom crypto.
+- Auth: missing authorization checks, role bypasses, insecure session/cookie
+  flags, insecure defaults, and unauthenticated admin endpoints.
+- Error handling: stack traces, tokens, headers, cookies, and internal paths in
+  logs or HTTP responses.
+- Dependencies: prefer existing lockfiles and configured scanners. Do not add
+  scanners without approval.
+- Dangerous defaults: debug mode, permissive CORS, trust-all TLS, public bind
+  addresses, insecure file permissions, and unsafe temporary files.
+- Backward compatibility: do not change public APIs, auth flows,
+  serialization formats, data formats, or routes without approval.
+
+### Python
+
+- Flag `os.system`, `os.popen`, `subprocess` with `shell=True`, unsafe command
+  construction, and user-controlled command arguments.
+- Flag `eval`, `exec`, `compile`, dynamic imports, unsafe template rendering,
+  unsafe plugin loading, `pickle`, `marshal`, `shelve`, multiprocessing
+  `Connection.recv`, unsafe YAML loaders, unsafe archive extraction, and
+  `tempfile.mktemp`.
+- Flag `random` for passwords, tokens, sessions, reset links, or keys.
+- Flag SQL f-strings, string formatting, concatenation, or interpolation.
+- Flag disabled TLS verification, unverified SSL contexts, plaintext HTTP for
+  sensitive traffic, and credentials in URLs.
+- Prefer argument arrays, parameterized queries, `pathlib` validation,
+  `NamedTemporaryFile`/`mkstemp`, `secrets`, safe loaders, and redaction
+  helpers.
+- Do not replace serialization formats, database query semantics, or auth
+  behavior without approval.
+
+### Java
+
+- Flag `ObjectInputStream` on untrusted data, missing `ObjectInputFilter`,
+  custom `readObject` risks, and broad class allowlists.
+- Flag SQL string concatenation, `Runtime.exec` with untrusted input,
+  `ProcessBuilder` with shell wrappers, LDAP/JNDI injection, and unsafe
+  template rendering.
+- Flag XML parsers without secure processing or unsafe external entity
+  handling.
+- Flag insecure algorithms, weak randomness, static IVs, hardcoded keys,
+  disabled hostname verification, and trust-all certificate managers.
+- Prefer `PreparedStatement`, serialization filters, secure XML parser
+  features, `SecureRandom`, narrow command invocation, canonical path
+  validation, and secret externalization.
+- Do not change serialization compatibility, crypto protocols, or auth flows
+  without approval.
+
+### JavaScript and Node.js
+
+- Flag `child_process.exec`, `execSync`, `spawn` with `shell: true`, unsafe
+  command construction, and untrusted input in commands.
+- Flag `eval`, `new Function`, `vm` with untrusted input, dynamic
+  `require`/`import` from user input, and unsafe template rendering.
+- Flag prototype pollution via unsafe object merge, deep merge of untrusted
+  input, `__proto__`, `constructor`, and `prototype` assignment.
+- Flag path traversal, archive extraction risks, public file serving without
+  path normalization, SSRF with user-controlled URLs, unsafe `innerHTML`,
+  direct HTML injection, JWT decode without verification, weak cookie flags,
+  missing CSRF where applicable, permissive CORS, and risky regex patterns on
+  untrusted input.
+- Prefer `execFile` or `spawn` without shell, URL allowlists, path resolution
+  checks, structured validation, redacted logging, secure cookie flags, and
+  verified tokens.
+- Do not change auth middleware, token validation behavior, or public routes
+  without approval.
+
+### TypeScript
+
+- Include all JavaScript and Node.js checks.
+- Flag disabled `strict`, disabled `noImplicitAny`, disabled
+  `strictNullChecks`, broad `any` on trust boundaries, unsafe assertions, and
+  unchecked `unknown` input.
+- Flag external input trusted only because of TypeScript types. Recommend
+  runtime validation for HTTP requests, queues, config files, and environment
+  variables.
+- Flag missing guards on security-relevant values such as user identity, tenant
+  ID, role, token claims, and authorization context.
+- Prefer `unknown` at trust boundaries, explicit narrowing, staged strictness,
+  and runtime validation adapters.
+- Do not enable strict mode across a whole project automatically if it causes
+  many type errors. Produce a staged migration plan.
+
+### Rust
+
+- Flag `unsafe` blocks/functions/traits, mutable statics, raw pointer
+  dereferences, FFI boundaries, and missing safety comments.
+- Flag `Command` invoking `sh`, `bash`, `cmd`, or `powershell` with
+  user-controlled input.
+- Flag untrusted deserialization without size limits, schema validation, or
+  allowlists.
+- Flag `unwrap`, `expect`, `panic`, `unreachable`, and indexing on untrusted or
+  network-facing paths.
+- Flag path traversal, symlink-sensitive canonicalization assumptions, unsafe
+  temporary files, broad permissions, hardcoded secrets, and `Debug` output of
+  secret-bearing structs.
+- Prefer minimizing unsafe scope, adding safety comments, validating before
+  unsafe boundaries, `Command` args without shell, `Result` propagation, and
+  avoiding sensitive debug output.
+- Do not remove unsafe code automatically. Plan first unless the fix is local,
+  obvious, and validated.
+
+### Bash and Shell
+
+- Flag unquoted variables, command substitutions, globs, arrays, and paths
+  where word splitting or filename expansion is not intended.
+- Recommend `set -euo pipefail` only after checking control-flow impact.
+- Flag `eval`, unsafe `xargs`, unsafe `find -exec`, user-controlled command
+  construction, backticks, `set -x` around secrets, env dumps, credentials in
+  arguments, predictable temp paths, unsafe `rm -rf`, wildcard deletes,
+  world-writable files, unsafe `chmod`, curl-pipe-shell, unsigned downloads,
+  unqualified privileged commands, unsafe `IFS`, and exported secrets.
+- Prefer quoting, arrays, `mktemp`, cleanup traps, `command -v`, no `eval`,
+  tracing disabled around secrets, argument validation, and safe temp dirs.
+- Do not add strict mode, rewrite control flow, or change destructive
+  operations without approval.
+
+## Severity and Confidence
+
+### Severity
+
+- Critical: exposed credentials, public write access, admin CI token exposure,
+  unauthenticated admin route, remote command execution, unsafe deserialization
+  reachable from untrusted input, or privilege escalation to cluster/cloud
+  admin.
+- High: public database/admin endpoint, privileged container without clear
+  need, cluster-admin binding, wildcard IAM write permissions, shell injection,
+  SQL injection, trust-all TLS, or hardcoded production secrets.
+- Medium: missing NetworkPolicy, mutable image tags, broad read permissions,
+  missing security context controls, permissive CORS, weak crypto, missing
+  runtime validation on trust boundaries, or unsafe file path handling.
+- Low: missing documentation, weak defaults with explicit safeguards elsewhere,
+  minor compiler hardening gaps, or non-sensitive debug logging.
+- Info: improvement suggestions without direct risk.
+
+### Confidence
+
+- High: repository code clearly shows the risky path and the exploitability is
+  not dependent on unknown deployment context.
+- Medium: the risky pattern is present, but reachability, environment, or
+  compensating controls are not fully known.
+- Low: the pattern is suspicious but could be safe depending on runtime
+  configuration, generated code, or external controls.
+
+## Safe Auto-Fix Policy
+
+Safe to patch directly when the change is local, reviewable, and unlikely to
+break intended behavior:
+
+- missing compatible `securityContext` fields
+- obvious log redaction
+- unquoted Bash variables where word splitting is not intended
+- `shell=True` removal when equivalent args are clear
+- missing workflow `permissions: read-all`
+- `sensitive = true` on Terraform variables or outputs
+- non-breaking Helm values that preserve override flexibility
+
+Plan first:
+
+- public endpoint changes
+- IAM or RBAC narrowing
+- NetworkPolicy default-deny
+- TypeScript strict mode
+- Java deserialization behavior
+- crypto changes
+- auth changes
+- CORS changes
+- production service exposure
+- shell strict mode
+
+Never auto-fix without explicit approval:
+
+- credential rotation
+- git history rewriting
+- deleting resources
+- disabling features
+- changing public APIs
+- changing database schemas
+- replacing serialization protocols
+- changing auth algorithms
+- changing externally visible routes
+
+## Safe Override Policy
+
+Every intentional exception should include:
+
+- explicit opt-in variable or value
+- owner
+- reason
+- narrow scope
+- `reviewBy` date
+- visible warning in scan output
+
+Examples:
+
+- `allowPublicExposure: true`
+- `allowPrivileged: true`
+- `allowUnsafeDeserialization: true`
+- `allowShellExecution: true`
+- `allowInsecureTls: true`
+- `securityException.owner`
+- `securityException.reason`
+- `securityException.scope`
+- `securityException.reviewBy`
+
+## Production Hardening Extension
+
+- Treat public exposure as denied by default unless an explicit
+  `allowPublicExposure` or equivalent variable exists.
+- Require exceptions to include owner, reason, scope, and `reviewBy` date.
+- Separate development, staging, and production defaults when environment
+  intent is visible.
+- Add staged rollout plans for stricter TypeScript, NetworkPolicy, IAM, and
+  runtime security changes.
+- Keep a no-auto-fix list for availability, authentication, authorization,
+  crypto, data retention, and external network access.
+
+## Policy-as-Code Compatibility
+
+Phrase findings so they can later map to OPA, Conftest, Checkov, tfsec,
+Terrascan, or cloud-native policy engines:
+
+- stable finding ID
+- normalized area
+- resource/file selector
+- risk condition
+- allowed exception fields
+- remediation fields
+- severity and confidence

--- a/skills/attach-ubuntu/SKILL.md
+++ b/skills/attach-ubuntu/SKILL.md
@@ -74,3 +74,20 @@ explain the relevant command instead of running it.
   `./attach-ubuntu/scripts/attach-ubuntu.sh --stop`
 - Remove the per-project container:
   `./attach-ubuntu/scripts/attach-ubuntu.sh --remove`
+
+## Learning Loop
+
+When using this skill, capture durable, reusable, public-safe learnings back
+into this skill's local source materials before completion when the current task
+contract allows source edits. Update the narrowest appropriate surface:
+`SKILL.md` for runtime rules, `references/` for detailed guidance, `assets/`
+for reusable templates, `scripts/` for deterministic helpers, and README or
+changelog entries for human-facing or release-note updates.
+
+If the current task is explicitly read-only/report-only, or source writes are
+outside this skill's task contract, do not edit skill sources; report the
+skipped source update instead.
+
+Do not capture secrets, private URLs, customer data, raw logs, one-off local
+state, or unverified/vendor-specific claims. If a useful learning is not safe,
+not evidence-backed, or outside this skill's scope, report that it was skipped.

--- a/skills/code-info/SKILL.md
+++ b/skills/code-info/SKILL.md
@@ -107,3 +107,20 @@ Authentication behavior:
 - Keep caveats short and placed after the report.
 - Do not invent unavailable metrics. Report `Not detected` or `Unavailable`
   when the evidence is missing.
+
+## Learning Loop
+
+When using this skill, capture durable, reusable, public-safe learnings back
+into this skill's local source materials before completion when the current task
+contract allows source edits. Update the narrowest appropriate surface:
+`SKILL.md` for runtime rules, `references/` for detailed guidance, `assets/`
+for reusable templates, `scripts/` for deterministic helpers, and README or
+changelog entries for human-facing or release-note updates.
+
+If the current task is explicitly read-only/report-only, or source writes are
+outside this skill's task contract, do not edit skill sources; report the
+skipped source update instead.
+
+Do not capture secrets, private URLs, customer data, raw logs, one-off local
+state, or unverified/vendor-specific claims. If a useful learning is not safe,
+not evidence-backed, or outside this skill's scope, report that it was skipped.

--- a/skills/commit-push/SKILL.md
+++ b/skills/commit-push/SKILL.md
@@ -144,6 +144,23 @@ the workflow narrow: commit, push, verify status, and report blockers.
 - Push with upstream: `git push -u origin HEAD:<branch>`
 - Push existing upstream: `git push origin HEAD:<branch>`
 
+## Learning Loop
+
+When using this skill, capture durable, reusable, public-safe learnings back
+into this skill's local source materials before completion when the current task
+contract allows source edits. Update the narrowest appropriate surface:
+`SKILL.md` for runtime rules, `references/` for detailed guidance, `assets/`
+for reusable templates, `scripts/` for deterministic helpers, and README or
+changelog entries for human-facing or release-note updates.
+
+If the current task is explicitly read-only/report-only, or source writes are
+outside this skill's task contract, do not edit skill sources; report the
+skipped source update instead.
+
+Do not capture secrets, private URLs, customer data, raw logs, one-off local
+state, or unverified/vendor-specific claims. If a useful learning is not safe,
+not evidence-backed, or outside this skill's scope, report that it was skipped.
+
 ## Guardrails
 
 - Treat `$commit-push` plus an action request as permission to run mutating Git

--- a/skills/config-codex/README.md
+++ b/skills/config-codex/README.md
@@ -109,11 +109,26 @@ and `config-codex` are already discoverable from the installed skills
 directory, explicit `[[skills.config]]` entries are optional and should not be
 added just to match the template.
 
+The public-safe MCP baseline in `assets/config.toml.template` covers reusable
+servers such as Context7, Playwright, Terraform, MarkItDown, Microsoft Learn,
+GitHub, and OpenAI developer docs. Existing local configs may also contain
+plugin-managed or machine-specific MCP servers with absolute commands, private
+environment values, or tool-specific installers. Preserve those entries when
+patching an existing `config.toml`; do not copy their private values into this
+public skill. Restore those integrations through their owning plugin or setup
+skill.
+
 Hook scripts, custom-agent TOML files, and optional policy files are template
 assets rather than semantic patch targets. Copy them when missing. If an
 existing file byte-matches the previous template, replacing it with the current
 template is idempotent and safe. If it differs from the expected template, stop
 and show the diff instead of overwriting local customizations.
+
+`hooks.json` is a semantic merge target, not a byte-for-byte payload template.
+The required global-context `SessionStart` and `UserPromptSubmit` entries must
+be present, but additional reviewed workflow hooks, such as Agentic SDLC
+`PreToolUse` and `Stop`, should be preserved and reviewed under their owning
+workflow.
 
 ### Secrets Stay Out Of Config
 
@@ -139,16 +154,21 @@ Use skills for workflow-specific instructions.
 ```
 
 Hooks do not implement the task. They make the right context visible to Codex.
+The parent agent creates and updates the advertised task-state file when
+continuity is useful. The config template allows sandbox writes under
+`$CODEX_HOME/task-state`; any installed PreToolUse guard should allow that
+same path while continuing to protect unrelated runtime files such as
+`$CODEX_HOME/hooks`.
 If a user deliberately opts in by creating
 `$CODEX_HOME/hooks/global_context_policy.json`, the `UserPromptSubmit` hook can
 also discover configured read-only agents from `$CODEX_HOME/config.toml` and
-add a lightweight delegation hint for complex prompts. The hook injects agent
+add a lightweight delegation request for complex prompts. The hook injects agent
 names only by default, does not directly call subagent tools, and leaves
 detailed helper lifecycle rules to `global-context-management`.
 
 This global-context setup owns only the non-SDLC hook events: `SessionStart`
 for stable global context and task-state path injection, and `UserPromptSubmit`
-for lightweight prompt-time context, safety, or opt-in delegation hints.
+for lightweight prompt-time context, safety, or opt-in delegation requests.
 Workflow-specific systems such as Agentic SDLC must use separate hook events,
 for example `PreToolUse` for hard guardrails and `Stop` for bounded
 continuation.
@@ -204,9 +224,9 @@ They may not appear as separate user-visible controls in every surface. In
 current Codex surfaces, this setup makes subagent tools available but does not
 force automatic delegation; prompts that need subagents should explicitly say
 to use or spawn subagents, use delegation, or run parallel agents, unless the
-local hook policy adds a lightweight delegation hint for the prompt. For users
+local hook policy adds a lightweight delegation request for the prompt. For users
 who want hook-assisted delegation, a private local policy file can opt in to
-adding that hint for complex prompts without hardcoding agent names in the
+adding that request for complex prompts without hardcoding agent names in the
 public repo:
 
 When delegation is authorized and useful but subagent controls are not visible,
@@ -407,7 +427,22 @@ setup.
 - `assets/task-state-template.md`: initial durable task-state document.
 - `scripts/check-local-idempotency.py`: read-only preflight that checks the
   minimal no-change contract for an already configured Codex home without
-  printing config values.
+  printing config values. It checks required global hook registrations as a
+  subset so extra reviewed workflow hooks can coexist.
+
+Low-level hook file sync can use the root installer:
+
+```bash
+./install-skills.sh --install-all-hooks
+./install-skills.sh --install-hooks config-codex/assets/hooks
+```
+
+The first command syncs every reviewed hook-only bundle under the source skills
+folder. The second command syncs only this skill's hook payload templates. Both
+copy into `$CODEX_HOME/hooks` with `.template` stripped from installed file
+names. Neither updates `$CODEX_HOME/hooks.json`, trusts hooks, patches
+`config.toml`, or replaces the full `config-codex` setup workflow.
+
 - `agents/openai.yaml`: UI metadata and implicit invocation policy.
 
 ## Validation For This Skill

--- a/skills/config-codex/README.md
+++ b/skills/config-codex/README.md
@@ -162,9 +162,9 @@ same path while continuing to protect unrelated runtime files such as
 If a user deliberately opts in by creating
 `$CODEX_HOME/hooks/global_context_policy.json`, the `UserPromptSubmit` hook can
 also discover configured read-only agents from `$CODEX_HOME/config.toml` and
-add a lightweight delegation request for complex prompts. The hook injects agent
-names only by default, does not directly call subagent tools, and leaves
-detailed helper lifecycle rules to `global-context-management`.
+add a lightweight bounded delegation request for complex prompts. The hook
+injects agent names only by default, does not directly call subagent tools, and
+leaves detailed helper lifecycle rules to `global-context-management`.
 
 This global-context setup owns only the non-SDLC hook events: `SessionStart`
 for stable global context and task-state path injection, and `UserPromptSubmit`
@@ -188,7 +188,9 @@ documents.
 state path. It tells Codex when to read and update task state, how to avoid
 parent-thread noise, when to use read-only subagents if delegation is
 authorized by the prompt or a user-enabled local hook policy and the current
-runtime permits it, and how to validate and review risk.
+runtime permits it, and how to validate and review risk. Once delegation is
+authorized, Codex should choose targeted helper roles when useful; the prompt
+does not need to name a specific role.
 
 ### Custom Agents Are Read-Only Helpers
 
@@ -224,10 +226,11 @@ They may not appear as separate user-visible controls in every surface. In
 current Codex surfaces, this setup makes subagent tools available but does not
 force automatic delegation; prompts that need subagents should explicitly say
 to use or spawn subagents, use delegation, or run parallel agents, unless the
-local hook policy adds a lightweight delegation request for the prompt. For users
-who want hook-assisted delegation, a private local policy file can opt in to
-adding that request for complex prompts without hardcoding agent names in the
-public repo:
+local hook policy adds a lightweight bounded delegation request for the prompt.
+After either source authorizes delegation, Codex should choose the useful
+targeted role instead of waiting for the prompt to name one. For users who want
+hook-assisted delegation, a private local policy file can opt in to adding that
+request for complex prompts without hardcoding agent names in the public repo:
 
 When delegation is authorized and useful but subagent controls are not visible,
 and `tool_search` is available, Codex should search for multi-agent/subagent

--- a/skills/config-codex/README.md
+++ b/skills/config-codex/README.md
@@ -132,18 +132,35 @@ The hook layer injects durable context before Codex starts work:
 ```text
 Here is the workspace root.
 Here is the task-state path.
-Create task state automatically only for complex prompts.
-Read current task state when it already exists and prior context may matter.
-Use global-context-management for complex work.
-Keep the parent thread concise.
+Do not create task state automatically.
+Read existing task state when prior context may matter.
+Keep raw logs and broad exploration output out of task state.
+Use skills for workflow-specific instructions.
 ```
 
 Hooks do not implement the task. They make the right context visible to Codex.
 If a user deliberately opts in by creating
 `$CODEX_HOME/hooks/global_context_policy.json`, the `UserPromptSubmit` hook can
 also discover configured read-only agents from `$CODEX_HOME/config.toml` and
-inject a request to use them for complex prompts. The hook injects agent names
-only by default and does not directly call subagent tools.
+add a lightweight delegation hint for complex prompts. The hook injects agent
+names only by default, does not directly call subagent tools, and leaves
+detailed helper lifecycle rules to `global-context-management`.
+
+This global-context setup owns only the non-SDLC hook events: `SessionStart`
+for stable global context and task-state path injection, and `UserPromptSubmit`
+for lightweight prompt-time context, safety, or opt-in delegation hints.
+Workflow-specific systems such as Agentic SDLC must use separate hook events,
+for example `PreToolUse` for hard guardrails and `Stop` for bounded
+continuation.
+
+Use `SessionStart` for global conventions, workspace context, environment
+notes, coding standards, and stable task-state path hints. Do not use it to
+select SDLC phases, modify run state, or inject large documents.
+
+Use `UserPromptSubmit` only for small global reminders, prompt safety, and
+lightweight context hints. Do not use it to route `sdlc-start`, parse
+requirements, select workflow skills, create run state, or inject large
+documents.
 
 ### Skills Provide Workflow
 
@@ -187,10 +204,10 @@ They may not appear as separate user-visible controls in every surface. In
 current Codex surfaces, this setup makes subagent tools available but does not
 force automatic delegation; prompts that need subagents should explicitly say
 to use or spawn subagents, use delegation, or run parallel agents, unless the
-local hook policy injects that request for the prompt. For users who want
-hook-assisted delegation, a private local policy file can opt in to injecting
-that request for complex prompts without hardcoding agent names in the public
-repo:
+local hook policy adds a lightweight delegation hint for the prompt. For users
+who want hook-assisted delegation, a private local policy file can opt in to
+adding that hint for complex prompts without hardcoding agent names in the
+public repo:
 
 When delegation is authorized and useful but subagent controls are not visible,
 and `tool_search` is available, Codex should search for multi-agent/subagent
@@ -323,8 +340,9 @@ setup.
    /hooks
    ```
 
-   Review the two local hook commands. They should resolve to the local hook
-   scripts, either directly or through `${CODEX_HOME:-$HOME/.codex}`:
+   Review the two global-context hook commands. They should resolve to the
+   local hook scripts, either directly or through
+   `${CODEX_HOME:-$HOME/.codex}`:
 
    ```text
    $CODEX_HOME/hooks/session_start_context.py
@@ -332,7 +350,8 @@ setup.
    ```
 
    Trust or enable the hooks only after the resolved paths are local and
-   expected.
+   expected. If other workflows add their own hooks, review those separately
+   and keep their event ownership distinct.
 
 10. Run a non-mutating probe:
 
@@ -360,16 +379,16 @@ setup.
    tools before reporting delegation unavailable.
 
    Direct hook unit probes against a live `$CODEX_HOME` with synthetic
-   `session_id` values create scaffold-only task-state directories named after
-   those IDs. They prove the hook path calculation, but they are not active
-   persistent model state unless an agent later reads and updates that exact
-   path. Prefer `global-context-management/scripts/validate-local-templates.py`
-   for hook-unit validation because it uses disposable temporary homes and
-   checks that `SessionStart` does not create missing scaffold files, an
-   existing nonempty `current.md` is preserved for the agent to read instead of
-   being overwritten or injected into hook context, and loose task-state file
-   permissions are repaired on reuse. No manual or legacy task-state path is
-   created when a hook payload lacks `session_id`.
+   `session_id` values should not create task-state files or directories. They
+   prove hook path calculation and prompt-time hints, not active persistent
+   model state. Prefer
+   `global-context-management/scripts/validate-local-templates.py` for
+   hook-unit validation because it uses disposable temporary homes and checks
+   that `SessionStart` and `UserPromptSubmit` do not create missing scaffold
+   files, an existing nonempty `current.md` is preserved for the agent to read
+   instead of being overwritten or injected into hook context, and loose
+   task-state file permissions are repaired on reuse. No manual or legacy
+   task-state path is created when a hook payload lacks `session_id`.
 
 ## File Responsibilities
 

--- a/skills/config-codex/SKILL.md
+++ b/skills/config-codex/SKILL.md
@@ -120,8 +120,10 @@ For existing `$CODEX_HOME/config.toml`:
    skill entries if discovery already works.
 10. Validate local hook scripts, TOML, JSON, feature flags, idempotency, and
    secret hygiene.
-11. Tell the user to restart Codex, open `/hooks`, review the two local hooks,
-   and trust them only after confirming the paths are expected.
+11. Tell the user to restart Codex, open `/hooks`, review the two
+    global-context hooks, and trust them only after confirming the paths are
+    expected. If other workflows add their own hooks, review those separately
+    and keep event ownership distinct.
 
 ## Template Rules
 
@@ -201,3 +203,18 @@ Return:
 - how to restart Codex and trust hooks
 - whether optional hook-assisted read-only subagent delegation was enabled
 - any remaining risk or unverified runtime behavior
+
+## Hook Event Boundary
+
+This skill's global-context setup owns only `SessionStart` and
+`UserPromptSubmit`.
+
+- `SessionStart`: use for global conventions, workspace context, environment
+  notes, coding standards, and stable task-state path hints. Do not select
+  SDLC phases, modify run state, or inject large documents.
+- `UserPromptSubmit`: use only for small global reminders, prompt safety, and
+  lightweight context hints. Do not route `sdlc-start`, parse requirements,
+  select workflow skills, create run state, or inject large documents.
+
+Workflow-specific guardrails such as Agentic SDLC must use separate event
+hooks, for example `PreToolUse` and `Stop`.

--- a/skills/config-codex/SKILL.md
+++ b/skills/config-codex/SKILL.md
@@ -196,7 +196,10 @@ search for multi-agent/subagent tools before reporting delegation unavailable.
 If a local hook policy is enabled, verify it in a fresh trusted-hook session
 before claiming hook-assisted delegation works. Do not claim that hooks,
 skills, `multi_agent`, or `[agents.*]` config force automatic delegation; they
-only make delegation possible when the runtime policy allows it.
+only make delegation possible when the runtime policy allows it. After a prompt
+or local hook policy request authorizes delegation, the fresh session may choose
+targeted read-only helper roles itself; the prompt does not need to name the
+exact role.
 
 ## References
 

--- a/skills/config-codex/SKILL.md
+++ b/skills/config-codex/SKILL.md
@@ -140,6 +140,23 @@ rendered files. Treat full-file templates as source material for missing files;
 for existing `AGENTS.md` and `config.toml`, extract and patch only the missing
 sections or keys.
 
+## Learning Loop
+
+When using this skill, capture durable, reusable, public-safe learnings back
+into this skill's local source materials before completion when the current task
+contract allows source edits. Update the narrowest appropriate surface:
+`SKILL.md` for runtime rules, `references/` for detailed guidance, `assets/`
+for reusable templates, `scripts/` for deterministic helpers, and README or
+changelog entries for human-facing or release-note updates.
+
+If the current task is explicitly read-only/report-only, or source writes are
+outside this skill's task contract, do not edit skill sources; report the
+skipped source update instead.
+
+Do not capture secrets, private URLs, customer data, raw logs, one-off local
+state, or unverified/vendor-specific claims. If a useful learning is not safe,
+not evidence-backed, or outside this skill's scope, report that it was skipped.
+
 ## Validation
 
 Use the focused checks in `references/local-setup.md`. At minimum:

--- a/skills/config-codex/SKILL.md
+++ b/skills/config-codex/SKILL.md
@@ -112,9 +112,19 @@ For existing `$CODEX_HOME/config.toml`:
    - optional hook policy template
    - custom-agent TOML templates
    - task-state template
-   For hook and custom-agent assets, use replace-if-unmodified behavior:
+   For hook scripts, custom-agent assets, and optional policy assets, use
+   replace-if-unmodified behavior:
    copy missing files, leave matching files unchanged, and stop for review when
    an existing file differs from both the old and new expected content.
+   For `hooks.json`, verify the required global `SessionStart` and
+   `UserPromptSubmit` entries are present, but preserve additional workflow hook
+   entries such as SDLC `PreToolUse` and `Stop`.
+   The root `install-skills.sh --install-all-hooks` helper can perform a
+   direct sync of all reviewed hook-only bundles when that is explicitly
+   needed. Use `install-skills.sh --install-hooks config-codex/assets/hooks`
+   only for a single-bundle sync. Both paths strip `.template` from installed
+   hook file names, and neither path patches `hooks.json`, trusts hooks, patches
+   `config.toml`, or replaces this full setup workflow.
 9. Confirm `global-context-management` and `config-codex` are installed,
    discoverable, or explicitly enabled as skill folders. Do not add explicit
    skill entries if discovery already works.
@@ -164,7 +174,9 @@ not evidence-backed, or outside this skill's scope, report that it was skipped.
 Use the focused checks in `references/local-setup.md`. At minimum:
 
 - Run `python3 scripts/check-local-idempotency.py --strict-agents-template` for
-  a laptop already expected to match these templates. This script is read-only.
+  a laptop already expected to match the canonical global `AGENTS.md` template.
+  This script is read-only and allows extra reviewed hook registrations in
+  `hooks.json` when the required global hooks are present.
 - Python-compile hook scripts.
 - Parse `config.toml` with `tomllib`.
 - Parse `hooks.json` with `json`.

--- a/skills/config-codex/assets/AGENTS.md.template
+++ b/skills/config-codex/assets/AGENTS.md.template
@@ -39,10 +39,6 @@
 - For non-trivial planning, implementation, debugging, refactoring, migration,
   architecture, review, testing, CI failure, or multi-file coding tasks, use
   `global-context-management`.
-- For Codex runtime setup, config, hooks, custom agents, or `$CODEX_HOME`
-  layout work, use `config-codex`.
-- For `.gitignore`, shell/Bash automation, or Shell/Markdown/Python linting
-  work, use the matching `gitignore`, `shell-scripting`, and/or `linter` skill.
 - When skill guidance or reference code depends on a product, cloud, API, CLI,
   SDK, framework, or package manager, verify version-sensitive behavior against
   current official vendor documentation before changing or recommending it.
@@ -66,9 +62,9 @@
   the parent thread.
 - Use bounded read-only subagents for noisy exploration when the user
   explicitly requests delegation, or when a user-enabled local hook policy
-  adds a lightweight delegation hint, and subagents are available and
-  permitted. Ask helpers for concise summaries, consolidate results, and close
-  completed helpers when close controls are available.
+  injects that request, and subagents are available and permitted. Ask helpers
+  for concise summaries, consolidate results, and close completed helpers when
+  close controls are available.
 - After making code changes in a turn, before the final response, explicitly
   use `$align` for the changed scope unless the user says not to. If `$align`
   is unavailable, perform the equivalent local alignment checklist and say so.

--- a/skills/config-codex/assets/AGENTS.md.template
+++ b/skills/config-codex/assets/AGENTS.md.template
@@ -62,9 +62,11 @@
   the parent thread.
 - Use bounded read-only subagents for noisy exploration when the user
   explicitly requests delegation, or when a user-enabled local hook policy
-  injects that request, and subagents are available and permitted. Ask helpers
-  for concise summaries, consolidate results, and close completed helpers when
-  close controls are available.
+  injects that request, and subagents are useful, available, and permitted.
+  After authorization, choose targeted helper roles yourself instead of waiting
+  for the user to name an exact role. Ask helpers for concise summaries,
+  consolidate results, and close completed helpers when close controls are
+  available.
 - After making code changes in a turn, before the final response, explicitly
   use `$align` for the changed scope unless the user says not to. If `$align`
   is unavailable, perform the equivalent local alignment checklist and say so.

--- a/skills/config-codex/assets/AGENTS.md.template
+++ b/skills/config-codex/assets/AGENTS.md.template
@@ -66,9 +66,9 @@
   the parent thread.
 - Use bounded read-only subagents for noisy exploration when the user
   explicitly requests delegation, or when a user-enabled local hook policy
-  injects that request, and subagents are available and permitted. Ask helpers
-  for concise summaries, consolidate results, and close completed helpers when
-  close controls are available.
+  adds a lightweight delegation hint, and subagents are available and
+  permitted. Ask helpers for concise summaries, consolidate results, and close
+  completed helpers when close controls are available.
 - After making code changes in a turn, before the final response, explicitly
   use `$align` for the changed scope unless the user says not to. If `$align`
   is unavailable, perform the equivalent local alignment checklist and say so.

--- a/skills/config-codex/assets/hooks/session_start_context.py.template
+++ b/skills/config-codex/assets/hooks/session_start_context.py.template
@@ -95,45 +95,17 @@ without creating a manual fallback path or repo-local state file.
     else:
         task_state_context = f"""Durable task-state file: `{state_file}`
 
-SessionStart only advertises this path; it does not create a scaffold file for
-every session. For complex prompts, the prompt hook creates or reuses this file
-automatically. If the file already exists, read it at the start of complex work
-when it may contain prior decisions, validation status, or next action. Use it
-instead of creating repo-local state files.
+SessionStart only advertises this path; it does not create task-state, SDLC run
+state, or workflow state. If the file already exists, read it when prior
+decisions may matter.
 """
 
-    context = f"""Global context management is enabled.
+    context = f"""Global context is available.
 
 Workspace root: `{root}`
 {task_state_context}
-
-For non-trivial planning, implementation, debugging, refactoring, migration,
-architecture, review, testing, CI failure, or multi-file work, apply the
-`global-context-management` skill.
-
-Use bounded read-only subagents when delegation is authorized by the user
-prompt or by a user-enabled local hook policy, when they are useful, the
-current runtime exposes subagent tools, and the current instructions permit
-delegation. When hook-assisted delegation is enabled, the prompt hook
-discovers configured read-only subagent roles from the local Codex config and
-requests them by configured name.
-
-If delegation was not authorized by the prompt or local hook policy, or
-subagents are unavailable or not permitted, continue with narrow local reads and
-state that limitation.
-If delegation is authorized and useful but subagent controls are not visible,
-and `tool_search` is available, first search for multi-agent/subagent tools
-before reporting delegation unavailable.
-
-When subagents are used, ask them for concise final summaries, wait for their
-results, consolidate them in the parent thread, and close completed subagent
-threads when close controls are available and no follow-up is needed.
-With multiple subagents, close each completed handle as its terminal result
-arrives, then continue waiting on the remaining handles.
-
-Keep the parent thread concise and update the task-state file before
-implementation, after major edits, after tests, before compaction, and before
-the final response.
+Keep raw logs, secrets, and broad exploration output out of durable task state.
+Use project skills for workflow-specific instructions.
 """
 
     print(

--- a/skills/config-codex/assets/hooks/user_prompt_context.py.template
+++ b/skills/config-codex/assets/hooks/user_prompt_context.py.template
@@ -274,7 +274,7 @@ def subagent_context(home: Path) -> str:
     review: list[str] = []
     lines = [
         "",
-        "Local policy permits read-only subagent delegation for this prompt.",
+        "Local policy requests bounded read-only subagent delegation for this prompt when useful.",
         "Available read-only roles:",
     ]
     for agent in agents:
@@ -299,8 +299,8 @@ def subagent_context(home: Path) -> str:
     if role_hint_parts:
         lines.append("Suggested role timing: " + "; ".join(role_hint_parts) + ".")
     lines.append(
-        "Use only targeted roles when useful, available, and permitted; do not "
-        "spawn every role by default."
+        "Use targeted roles when useful, available, and permitted; do not spawn "
+        "every role by default."
     )
     return "\n".join(lines) + "\n"
 
@@ -337,8 +337,8 @@ creating a manual fallback path or repo-local state file.
 
 {task_state_context}
 Keep raw exploration output out of the parent context. Use configured read-only
-subagents only when delegation is authorized by the user prompt or local hook
-policy, the runtime exposes subagent tools, and active instructions permit it.
+subagents when delegation is authorized by the user prompt or local hook policy,
+the runtime exposes subagent tools, and active instructions permit it.
 This hook does not route SDLC phases, parse requirements, select workflow
 skills, create run state, or inject large documents.
 {subagent_context(home)}"""

--- a/skills/config-codex/assets/hooks/user_prompt_context.py.template
+++ b/skills/config-codex/assets/hooks/user_prompt_context.py.template
@@ -53,32 +53,6 @@ COMPLEX_KEYWORDS = (
     "root-cause",
 )
 
-STATE_TEMPLATE = """# Current Codex task state
-
-## Workspace
-
-- Root: `{root}`
-
-## Objective
-
-## Constraints
-
-## Current plan
-
-## Decisions made
-
-## Relevant files and symbols
-
-## Commands run
-
-## Test status
-
-## Risks
-
-## Next action
-"""
-
-
 def read_payload() -> dict:
     try:
         return json.load(sys.stdin)
@@ -140,15 +114,13 @@ def state_file_for_payload(root: str, payload: dict) -> Path | None:
         / f"{workspace_name}-{workspace_hash}"
         / session_segment
     )
-    state_dir.mkdir(parents=True, exist_ok=True)
-    chmod_private(home / "task-state", 0o700)
-    chmod_private(state_dir.parent, 0o700)
-    chmod_private(state_dir, 0o700)
 
     state_file = state_dir / "current.md"
-    if not state_file.exists():
-        state_file.write_text(STATE_TEMPLATE.format(root=root), encoding="utf-8")
-    chmod_private(state_file, 0o600)
+    if state_file.exists():
+        chmod_private(home / "task-state", 0o700)
+        chmod_private(state_dir.parent, 0o700)
+        chmod_private(state_dir, 0o700)
+        chmod_private(state_file, 0o600)
 
     return state_file
 
@@ -302,11 +274,8 @@ def subagent_context(home: Path) -> str:
     review: list[str] = []
     lines = [
         "",
-        "Hook-assisted read-only subagent delegation is enabled by local policy.",
-        "This hook output is the local-policy delegation request for this turn;",
-        "do not wait for another manual user request before using useful,",
-        "available, and permitted read-only helpers.",
-        "Configured read-only agent roles discovered from `$CODEX_HOME/config.toml`:",
+        "Local policy permits read-only subagent delegation for this prompt.",
+        "Available read-only roles:",
     ]
     for agent in agents:
         name = agent["name"]
@@ -320,50 +289,18 @@ def subagent_context(home: Path) -> str:
         else:
             exploration_or_planning.append(name)
 
-    lines.extend(
-        [
-            "",
-            "For complex tasks that touch many files or require noisy exploration,",
-            "use configured read-only roles when they are useful, the current",
-            "runtime exposes subagent tools, and active instructions permit",
-            "delegation. Do not spawn every configured role by default.",
-        ]
-    )
+    role_hint_parts = []
     if exploration_or_planning:
-        lines.append(
-            "Use these read-only exploration/planning roles early, preferably in "
-            f"parallel only when their work is independent and useful: "
-            f"{format_agent_names(exploration_or_planning)}."
+        role_hint_parts.append(
+            "exploration/planning: " + format_agent_names(exploration_or_planning)
         )
     if review:
-        lines.append(
-            "Use these read-only review roles near the end for non-trivial or "
-            f"risky changes: {format_agent_names(review)}."
-        )
+        role_hint_parts.append("review: " + format_agent_names(review))
+    if role_hint_parts:
+        lines.append("Suggested role timing: " + "; ".join(role_hint_parts) + ".")
     lines.append(
-        "For every subagent you spawn, request a concise final summary, wait "
-        "for the result, consolidate it in the parent thread, and close the "
-        "completed subagent thread when close controls are available and no "
-        "follow-up is needed."
-    )
-    lines.append(
-        "When multiple subagents are running, close each completed handle as "
-        "its terminal result arrives, then continue waiting on the remaining "
-        "handles until all spawned subagents are closed."
-    )
-    lines.append(
-        "Treat both `wait_agent` completions and asynchronous subagent "
-        "completion notifications as terminal results that should be "
-        "consolidated and closed."
-    )
-    lines.append(
-        "Keep subagent requests bounded and read-only. If spawning is unavailable "
-        "or denied, continue locally with narrow reads and state that limitation."
-    )
-    lines.append(
-        "If delegation is authorized and useful but subagent controls are not "
-        "visible, and `tool_search` is available, first search for "
-        "multi-agent/subagent tools before reporting delegation unavailable."
+        "Use only targeted roles when useful, available, and permitted; do not "
+        "spawn every role by default."
     )
     return "\n".join(lines) + "\n"
 
@@ -385,25 +322,25 @@ No session-scoped task-state path is available for this prompt. Continue without
 creating a manual fallback path or repo-local state file.
 """
     else:
+        state_note = (
+            "An existing task-state file is available; read it when this prompt "
+            "is a continuation or prior decisions may matter."
+            if state_file.exists()
+            else "This hook only advertises the path; it does not create task-state, SDLC run state, or workflow state."
+        )
         task_state_context = f"""Durable task-state file: `{state_file}`
 
-Read the task-state file first when this prompt is a continuation or prior
-decisions may matter.
+{state_note}
 """
 
-    context = f"""This prompt should use global context management.
+    context = f"""Global context hint for a complex prompt.
 
 {task_state_context}
-Apply the `global-context-management` skill. Keep raw
-exploration output out of the parent context. Use configured read-only
-subagents for read-heavy exploration when delegation is authorized by the user
-prompt or by a user-enabled local hook policy, when they are useful, the
-current runtime exposes subagent tools, and the current instructions permit
-delegation. If delegation was not authorized by the prompt or local hook
-policy, or subagents are unavailable or not permitted, continue with narrow
-local reads and state that limitation. Use read-only review agents before
-finalizing non-trivial code changes only when delegation is authorized,
-available, and permitted.
+Keep raw exploration output out of the parent context. Use configured read-only
+subagents only when delegation is authorized by the user prompt or local hook
+policy, the runtime exposes subagent tools, and active instructions permit it.
+This hook does not route SDLC phases, parse requirements, select workflow
+skills, create run state, or inject large documents.
 {subagent_context(home)}"""
 
     print(

--- a/skills/config-codex/references/local-setup.md
+++ b/skills/config-codex/references/local-setup.md
@@ -109,6 +109,12 @@ The `hooks.json` template intentionally uses
 `${CODEX_HOME:-$HOME/.codex}` directly, so the hook commands stay portable when
 the user sets `CODEX_HOME` in the shell before starting Codex.
 
+Treat `hooks.json` as a semantic merge target on existing machines. Ensure the
+global-context `SessionStart` and `UserPromptSubmit` entries from the template
+are present, but preserve additional reviewed workflow entries such as Agentic
+SDLC `PreToolUse` and `Stop` hooks. Do not replace `hooks.json` just to match
+the template byte-for-byte.
+
 If `$CODEX_HOME/AGENTS.md` is missing, create it from
 `assets/AGENTS.md.template`. If it exists, do not replace it. Append or update a
 small managed section for `config-codex`/`global-context-management` guidance
@@ -142,6 +148,13 @@ Do not silently relax approval or sandbox settings.
 Do not add template-only model defaults, app/plugin settings, MCP servers,
 project entries, skill entries, or writable roots to an existing config merely
 because they appear in `assets/config.toml.template`.
+
+For a missing config, the public-safe MCP baseline in the template restores the
+reusable MCP servers that can be expressed without private values. Existing
+configs may also contain plugin-managed or machine-specific MCP servers with
+absolute commands or private environment values. Preserve those entries during
+patching, but restore them through their owning plugin or setup skill rather
+than copying local values into public templates.
 
 ## Optional Hook-Assisted Subagent Policy
 
@@ -197,6 +210,9 @@ python3 config-codex/scripts/check-local-idempotency.py \
   --codex-home "$CODEX_HOME" \
   --strict-agents-template
 ```
+
+The preflight checks the required global hook registrations as a subset and
+allows extra reviewed workflow hooks to coexist in `hooks.json`.
 
 Compile hooks:
 
@@ -309,6 +325,10 @@ Expected evidence:
   context may matter, then keep checkpoint updates concise.
   If the optional policy is enabled, it should also mention the discovered
   configured read-only agents by name.
+- Sandbox configuration and any installed PreToolUse write guard allow
+  `$CODEX_HOME/task-state` so the parent agent can create and update the
+  advertised `current.md`, while broader runtime paths such as
+  `$CODEX_HOME/hooks` remain protected unless deliberately synced.
 
 Direct hook unit probes against a live `$CODEX_HOME` with synthetic
 `session_id` values should not create task-state files or directories. They

--- a/skills/config-codex/references/local-setup.md
+++ b/skills/config-codex/references/local-setup.md
@@ -145,7 +145,7 @@ because they appear in `assets/config.toml.template`.
 
 ## Optional Hook-Assisted Subagent Policy
 
-To have the `UserPromptSubmit` hook inject a request to use configured
+To have the `UserPromptSubmit` hook add a lightweight hint about configured
 read-only subagents for complex prompts, create this local-only file:
 
 ```json
@@ -160,9 +160,9 @@ do not hardcode agent names for this path. The hook reads `$CODEX_HOME/config.to
 discovers `[agents.<name>]` entries whose referenced config files have
 `sandbox_mode = "read-only"`, and injects those agent names into model-visible
 context. It does not inject local agent config paths, and it does not directly
-call the subagent tool. The injected request is the local-policy delegation
-request for that turn, so the main agent should not wait for another manual
-prompt phrase before using useful, available, and permitted read-only helpers.
+call the subagent tool. The hint is local-policy context for that turn, so the
+main agent still uses read-only helpers only when useful, available, and
+permitted.
 The parent agent still owns lifecycle cleanup: wait for returned summaries,
 consolidate them, and close completed subagent threads when close controls are
 available and no follow-up is needed.
@@ -311,9 +311,9 @@ Expected evidence:
   configured read-only agents by name.
 
 Direct hook unit probes against a live `$CODEX_HOME` with synthetic
-`session_id` values can create scaffold-only task-state directories named after
-those IDs when they exercise the complex-prompt hook. They validate hook path
-calculation, not active persistent model state. Prefer
+`session_id` values should not create task-state files or directories. They
+validate hook path calculation and prompt-time hints, not active persistent
+model state. Prefer
 `global-context-management/scripts/validate-local-templates.py` for hook-unit
 validation because it uses disposable temporary homes. If a hook payload has no
 `session_id`, task state is unavailable and no manual or legacy fallback path is

--- a/skills/config-codex/references/local-setup.md
+++ b/skills/config-codex/references/local-setup.md
@@ -169,13 +169,14 @@ read-only subagents for complex prompts, create this local-only file:
 ```
 
 Save it as `$CODEX_HOME/hooks/global_context_policy.json`. The public templates
-do not hardcode agent names for this path. The hook reads `$CODEX_HOME/config.toml`,
-discovers `[agents.<name>]` entries whose referenced config files have
-`sandbox_mode = "read-only"`, and injects those agent names into model-visible
-context. It does not inject local agent config paths, and it does not directly
-call the subagent tool. The hint is local-policy context for that turn, so the
-main agent still uses read-only helpers only when useful, available, and
-permitted.
+do not hardcode agent names for this path. The hook reads
+`$CODEX_HOME/config.toml`, discovers `[agents.<name>]` entries whose referenced
+config files have `sandbox_mode = "read-only"`, and injects those agent names
+into model-visible context as a bounded read-only delegation request. It does
+not inject local agent config paths, and it does not directly call the subagent
+tool. The hint is local-policy context for that turn, so the main agent still
+uses targeted read-only helpers only when useful, available, and permitted.
+After authorization, the prompt does not need to name a specific helper role.
 The parent agent still owns lifecycle cleanup: wait for returned summaries,
 consolidate them, and close completed subagent threads when close controls are
 available and no follow-up is needed.
@@ -350,7 +351,9 @@ If that succeeds but ordinary complex prompts do not spawn subagents, the
 configuration is working; the remaining gate is delegation authorization. A
 prompt can explicitly ask for subagents, delegation, or parallel agents, and
 the optional local hook policy can inject that request for complex prompts
-after it is enabled and trusted in a fresh session.
+after it is enabled and trusted in a fresh session. Once authorization is
+present, Codex may choose useful targeted roles itself; the prompt does not
+need to name the exact role.
 
 If the explicit probe does not see subagent controls but `tool_search` is
 available, the agent should search for multi-agent/subagent tools before

--- a/skills/config-codex/scripts/check-local-idempotency.py
+++ b/skills/config-codex/scripts/check-local-idempotency.py
@@ -3,8 +3,8 @@
 
 The check intentionally validates the minimal config-codex contract instead of
 diffing config.toml against the public template. Existing local config files
-often contain app, plugin, project, hook-trust, desktop, or MCP settings that
-must be preserved and are not part of this skill's convergence target.
+often contain app, plugin, project, hook-trust, desktop, or extra MCP settings
+that must be preserved and are not part of this skill's convergence target.
 """
 
 from __future__ import annotations
@@ -22,7 +22,6 @@ REQUIRED_AGENT_NAMES = ("repo_mapper", "test_strategist", "risk_reviewer")
 MANAGED_BEGIN = "<!-- BEGIN config-codex managed context -->"
 MANAGED_END = "<!-- END config-codex managed context -->"
 TEMPLATE_ASSETS = {
-    "hooks.json": "hooks.json.template",
     "hooks/session_start_context.py": "hooks/session_start_context.py.template",
     "hooks/user_prompt_context.py": "hooks/user_prompt_context.py.template",
     "agents/repo_mapper.toml": "agents/repo_mapper.toml.template",
@@ -79,6 +78,21 @@ def load_toml(path: Path, label: str, failures: list[str]) -> dict:
     return {}
 
 
+def load_json(path: Path, label: str, failures: list[str]) -> dict:
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        fail(f"{label} is missing", failures)
+        return {}
+    except json.JSONDecodeError as exc:
+        fail(f"{label} is not valid JSON: {exc}", failures)
+        return {}
+    if isinstance(data, dict):
+        return data
+    fail(f"{label} must contain a JSON object", failures)
+    return {}
+
+
 def check_agents_md(codex_home: Path, strict: bool, failures: list[str]) -> None:
     agents_path = codex_home / "AGENTS.md"
     template_path = skill_root() / "assets" / "AGENTS.md.template"
@@ -105,6 +119,11 @@ def check_config_toml(codex_home: Path, failures: list[str]) -> None:
     config = load_toml(config_path, "config.toml", failures)
     if not config:
         return
+    template = load_toml(
+        skill_root() / "assets" / "config.toml.template",
+        "config.toml.template",
+        failures,
+    )
 
     features = config.get("features", {})
     for key in ("hooks", "multi_agent"):
@@ -146,6 +165,29 @@ def check_config_toml(codex_home: Path, failures: list[str]) -> None:
         else:
             fail(f"agents.{name} is not read-only", failures)
 
+    check_required_mcp_servers(config, template, failures)
+
+
+def check_required_mcp_servers(config: dict, template: dict, failures: list[str]) -> None:
+    required = template.get("mcp_servers", {})
+    actual = config.get("mcp_servers", {})
+    if not isinstance(required, dict) or not required:
+        fail("config.toml.template has no required MCP server definitions", failures)
+        return
+    if not isinstance(actual, dict):
+        fail("config.toml mcp_servers table is missing", failures)
+        return
+
+    for name, expected_spec in sorted(required.items()):
+        actual_spec = actual.get(name)
+        if not isinstance(actual_spec, dict):
+            fail(f"mcp_servers.{name} is missing", failures)
+            continue
+        if actual_spec == expected_spec:
+            ok(f"mcp_servers.{name} matches template")
+        else:
+            fail(f"mcp_servers.{name} differs from template and needs review", failures)
+
 
 def check_template_asset(relative: str, template_relative: str, codex_home: Path, failures: list[str]) -> None:
     actual_path = codex_home / relative
@@ -170,14 +212,7 @@ def check_runtime_files(codex_home: Path, failures: list[str]) -> None:
     for relative, template_relative in TEMPLATE_ASSETS.items():
         check_template_asset(relative, template_relative, codex_home, failures)
 
-    hooks_json = codex_home / "hooks.json"
-    try:
-        json.loads(hooks_json.read_text(encoding="utf-8"))
-        ok("hooks.json is valid JSON")
-    except FileNotFoundError:
-        fail("hooks.json is missing", failures)
-    except json.JSONDecodeError as exc:
-        fail(f"hooks.json is not valid JSON: {exc}", failures)
+    check_hooks_json(codex_home, failures)
 
     task_state = codex_home / "task-state"
     if not task_state.is_dir():
@@ -191,11 +226,45 @@ def check_runtime_files(codex_home: Path, failures: list[str]) -> None:
 
     policy = codex_home / "hooks/global_context_policy.json"
     if policy.exists():
-        try:
-            json.loads(policy.read_text(encoding="utf-8"))
+        if load_json(policy, "global_context_policy.json", failures):
             ok("optional global_context_policy.json is valid JSON")
-        except json.JSONDecodeError as exc:
-            fail(f"global_context_policy.json is not valid JSON: {exc}", failures)
+
+
+def check_hooks_json(codex_home: Path, failures: list[str]) -> None:
+    actual = load_json(codex_home / "hooks.json", "hooks.json", failures)
+    if not actual:
+        return
+    expected = load_json(
+        skill_root() / "assets" / "hooks.json.template",
+        "hooks.json.template",
+        failures,
+    )
+    if not expected:
+        return
+    ok("hooks.json is valid JSON")
+
+    actual_hooks = actual.get("hooks")
+    expected_hooks = expected.get("hooks")
+    if not isinstance(actual_hooks, dict):
+        fail("hooks.json hooks table is missing", failures)
+        return
+    if not isinstance(expected_hooks, dict):
+        fail("hooks.json.template hooks table is missing", failures)
+        return
+
+    for event_name, expected_entries in sorted(expected_hooks.items()):
+        actual_entries = actual_hooks.get(event_name)
+        if not isinstance(expected_entries, list) or not expected_entries:
+            fail(f"hooks.json.template {event_name} entries are invalid", failures)
+            continue
+        if not isinstance(actual_entries, list):
+            fail(f"hooks.json missing required {event_name} hook registration", failures)
+            continue
+        for expected_entry in expected_entries:
+            if expected_entry in actual_entries:
+                ok(f"hooks.json includes required {event_name} hook registration")
+            else:
+                fail(f"hooks.json missing required {event_name} hook registration", failures)
 
 
 def main(argv: list[str]) -> int:

--- a/skills/create-pr/README.md
+++ b/skills/create-pr/README.md
@@ -15,6 +15,10 @@ and GitHub steps.
   failures before presenting PR creation as handled.
 - Opens or reuses GitHub pull requests.
 - Preserves explicit user-supplied PR titles and bodies.
+- When invoked from Agentic SDLC, checks local UAT evidence and summarizes
+  requirements, features, validation, tests, evaluation, and UAT in the PR body.
+- When Agentic SDLC local state is available, records the PR URL and readiness
+  summary in run evidence.
 - Reports PR URLs, readiness, and merge order for multi-branch work.
 
 ## Architecture
@@ -55,9 +59,11 @@ Report PR number, URL, and blockers
 5. Run focused validation and repair safe branch-owned failures.
 6. Push the branch.
 7. Open or reuse the PR with the requested title and body.
-8. Keep repairing available branch-caused check failures when safe, or mark a
+8. For Agentic SDLC runs, include available SDLC evidence and use a draft PR
+   for explicitly requested early PRs when UAT is missing or failed.
+9. Keep repairing available branch-caused check failures when safe, or mark a
    real blocker.
-9. Return PR details, validation state, and remaining blockers.
+10. Return PR details, validation state, and remaining blockers.
 
 ## Core Concepts
 

--- a/skills/create-pr/SKILL.md
+++ b/skills/create-pr/SKILL.md
@@ -31,6 +31,9 @@ branch, and report the order the user should merge the PRs manually.
 - Honoring an explicit user-provided PR title or body instead of inventing one.
 - Returning PR numbers, URLs, readiness state, and merge order so the user can
   review or merge manually.
+- In an Agentic SDLC run, creating or reusing the PR only after `sdlc-uat-tests`
+  evidence says the product is ready for PR creation, unless the user
+  explicitly requests an early draft PR.
 
 ## Requirements
 
@@ -69,6 +72,8 @@ branch, and report the order the user should merge the PRs manually.
    - whether the current branch already has an upstream
    - whether the current branch is ahead of or behind `origin/<base>`
    - whether the user named target branches or expects current-branch fallback
+   - whether an Agentic SDLC UAT report exists for the current run and whether
+     it passed, when this skill is invoked from the SDLC workflow
 2. Resolve and commit the current feature-branch path before any branch
    creation or switching.
    - If `HEAD` is detached, stop and explain the problem.
@@ -151,6 +156,12 @@ branch, and report the order the user should merge the PRs manually.
    branch has fixable local test, lint, build, or CI failures. Commit and push
    the repair, then rerun the focused failing checks.
 9. Publish each branch.
+   In an Agentic SDLC run, write
+   `permissions/pr-authorization.json` in the active run directory immediately
+   before pushing or opening/reusing the PR. Include `allowed: true`,
+   `phase: "create-pr"`, the branch, UAT status, and a short `expires_at`
+   timestamp. If UAT failed or is missing, create this authorization only when
+   the user explicitly requested an early draft PR and record that scope.
    If a branch has no upstream yet, push it with upstream tracking. If conflict
    resolution created new commits, push those commits to the same branch.
 10. Avoid duplicate PRs.
@@ -174,6 +185,15 @@ branch, and report the order the user should merge the PRs manually.
    after the PR is opened and the failures are available and branch-caused,
    keep working on the same branch until the failures are resolved or clearly
    blocked by external state.
+   In an Agentic SDLC run, include requirements covered, feature list,
+   validation, tests, evaluation, and UAT evidence summary in the PR body when
+   that local evidence exists. If UAT failed or is missing, use a draft PR only
+   when the user explicitly requested early PR creation.
+   Record the PR URL and readiness summary in the active SDLC run evidence
+   when local run state is available; if local state cannot be updated, report
+   the missing write explicitly.
+   Remove or expire `permissions/pr-authorization.json` after publishing and
+   PR creation/reuse completes.
 12. Return the result.
    Report:
 

--- a/skills/create-pr/SKILL.md
+++ b/skills/create-pr/SKILL.md
@@ -234,6 +234,23 @@ branch, and report the order the user should merge the PRs manually.
   - `gh pr create --base <base> --head <branch> --title <title> --body <body>`
   - draft variant: `gh pr create --draft ...`
 
+## Learning Loop
+
+When using this skill, capture durable, reusable, public-safe learnings back
+into this skill's local source materials before completion when the current task
+contract allows source edits. Update the narrowest appropriate surface:
+`SKILL.md` for runtime rules, `references/` for detailed guidance, `assets/`
+for reusable templates, `scripts/` for deterministic helpers, and README or
+changelog entries for human-facing or release-note updates.
+
+If the current task is explicitly read-only/report-only, or source writes are
+outside this skill's task contract, do not edit skill sources; report the
+skipped source update instead.
+
+Do not capture secrets, private URLs, customer data, raw logs, one-off local
+state, or unverified/vendor-specific claims. If a useful learning is not safe,
+not evidence-backed, or outside this skill's scope, report that it was skipped.
+
 ## Guardrails
 
 - Never keep new work on the default branch once the user asks to open a PR.

--- a/skills/github-workflows/SKILL.md
+++ b/skills/github-workflows/SKILL.md
@@ -48,6 +48,23 @@ Apply repository-native GitHub Actions patterns instead of inventing one-off wor
    - If a paired script/template exists, run `bash -n`.
    - Run the same lint/test/build path the workflow expects when the target service can be validated locally.
 
+## Learning Loop
+
+When using this skill, capture durable, reusable, public-safe learnings back
+into this skill's local source materials before completion when the current task
+contract allows source edits. Update the narrowest appropriate surface:
+`SKILL.md` for runtime rules, `references/` for detailed guidance, `assets/`
+for reusable templates, `scripts/` for deterministic helpers, and README or
+changelog entries for human-facing or release-note updates.
+
+If the current task is explicitly read-only/report-only, or source writes are
+outside this skill's task contract, do not edit skill sources; report the
+skipped source update instead.
+
+Do not capture secrets, private URLs, customer data, raw logs, one-off local
+state, or unverified/vendor-specific claims. If a useful learning is not safe,
+not evidence-backed, or outside this skill's scope, report that it was skipped.
+
 ## Guardrails
 
 - Do not use `pull_request_target` for untrusted PR code execution.

--- a/skills/gitignore/SKILL.md
+++ b/skills/gitignore/SKILL.md
@@ -44,3 +44,20 @@ Add only when relevant:
 - Write the final file as `.gitignore` in repo root.
 - Keep sections grouped with short comments.
 - Keep output idempotent so re-running does not introduce churn.
+
+## Learning Loop
+
+When using this skill, capture durable, reusable, public-safe learnings back
+into this skill's local source materials before completion when the current task
+contract allows source edits. Update the narrowest appropriate surface:
+`SKILL.md` for runtime rules, `references/` for detailed guidance, `assets/`
+for reusable templates, `scripts/` for deterministic helpers, and README or
+changelog entries for human-facing or release-note updates.
+
+If the current task is explicitly read-only/report-only, or source writes are
+outside this skill's task contract, do not edit skill sources; report the
+skipped source update instead.
+
+Do not capture secrets, private URLs, customer data, raw logs, one-off local
+state, or unverified/vendor-specific claims. If a useful learning is not safe,
+not evidence-backed, or outside this skill's scope, report that it was skipped.

--- a/skills/global-context-management/README.md
+++ b/skills/global-context-management/README.md
@@ -4,7 +4,7 @@
 for keeping long or complex coding sessions focused.
 It reduces context pollution by separating runtime policy, task-state
 continuity, and authorized read-only exploration roles when the current Codex
-surface permits delegation.
+surface exposes delegation tools.
 
 ## Design Goal
 
@@ -114,8 +114,8 @@ Understand the task.
 Read current task state when continuity may matter.
 Update task state.
 Use targeted reads.
-Delegate bounded read-only exploration when authorization comes from the prompt
-or a user-enabled local hook policy, and delegation is available and useful.
+Use bounded read-only exploration when authorization comes from the prompt or a
+user-enabled local hook policy, and delegation is available and useful.
 Plan the smallest coherent change.
 Edit in focused patches.
 Validate narrowly first.
@@ -131,7 +131,7 @@ skill is used. Detailed local setup lives in `references/local-setup.md`.
 Subagents are bounded read-only helpers for large sidecar exploration,
 validation planning, and risk review. Use them when the work would pollute the
 parent thread, delegation is authorized by the prompt or by a user-enabled
-local hook policy, and the current Codex surface permits delegation.
+local hook policy, and the current Codex surface exposes delegation tools.
 
 - `repo_mapper`: maps relevant files, symbols, flows, and conventions.
 - `test_strategist`: finds focused tests, fixtures, and validation order.
@@ -160,12 +160,14 @@ as a user request to use them. Current public Codex docs say Codex only spawns
 subagents when explicitly asked. In this workflow, that explicit request can
 come from the user prompt or from a user-enabled local hook policy that adds a
 lightweight delegation request for complex prompts, when the active runtime and
-instruction policy accept that hook context. If delegation is authorized and
-useful but subagent controls are not visible, and `tool_search` is available,
-the main agent should first search for multi-agent/subagent tools before
-reporting delegation unavailable. If a session still cannot spawn a subagent,
-the main agent should keep working with narrower reads and report that
-delegation was unavailable or not permitted.
+instruction policy accept that hook context. Once either source authorizes
+delegation, the main agent should choose targeted helper roles itself; the user
+does not need to name `repo_mapper`, `test_strategist`, or `risk_reviewer`. If
+delegation is authorized and useful but subagent controls are not visible, and
+`tool_search` is available, the main agent should first search for
+multi-agent/subagent tools before reporting delegation unavailable. If a
+session still cannot spawn a subagent, the main agent should keep working with
+narrower reads and report that delegation was unavailable or not permitted.
 
 The optional hook policy lives only under `$CODEX_HOME`:
 
@@ -182,9 +184,9 @@ discovers configured read-only agents from `$CODEX_HOME/config.toml` and the
 referenced files under `$CODEX_HOME`. It injects agent names only by default,
 not local paths. This is still best-effort model-visible guidance; hooks do
 not directly call the subagent tool or repeat the full helper lifecycle. When
-this policy context is present, the main agent should treat it as an opt-in
-delegation request for that turn, then use read-only helpers only when they are
-useful, available, and permitted.
+this policy context is present, the main agent should treat it as an explicit
+request to consider bounded read-only delegation for that turn, then use
+targeted helpers when they are useful, available, and permitted.
 
 This skill's local hook layer owns only the non-SDLC global-context events:
 `SessionStart` for stable global context and task-state path injection, and
@@ -200,6 +202,12 @@ Use `UserPromptSubmit` only for small global reminders, prompt safety, and
 lightweight context hints. Do not use it to route `sdlc-start`, parse
 requirements, select workflow skills, create run state, or inject large
 documents.
+
+If an Agentic SDLC task also needs long-task context management, use
+`global-context-management` only to manage parent-thread noise, task-state
+continuity, and optional read-only helpers. Keep phase selection, SDLC run
+state, requirements and design updates, authorization files, and SDLC write
+policy in the `sdlc-*` skills and their dedicated hooks.
 
 ### Parent/Subagent Lifecycle
 
@@ -227,7 +235,7 @@ What it can do is change future behavior:
 - keep task state in a durable file instead of re-explaining it in chat
 - keep raw logs and broad file listings out of the parent thread
 - delegate broad read-only mapping and validation planning when authorized by
-  the prompt or local hook policy, and available
+  the prompt or local hook policy, useful, and available
 - require concise summaries from subagents
 - close completed subagent threads after their results are consolidated, when
   close controls are available
@@ -248,11 +256,11 @@ For a complex task, the intended flow is:
 2. Identify the objective, constraints, likely files, and validation path.
 3. Read existing task state when prior context may matter, then update it with
    the current plan.
-4. Prefer read-only subagents when they reduce parent-thread noise,
-   delegation is authorized by the prompt or local hook policy, and the current
-   runtime permits delegation. Use `repo_mapper` and `test_strategist` early
-   only when useful and independent; close completed helpers after
-   consolidation. Do not spawn every configured role by default.
+4. Use read-only subagents when they reduce parent-thread noise, delegation is
+   authorized by the prompt or local hook policy, and the current runtime
+   permits delegation. Use `repo_mapper` and `test_strategist` early only when
+   useful and independent; close completed helpers after consolidation. Do not
+   spawn every configured role by default.
 5. Implement the smallest coherent change in the main thread.
 6. Inspect the diff and run focused validation.
 7. Use `risk_reviewer` near the end only for non-trivial or risky changes.
@@ -269,7 +277,7 @@ The hook does this:
 Before Codex starts working:
   "Here is the repo.
    Here is the task-state path.
-   Create it automatically only when the prompt looks complex.
+   Advertise it for complex prompts; do not create it automatically.
    Read it when it already exists and prior context may matter.
    Use the global workflow for complex work."
 
@@ -301,8 +309,9 @@ multi-agent tools, the active instructions must permit delegation for the task,
 and current public Codex docs say Codex only spawns subagents when explicitly
 asked. A prompt can explicitly ask for subagents, delegation, or parallel
 agents; a user-enabled local hook policy can also inject that explicit request
-for complex prompts. Either way, spawning remains subject to active runtime and
-instruction policy.
+for complex prompts. After either source authorizes delegation, Codex should
+choose useful targeted roles instead of waiting for the prompt to name one.
+Either way, spawning remains subject to active runtime and instruction policy.
 
 ## File Responsibilities
 
@@ -421,4 +430,6 @@ To test policy-driven injection without hardcoding agent names into the public
 repo, create `$CODEX_HOME/hooks/global_context_policy.json` locally, restart
 Codex, trust the updated hook in `/hooks`, and run a complex prompt that does
 not mention a specific subagent. The hook should discover read-only agents from
-`$CODEX_HOME/config.toml` and request them by configured name.
+`$CODEX_HOME/config.toml` and request bounded read-only delegation by
+configured name. Codex should then choose targeted roles when useful, or state
+the active runtime/tool reason it cannot spawn them.

--- a/skills/global-context-management/README.md
+++ b/skills/global-context-management/README.md
@@ -53,7 +53,7 @@ They should say, in effect:
 ```text
 Here is the workspace root.
 Here is the durable task-state path.
-Create task state automatically only for complex prompts.
+Do not create task state from hooks.
 Read current task state when it already exists and prior context may matter.
 For complex work, use global-context-management.
 Keep the parent thread concise.
@@ -75,13 +75,12 @@ customer data, private URLs, or broad environment dumps.
 
 Task-state files are useful only when Codex reads and updates them. The
 `SessionStart` hook injects the path without creating a missing `current.md`;
-the `UserPromptSubmit` hook creates or reuses the file automatically only when
-the prompt looks complex. Hooks do not make hidden state automatically active in
-the model forever.
+the `UserPromptSubmit` hook only advertises or reuses the same path for complex
+prompts. Hooks do not create task-state files, SDLC run state, workflow state,
+or hidden state automatically active in the model forever.
 Synthetic complex-prompt hook probes that pass a made-up `session_id` against a
-live `$CODEX_HOME` can create scaffold-only directories named after that session
-ID. Those probe files are not active task context unless a real agent session
-later reads and updates that same path.
+live `$CODEX_HOME` should not create task-state files or directories. They
+validate hook path calculation and prompt-time hints only.
 
 Use the task-state file in three places:
 
@@ -152,8 +151,8 @@ agent roles, and the active instruction policy. In current Codex surfaces,
 enabling `multi_agent` makes the tools available but does not by itself count
 as a user request to use them. Current public Codex docs say Codex only spawns
 subagents when explicitly asked. In this workflow, that explicit request can
-come from the user prompt or from a user-enabled local hook policy that injects
-a delegation request for complex prompts, when the active runtime and
+come from the user prompt or from a user-enabled local hook policy that adds a
+lightweight delegation hint for complex prompts, when the active runtime and
 instruction policy accept that hook context. If delegation is authorized and
 useful but subagent controls are not visible, and `tool_search` is available,
 the main agent should first search for multi-agent/subagent tools before
@@ -175,10 +174,25 @@ When that policy is present at
 discovers configured read-only agents from `$CODEX_HOME/config.toml` and the
 referenced files under `$CODEX_HOME`. It injects agent names only by default,
 not local paths. This is still best-effort model-visible guidance; hooks do
-not directly call the subagent tool. When this policy context is present, the
-main agent should treat it as the local-policy delegation request for that turn
-and should not wait for another manual prompt phrase before using useful,
-available, and permitted read-only helpers.
+not directly call the subagent tool or repeat the full helper lifecycle. When
+this policy context is present, the main agent should treat it as an opt-in
+delegation hint for that turn, then use read-only helpers only when they are
+useful, available, and permitted.
+
+This skill's local hook layer owns only the non-SDLC global-context events:
+`SessionStart` for stable global context and task-state path injection, and
+`UserPromptSubmit` for lightweight prompt-time context, safety, or opt-in
+delegation hints. Do not use this layer to run Agentic SDLC loops. SDLC
+guardrails belong in separate `PreToolUse` and `Stop` hooks.
+
+Use `SessionStart` for global conventions, workspace context, environment
+notes, coding standards, and stable task-state path hints. Do not use it to
+select SDLC phases, modify run state, or inject large documents.
+
+Use `UserPromptSubmit` only for small global reminders, prompt safety, and
+lightweight context hints. Do not use it to route `sdlc-start`, parse
+requirements, select workflow skills, create run state, or inject large
+documents.
 
 ### Parent/Subagent Lifecycle
 
@@ -222,8 +236,8 @@ installed.
 
 For a complex task, the intended flow is:
 
-1. Receive prompt and injected task-state path; for complex prompts, create or
-   reuse the task-state file automatically.
+1. Receive prompt and injected task-state path; hooks only advertise or reuse
+   an existing file and do not create task-state.
 2. Identify the objective, constraints, likely files, and validation path.
 3. Read existing task state when prior context may matter, then update it with
    the current plan.
@@ -370,10 +384,13 @@ In the fresh session, open the hook review UI:
 /hooks
 ```
 
-Review the two configured hook commands. They should point to the local
-`$CODEX_HOME/hooks/session_start_context.py` and
-`$CODEX_HOME/hooks/user_prompt_context.py` scripts. Trust or enable those hooks
-from the `/hooks` UI only after confirming the paths are local and expected.
+Review the two configured global-context hook commands. They should point to
+the local `$CODEX_HOME/hooks/session_start_context.py` and
+`$CODEX_HOME/hooks/user_prompt_context.py` scripts. Trust or enable those
+hooks from the `/hooks` UI only after confirming the paths are local and
+expected.
+If other workflows add hooks, review those entries separately and keep their
+event ownership distinct.
 
 After trusting the hooks, start another fresh session and confirm a complex
 prompt receives an injected durable task-state path under:

--- a/skills/global-context-management/README.md
+++ b/skills/global-context-management/README.md
@@ -1,10 +1,10 @@
 # Global Context Management
 
-`global-context-management` is a reusable Codex skill plus optional local
-runtime setup for keeping long or complex coding sessions focused. It reduces
-context pollution by separating runtime policy, task-state persistence, and
-read-only exploration roles when the current Codex surface exposes them and
-delegation is authorized by the prompt or by a user-enabled local hook policy.
+`global-context-management` is a reusable Codex skill plus local runtime setup
+for keeping long or complex coding sessions focused.
+It reduces context pollution by separating runtime policy, task-state
+continuity, and authorized read-only exploration roles when the current Codex
+surface permits delegation.
 
 ## Design Goal
 
@@ -82,6 +82,13 @@ Synthetic complex-prompt hook probes that pass a made-up `session_id` against a
 live `$CODEX_HOME` should not create task-state files or directories. They
 validate hook path calculation and prompt-time hints only.
 
+The parent agent creates or updates the advertised file when durable continuity
+is useful. Any local PreToolUse write guard must explicitly allow
+`$CODEX_HOME/task-state` writes; otherwise the hook can advertise a valid path
+that later edits cannot persist. That allowlist is separate from broader
+runtime files such as `$CODEX_HOME/hooks`, which should remain protected unless
+the user intentionally syncs hook sources.
+
 Use the task-state file in three places:
 
 1. At task start, resume, or after compaction, read the current file when prior
@@ -121,10 +128,10 @@ skill is used. Detailed local setup lives in `references/local-setup.md`.
 
 ### Subagents
 
-Subagents are optional read-only helpers. They are useful when exploration is
-large enough that it would pollute the parent thread, delegation is authorized
-by the prompt or by a user-enabled local hook policy, and the current Codex
-surface permits delegation.
+Subagents are bounded read-only helpers for large sidecar exploration,
+validation planning, and risk review. Use them when the work would pollute the
+parent thread, delegation is authorized by the prompt or by a user-enabled
+local hook policy, and the current Codex surface permits delegation.
 
 - `repo_mapper`: maps relevant files, symbols, flows, and conventions.
 - `test_strategist`: finds focused tests, fixtures, and validation order.
@@ -152,7 +159,7 @@ enabling `multi_agent` makes the tools available but does not by itself count
 as a user request to use them. Current public Codex docs say Codex only spawns
 subagents when explicitly asked. In this workflow, that explicit request can
 come from the user prompt or from a user-enabled local hook policy that adds a
-lightweight delegation hint for complex prompts, when the active runtime and
+lightweight delegation request for complex prompts, when the active runtime and
 instruction policy accept that hook context. If delegation is authorized and
 useful but subagent controls are not visible, and `tool_search` is available,
 the main agent should first search for multi-agent/subagent tools before
@@ -176,13 +183,13 @@ referenced files under `$CODEX_HOME`. It injects agent names only by default,
 not local paths. This is still best-effort model-visible guidance; hooks do
 not directly call the subagent tool or repeat the full helper lifecycle. When
 this policy context is present, the main agent should treat it as an opt-in
-delegation hint for that turn, then use read-only helpers only when they are
+delegation request for that turn, then use read-only helpers only when they are
 useful, available, and permitted.
 
 This skill's local hook layer owns only the non-SDLC global-context events:
 `SessionStart` for stable global context and task-state path injection, and
 `UserPromptSubmit` for lightweight prompt-time context, safety, or opt-in
-delegation hints. Do not use this layer to run Agentic SDLC loops. SDLC
+delegation requests. Do not use this layer to run Agentic SDLC loops. SDLC
 guardrails belong in separate `PreToolUse` and `Stop` hooks.
 
 Use `SessionStart` for global conventions, workspace context, environment
@@ -241,7 +248,7 @@ For a complex task, the intended flow is:
 2. Identify the objective, constraints, likely files, and validation path.
 3. Read existing task state when prior context may matter, then update it with
    the current plan.
-4. Use read-only subagents only when they reduce parent-thread noise,
+4. Prefer read-only subagents when they reduce parent-thread noise,
    delegation is authorized by the prompt or local hook policy, and the current
    runtime permits delegation. Use `repo_mapper` and `test_strategist` early
    only when useful and independent; close completed helpers after

--- a/skills/global-context-management/SKILL.md
+++ b/skills/global-context-management/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: global-context-management
-description: "Use for complex Codex work: planning, implementation, debugging, refactoring, migration, architecture, reviews, tests, CI failures, or multi-file tasks. Keep parent context concise with durable task state, authorized read-only subagents when useful and permitted, focused validation, and final risk review."
+description: "Use for complex Codex work: planning, implementation, debugging, refactoring, migration, architecture, reviews, tests, CI failures, or multi-file tasks. Keep parent context concise with durable task state, authorized targeted read-only subagents when useful and permitted, focused validation, and final risk review."
 ---
 
 # Global Context Management
@@ -8,12 +8,13 @@ description: "Use for complex Codex work: planning, implementation, debugging, r
 ## Purpose
 
 Use this skill to keep long or complex Codex work focused and recoverable.
-The workflow keeps durable decisions outside the conversation, delegates noisy
-read-heavy investigation when authorized by the prompt or by a user-enabled
-local hook policy, useful for the task, and available in the current runtime.
-It keeps the parent thread centered on implementation and final judgment.
+The workflow keeps durable decisions outside the conversation and uses bounded
+read-only subagents for useful independent sidecar work after delegation is
+authorized by the prompt or by a user-enabled local hook policy, when the
+current runtime exposes the tools. It keeps the parent thread centered on
+implementation and final judgment.
 
-## Use This Skill For
+## When To Use
 
 - Multi-file implementation, refactoring, migration, debugging, or architecture
   work.
@@ -21,27 +22,68 @@ It keeps the parent thread centered on implementation and final judgment.
 - Code review or risk review where many files or contracts may be relevant.
 - Tasks likely to run long enough to hit compaction or lose earlier decisions.
 
-For tiny single-file edits, apply only the lightweight parts: concise
-exploration, minimal task-state notes if already injected, focused validation,
-and a short final summary.
+## When Not To Use
 
-## Non-Goals
+- For tiny single-file edits, apply only the lightweight parts: concise
+  exploration, minimal task-state notes if already injected, focused
+  validation, and a short final summary.
+- For machine-level Codex installation or local file rendering, use
+  `config-codex`; this skill owns the runtime work pattern, not setup.
+- For Agentic SDLC orchestration, use `sdlc-start` and the relevant `sdlc-*`
+  phase skills; this skill may only wrap that work for context management.
+
+## Must Not
 
 - Do not create repo-local task-state files unless the user explicitly asks.
 - Do not store raw prompts, secrets, command output, stack traces, customer
   data, private URLs, or environment-specific values in task-state files.
 - Do not make subagents responsible for final decisions. The parent agent owns
   consolidation, edits, verification, and the final answer.
-- Do not assume subagent tools are available or permitted just because this
-  skill was loaded. Use them only when the current Codex surface exposes them
-  and current user or developer instructions allow delegation.
+- Do not claim or fake subagent use when the current Codex surface does not
+  expose subagent tools or active instructions forbid delegation.
 - Do not treat skill activation, generic hook context, or configured
   `[agents.*]` roles as delegation authorization. Authorization comes from the
   user prompt or from a user-enabled local hook policy that deliberately
-  injects a lightweight delegation request for the current prompt; active runtime
-  policy may still deny delegation.
+  injects a lightweight delegation request for the current prompt. After one of
+  those sources authorizes delegation, do not ask for another confirmation just
+  because the prompt did not name a specific helper role; check usefulness,
+  tool availability, and active runtime policy instead.
 - Do not claim runtime hook or skill activation is proven unless it was
   observed in the current Codex surface.
+
+## Inputs
+
+- The current user prompt and active system/developer/repo instructions.
+- The durable task-state path injected by hooks, when available.
+- An existing task-state file at that path, when it exists and prior context may
+  matter.
+- Optional user-enabled hook-policy context that requests bounded read-only
+  delegation for the current prompt.
+- Current runtime tool availability, including whether subagent controls are
+  directly visible or discoverable through `tool_search`.
+
+## Required Reads
+
+- Read the injected task-state file at task start, resume, or after compaction
+  when it exists and prior decisions may matter.
+- Read target project files with targeted `rg`, `rg --files`, and small file
+  ranges before editing.
+- When changing this skill or its local setup contract, read `README.md`,
+  `references/local-setup.md`, relevant `assets/`, and duplicated
+  `config-codex` surfaces.
+- When changing Codex-specific guidance, verify current official Codex docs or
+  clearly mark unverified runtime behavior.
+
+## Writes
+
+- May create or update only the advertised task-state file under
+  `$CODEX_HOME/task-state` when continuity is useful and writes are permitted.
+- May edit requested project files, skill source files, docs, tests, or
+  templates in the current task scope.
+- May update this skill's public-safe local source materials under the Learning
+  Loop when the task contract allows source edits.
+- Must not write repo-local task-state files, SDLC run state, hook runtime files,
+  credentials, raw logs, or unrelated `$CODEX_HOME` files.
 
 ## Runtime Boundaries
 
@@ -61,11 +103,15 @@ multi-agent/subagent tools before reporting delegation unavailable. State that
 delegation was unavailable or not permitted instead of pretending it happened.
 
 Treat the user prompt and a user-enabled local hook policy as the two valid
-authorization sources. A complex task, this skill's activation, or configured
-agent roles are not enough by themselves. The prompt must clearly ask Codex to
-use or spawn subagents, use delegation, or run parallel agents, unless a
-user-enabled local hook policy injects a delegation request and the current runtime
-accepts it.
+authorization sources. A complex task, this skill's activation, generic hook
+context, or configured agent roles are not enough by themselves. For
+prompt-based authorization, the prompt must clearly ask Codex to use or spawn
+subagents, use delegation, or run parallel agents. For policy-based
+authorization, the hook output must explicitly request bounded read-only
+delegation for the current prompt and the current runtime must accept that hook
+context. Once authorization is present, choose targeted helper roles yourself
+when useful; the user does not need to name `repo_mapper`, `test_strategist`,
+or `risk_reviewer`.
 
 This skill's hook layer owns only non-SDLC global-context events:
 `SessionStart` for stable context and task-state path injection, and
@@ -79,6 +125,11 @@ hooks.
 - `UserPromptSubmit`: use only for small global reminders, prompt safety, and
   lightweight context hints. Do not route `sdlc-start`, parse requirements,
   select workflow skills, create run state, or inject large documents.
+
+When this skill is used during an Agentic SDLC task, it remains only the
+context-management wrapper around the work. It must not replace `sdlc-start`,
+select SDLC phase skills, write SDLC run state, create or modify
+`docs/requirements.md` or `docs/design.md`, or enforce SDLC write policy.
 
 ## Task State
 
@@ -120,6 +171,17 @@ edits, after validation, before a long pause or compaction, and before the
 final response. The file is useful only if it is read on continuation and kept
 small enough to act on.
 
+## Idempotency
+
+- Reuse the injected task-state path for the current session; do not invent a
+  fallback path when the hook did not provide one.
+- Update task state as a concise replacement or checkpoint, not by appending raw
+  logs or duplicating prior plans.
+- Spawn each useful subagent role only once for a specific sidecar question
+  unless a new, distinct follow-up is needed.
+- Re-run validation after edits and record the current status instead of
+  preserving stale results.
+
 ## Parent-Thread Discipline
 
 Keep the parent thread focused on:
@@ -140,17 +202,18 @@ Before running a noisy command in the parent thread, narrow it:
   recursive reads.
 - Limit command output when possible and summarize only the relevant facts.
 - Route broad read-only mapping, test discovery, and risk review to subagents
-  only when delegation is authorized by the prompt or a user-enabled local
-  hook policy, and the tools and instructions permit it.
+  when delegation is authorized by the prompt or a user-enabled local hook
+  policy, the work is useful and independent, and the tools and instructions
+  permit it.
 - Put durable decisions, current plan, and validation status in task state;
   do not copy raw logs there.
 
 ## Subagent Delegation
 
-For complex tasks, prefer bounded read-only subagents for read-heavy sidecar
-work when they materially help,
-delegation is authorized by the prompt or a user-enabled local hook policy,
-and the current Codex surface permits delegation:
+For complex tasks, actively use bounded read-only subagents for read-heavy
+sidecar work when they materially help, delegation is authorized by the prompt
+or a user-enabled local hook policy, and the current Codex surface permits
+delegation:
 
 - `repo_mapper`: map relevant files, symbols, execution paths, and conventions.
 - `test_strategist`: identify focused tests, fixtures, and validation order.
@@ -162,6 +225,13 @@ Do not spawn every configured role by default. With a conservative
 when their work is useful and independent, close completed helpers after
 consolidating their summaries, and reserve `risk_reviewer` for near-final
 review of non-trivial or risky changes.
+
+After delegation is authorized, the default decision should be to spawn one or
+two targeted read-only helpers for independent sidecar work. Skip delegation
+only when the task is tiny, the next step is blocked on the same investigation,
+there is no independent read-heavy work, subagent controls are unavailable or
+denied, or active instructions forbid delegation. Do not skip only because the
+user did not name the exact role.
 
 Ask subagents for concise final summaries only, and tell them to stop after
 returning the result instead of waiting for follow-up prompts. The parent
@@ -180,25 +250,53 @@ Good delegation targets are read-heavy sidecar tasks that can run while the
 parent keeps moving. Keep immediate blockers in the parent thread when waiting
 for a subagent would stall the next step.
 
-## Workflow
+## Failure Handling
+
+- If the task-state path is unavailable, continue without durable task state and
+  do not create a manual or repo-local fallback.
+- If task state exists but appears stale, treat it as a hint and verify drifted
+  facts before acting on them.
+- If delegation is authorized and useful but controls are not visible, use
+  `tool_search` to look for multi-agent/subagent tools before reporting
+  delegation unavailable.
+- If subagent spawning is denied, unavailable, or forbidden by active
+  instructions, continue locally with narrower reads and report that boundary.
+- If validation fails, classify whether the failure is from changed source,
+  duplicated template drift, environment/runtime availability, or optional
+  profile mismatch before retrying.
+
+## Process
 
 1. Understand the task and constraints.
 2. Read existing global task state when prior context may matter; create the
    task-state file only when complex work needs continuity, then update it.
-3. Explore with targeted reads; use read-only subagents only when delegation
-   is authorized by the prompt or a user-enabled local hook policy, useful for
-   the task, available, and permitted. Wait for their final summaries and
-   close completed subagent threads after consolidation when close controls
-   are available. For multiple subagents, repeat wait-and-close until every
-   spawned handle is closed.
+3. Explore with targeted reads; use read-only subagents when delegation is
+   authorized by the prompt or a user-enabled local hook policy, useful for the
+   task, available, and permitted. Wait for their final summaries and close
+   completed subagent threads after consolidation when close controls are
+   available. For multiple subagents, repeat wait-and-close until every spawned
+   handle is closed.
 4. Plan the smallest coherent implementation.
 5. Edit in focused patches using existing project conventions.
 6. Inspect the diff.
 7. Run narrow validation first, then broader checks when appropriate.
-8. Use `risk_reviewer` before finalizing non-trivial or risky changes only
-   when subagent delegation is authorized by the prompt or a user-enabled local
-   hook policy, and permitted.
+8. Use `risk_reviewer` before finalizing non-trivial or risky changes when
+   subagent delegation is authorized by the prompt or a user-enabled local hook
+   policy, useful, available, and permitted.
 9. Update task state and return the final summary.
+
+## Completion Criteria
+
+- The requested implementation, review, or investigation is complete or the
+  remaining blocker is explicitly reported.
+- Parent context contains decisions, changed files, validation status, and
+  residual risk rather than raw logs or broad dumps.
+- Task state, when available and useful, reflects current plan, validation
+  status, risks, and next action.
+- Any spawned subagents have returned final summaries and been closed when close
+  controls are available.
+- Relevant docs, README, changelog, duplicated templates, and validators are
+  aligned for changed behavior.
 
 ## Local Setup
 

--- a/skills/global-context-management/SKILL.md
+++ b/skills/global-context-management/SKILL.md
@@ -38,7 +38,7 @@ and a short final summary.
 - Do not treat skill activation, generic hook context, or configured
   `[agents.*]` roles as delegation authorization. Authorization comes from the
   user prompt or from a user-enabled local hook policy that deliberately
-  injects a subagent delegation request for the current prompt; active runtime
+  injects a lightweight delegation hint for the current prompt; active runtime
   policy may still deny delegation.
 - Do not claim runtime hook or skill activation is proven unless it was
   observed in the current Codex surface.
@@ -64,8 +64,21 @@ Treat the user prompt and a user-enabled local hook policy as the two valid
 authorization sources. A complex task, this skill's activation, or configured
 agent roles are not enough by themselves. The prompt must clearly ask Codex to
 use or spawn subagents, use delegation, or run parallel agents, unless a
-user-enabled local hook policy injects that request and the current runtime
+user-enabled local hook policy injects a delegation hint and the current runtime
 accepts it.
+
+This skill's hook layer owns only non-SDLC global-context events:
+`SessionStart` for stable context and task-state path injection, and
+`UserPromptSubmit` for lightweight prompt-time context, safety, or opt-in
+delegation hints. Agentic SDLC guardrails are separate `PreToolUse` and `Stop`
+hooks.
+
+- `SessionStart`: use for global conventions, workspace context, environment
+  notes, coding standards, and stable task-state path hints. Do not select
+  SDLC phases, modify run state, or inject large documents.
+- `UserPromptSubmit`: use only for small global reminders, prompt safety, and
+  lightweight context hints. Do not route `sdlc-start`, parse requirements,
+  select workflow skills, create run state, or inject large documents.
 
 ## Task State
 

--- a/skills/global-context-management/SKILL.md
+++ b/skills/global-context-management/SKILL.md
@@ -191,6 +191,23 @@ personal paths or secrets. When script execution is permitted, use
 validating hook setup. For the human-facing design and architecture map, read
 `README.md`.
 
+## Learning Loop
+
+When using this skill, capture durable, reusable, public-safe learnings back
+into this skill's local source materials before completion when the current task
+contract allows source edits. Update the narrowest appropriate surface:
+`SKILL.md` for runtime rules, `references/` for detailed guidance, `assets/`
+for reusable templates, `scripts/` for deterministic helpers, and README or
+changelog entries for human-facing or release-note updates.
+
+If the current task is explicitly read-only/report-only, or source writes are
+outside this skill's task contract, do not edit skill sources; report the
+skipped source update instead.
+
+Do not capture secrets, private URLs, customer data, raw logs, one-off local
+state, or unverified/vendor-specific claims. If a useful learning is not safe,
+not evidence-backed, or outside this skill's scope, report that it was skipped.
+
 ## Output Contract
 
 For code changes, return:

--- a/skills/global-context-management/SKILL.md
+++ b/skills/global-context-management/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: global-context-management
-description: "Use for complex Codex work: planning, implementation, debugging, refactoring, migration, architecture, reviews, tests, CI failures, or multi-file tasks. Keep parent context concise with durable task state, optional authorized read-only subagents, focused validation, and final risk review."
+description: "Use for complex Codex work: planning, implementation, debugging, refactoring, migration, architecture, reviews, tests, CI failures, or multi-file tasks. Keep parent context concise with durable task state, authorized read-only subagents when useful and permitted, focused validation, and final risk review."
 ---
 
 # Global Context Management
@@ -10,8 +10,8 @@ description: "Use for complex Codex work: planning, implementation, debugging, r
 Use this skill to keep long or complex Codex work focused and recoverable.
 The workflow keeps durable decisions outside the conversation, delegates noisy
 read-heavy investigation when authorized by the prompt or by a user-enabled
-local hook policy, and when delegation is available and useful. It keeps the
-parent thread centered on implementation and final judgment.
+local hook policy, useful for the task, and available in the current runtime.
+It keeps the parent thread centered on implementation and final judgment.
 
 ## Use This Skill For
 
@@ -38,7 +38,7 @@ and a short final summary.
 - Do not treat skill activation, generic hook context, or configured
   `[agents.*]` roles as delegation authorization. Authorization comes from the
   user prompt or from a user-enabled local hook policy that deliberately
-  injects a lightweight delegation hint for the current prompt; active runtime
+  injects a lightweight delegation request for the current prompt; active runtime
   policy may still deny delegation.
 - Do not claim runtime hook or skill activation is proven unless it was
   observed in the current Codex surface.
@@ -64,13 +64,13 @@ Treat the user prompt and a user-enabled local hook policy as the two valid
 authorization sources. A complex task, this skill's activation, or configured
 agent roles are not enough by themselves. The prompt must clearly ask Codex to
 use or spawn subagents, use delegation, or run parallel agents, unless a
-user-enabled local hook policy injects a delegation hint and the current runtime
+user-enabled local hook policy injects a delegation request and the current runtime
 accepts it.
 
 This skill's hook layer owns only non-SDLC global-context events:
 `SessionStart` for stable context and task-state path injection, and
 `UserPromptSubmit` for lightweight prompt-time context, safety, or opt-in
-delegation hints. Agentic SDLC guardrails are separate `PreToolUse` and `Stop`
+delegation requests. Agentic SDLC guardrails are separate `PreToolUse` and `Stop`
 hooks.
 
 - `SessionStart`: use for global conventions, workspace context, environment
@@ -86,6 +86,12 @@ Use the durable task-state path injected by global hooks. No legacy task-state
 path is created when the hook payload has no session id. If no path is
 available, continue without durable task state rather than creating a manual or
 repo-local fallback.
+
+The hook only advertises or reuses the path; the parent agent is responsible
+for creating and updating the file when continuity is useful. If a local
+PreToolUse write guard is installed, it must allow writes under
+`$CODEX_HOME/task-state` while continuing to block unrelated `$CODEX_HOME`
+runtime edits such as hook rewrites.
 
 At the start of a complex task, resume, or context transition, read the
 existing task-state file before planning when it may contain prior decisions,
@@ -141,7 +147,8 @@ Before running a noisy command in the parent thread, narrow it:
 
 ## Subagent Delegation
 
-For complex tasks, use bounded read-only subagents when they materially help,
+For complex tasks, prefer bounded read-only subagents for read-heavy sidecar
+work when they materially help,
 delegation is authorized by the prompt or a user-enabled local hook policy,
 and the current Codex surface permits delegation:
 

--- a/skills/global-context-management/agents/openai.yaml
+++ b/skills/global-context-management/agents/openai.yaml
@@ -1,6 +1,6 @@
 interface:
   display_name: "Global Context Management"
   short_description: "Keep long Codex tasks focused and recoverable"
-  default_prompt: "Use $global-context-management: read task state, keep parent concise, use subagents only when authorized, validate, review risk."
+  default_prompt: "Use $global-context-management: read task state, keep parent concise, use authorized read-only subagents when useful and permitted, validate, review risk."
 policy:
   allow_implicit_invocation: true

--- a/skills/global-context-management/agents/openai.yaml
+++ b/skills/global-context-management/agents/openai.yaml
@@ -1,6 +1,6 @@
 interface:
   display_name: "Global Context Management"
   short_description: "Keep long Codex tasks focused and recoverable"
-  default_prompt: "Use $global-context-management: read task state, keep parent concise, use authorized read-only subagents when useful and permitted, validate, review risk."
+  default_prompt: "Use $global-context-management: read task state, keep parent concise, use authorized targeted read-only subagents when useful and permitted, validate, review risk."
 policy:
   allow_implicit_invocation: true

--- a/skills/global-context-management/assets/session_start_context.py.template
+++ b/skills/global-context-management/assets/session_start_context.py.template
@@ -95,45 +95,17 @@ without creating a manual fallback path or repo-local state file.
     else:
         task_state_context = f"""Durable task-state file: `{state_file}`
 
-SessionStart only advertises this path; it does not create a scaffold file for
-every session. For complex prompts, the prompt hook creates or reuses this file
-automatically. If the file already exists, read it at the start of complex work
-when it may contain prior decisions, validation status, or next action. Use it
-instead of creating repo-local state files.
+SessionStart only advertises this path; it does not create task-state, SDLC run
+state, or workflow state. If the file already exists, read it when prior
+decisions may matter.
 """
 
-    context = f"""Global context management is enabled.
+    context = f"""Global context is available.
 
 Workspace root: `{root}`
 {task_state_context}
-
-For non-trivial planning, implementation, debugging, refactoring, migration,
-architecture, review, testing, CI failure, or multi-file work, apply the
-`global-context-management` skill.
-
-Use bounded read-only subagents when delegation is authorized by the user
-prompt or by a user-enabled local hook policy, when they are useful, the
-current runtime exposes subagent tools, and the current instructions permit
-delegation. When hook-assisted delegation is enabled, the prompt hook
-discovers configured read-only subagent roles from the local Codex config and
-requests them by configured name.
-
-If delegation was not authorized by the prompt or local hook policy, or
-subagents are unavailable or not permitted, continue with narrow local reads and
-state that limitation.
-If delegation is authorized and useful but subagent controls are not visible,
-and `tool_search` is available, first search for multi-agent/subagent tools
-before reporting delegation unavailable.
-
-When subagents are used, ask them for concise final summaries, wait for their
-results, consolidate them in the parent thread, and close completed subagent
-threads when close controls are available and no follow-up is needed.
-With multiple subagents, close each completed handle as its terminal result
-arrives, then continue waiting on the remaining handles.
-
-Keep the parent thread concise and update the task-state file before
-implementation, after major edits, after tests, before compaction, and before
-the final response.
+Keep raw logs, secrets, and broad exploration output out of durable task state.
+Use project skills for workflow-specific instructions.
 """
 
     print(

--- a/skills/global-context-management/assets/user_prompt_context.py.template
+++ b/skills/global-context-management/assets/user_prompt_context.py.template
@@ -274,7 +274,7 @@ def subagent_context(home: Path) -> str:
     review: list[str] = []
     lines = [
         "",
-        "Local policy permits read-only subagent delegation for this prompt.",
+        "Local policy requests bounded read-only subagent delegation for this prompt when useful.",
         "Available read-only roles:",
     ]
     for agent in agents:
@@ -299,8 +299,8 @@ def subagent_context(home: Path) -> str:
     if role_hint_parts:
         lines.append("Suggested role timing: " + "; ".join(role_hint_parts) + ".")
     lines.append(
-        "Use only targeted roles when useful, available, and permitted; do not "
-        "spawn every role by default."
+        "Use targeted roles when useful, available, and permitted; do not spawn "
+        "every role by default."
     )
     return "\n".join(lines) + "\n"
 
@@ -337,8 +337,8 @@ creating a manual fallback path or repo-local state file.
 
 {task_state_context}
 Keep raw exploration output out of the parent context. Use configured read-only
-subagents only when delegation is authorized by the user prompt or local hook
-policy, the runtime exposes subagent tools, and active instructions permit it.
+subagents when delegation is authorized by the user prompt or local hook policy,
+the runtime exposes subagent tools, and active instructions permit it.
 This hook does not route SDLC phases, parse requirements, select workflow
 skills, create run state, or inject large documents.
 {subagent_context(home)}"""

--- a/skills/global-context-management/assets/user_prompt_context.py.template
+++ b/skills/global-context-management/assets/user_prompt_context.py.template
@@ -53,32 +53,6 @@ COMPLEX_KEYWORDS = (
     "root-cause",
 )
 
-STATE_TEMPLATE = """# Current Codex task state
-
-## Workspace
-
-- Root: `{root}`
-
-## Objective
-
-## Constraints
-
-## Current plan
-
-## Decisions made
-
-## Relevant files and symbols
-
-## Commands run
-
-## Test status
-
-## Risks
-
-## Next action
-"""
-
-
 def read_payload() -> dict:
     try:
         return json.load(sys.stdin)
@@ -140,15 +114,13 @@ def state_file_for_payload(root: str, payload: dict) -> Path | None:
         / f"{workspace_name}-{workspace_hash}"
         / session_segment
     )
-    state_dir.mkdir(parents=True, exist_ok=True)
-    chmod_private(home / "task-state", 0o700)
-    chmod_private(state_dir.parent, 0o700)
-    chmod_private(state_dir, 0o700)
 
     state_file = state_dir / "current.md"
-    if not state_file.exists():
-        state_file.write_text(STATE_TEMPLATE.format(root=root), encoding="utf-8")
-    chmod_private(state_file, 0o600)
+    if state_file.exists():
+        chmod_private(home / "task-state", 0o700)
+        chmod_private(state_dir.parent, 0o700)
+        chmod_private(state_dir, 0o700)
+        chmod_private(state_file, 0o600)
 
     return state_file
 
@@ -302,11 +274,8 @@ def subagent_context(home: Path) -> str:
     review: list[str] = []
     lines = [
         "",
-        "Hook-assisted read-only subagent delegation is enabled by local policy.",
-        "This hook output is the local-policy delegation request for this turn;",
-        "do not wait for another manual user request before using useful,",
-        "available, and permitted read-only helpers.",
-        "Configured read-only agent roles discovered from `$CODEX_HOME/config.toml`:",
+        "Local policy permits read-only subagent delegation for this prompt.",
+        "Available read-only roles:",
     ]
     for agent in agents:
         name = agent["name"]
@@ -320,50 +289,18 @@ def subagent_context(home: Path) -> str:
         else:
             exploration_or_planning.append(name)
 
-    lines.extend(
-        [
-            "",
-            "For complex tasks that touch many files or require noisy exploration,",
-            "use configured read-only roles when they are useful, the current",
-            "runtime exposes subagent tools, and active instructions permit",
-            "delegation. Do not spawn every configured role by default.",
-        ]
-    )
+    role_hint_parts = []
     if exploration_or_planning:
-        lines.append(
-            "Use these read-only exploration/planning roles early, preferably in "
-            f"parallel only when their work is independent and useful: "
-            f"{format_agent_names(exploration_or_planning)}."
+        role_hint_parts.append(
+            "exploration/planning: " + format_agent_names(exploration_or_planning)
         )
     if review:
-        lines.append(
-            "Use these read-only review roles near the end for non-trivial or "
-            f"risky changes: {format_agent_names(review)}."
-        )
+        role_hint_parts.append("review: " + format_agent_names(review))
+    if role_hint_parts:
+        lines.append("Suggested role timing: " + "; ".join(role_hint_parts) + ".")
     lines.append(
-        "For every subagent you spawn, request a concise final summary, wait "
-        "for the result, consolidate it in the parent thread, and close the "
-        "completed subagent thread when close controls are available and no "
-        "follow-up is needed."
-    )
-    lines.append(
-        "When multiple subagents are running, close each completed handle as "
-        "its terminal result arrives, then continue waiting on the remaining "
-        "handles until all spawned subagents are closed."
-    )
-    lines.append(
-        "Treat both `wait_agent` completions and asynchronous subagent "
-        "completion notifications as terminal results that should be "
-        "consolidated and closed."
-    )
-    lines.append(
-        "Keep subagent requests bounded and read-only. If spawning is unavailable "
-        "or denied, continue locally with narrow reads and state that limitation."
-    )
-    lines.append(
-        "If delegation is authorized and useful but subagent controls are not "
-        "visible, and `tool_search` is available, first search for "
-        "multi-agent/subagent tools before reporting delegation unavailable."
+        "Use only targeted roles when useful, available, and permitted; do not "
+        "spawn every role by default."
     )
     return "\n".join(lines) + "\n"
 
@@ -385,25 +322,25 @@ No session-scoped task-state path is available for this prompt. Continue without
 creating a manual fallback path or repo-local state file.
 """
     else:
+        state_note = (
+            "An existing task-state file is available; read it when this prompt "
+            "is a continuation or prior decisions may matter."
+            if state_file.exists()
+            else "This hook only advertises the path; it does not create task-state, SDLC run state, or workflow state."
+        )
         task_state_context = f"""Durable task-state file: `{state_file}`
 
-Read the task-state file first when this prompt is a continuation or prior
-decisions may matter.
+{state_note}
 """
 
-    context = f"""This prompt should use global context management.
+    context = f"""Global context hint for a complex prompt.
 
 {task_state_context}
-Apply the `global-context-management` skill. Keep raw
-exploration output out of the parent context. Use configured read-only
-subagents for read-heavy exploration when delegation is authorized by the user
-prompt or by a user-enabled local hook policy, when they are useful, the
-current runtime exposes subagent tools, and the current instructions permit
-delegation. If delegation was not authorized by the prompt or local hook
-policy, or subagents are unavailable or not permitted, continue with narrow
-local reads and state that limitation. Use read-only review agents before
-finalizing non-trivial code changes only when delegation is authorized,
-available, and permitted.
+Keep raw exploration output out of the parent context. Use configured read-only
+subagents only when delegation is authorized by the user prompt or local hook
+policy, the runtime exposes subagent tools, and active instructions permit it.
+This hook does not route SDLC phases, parse requirements, select workflow
+skills, create run state, or inject large documents.
 {subagent_context(home)}"""
 
     print(

--- a/skills/global-context-management/references/local-setup.md
+++ b/skills/global-context-management/references/local-setup.md
@@ -72,7 +72,7 @@ global file.
   the parent thread.
 - Use bounded read-only subagents for noisy exploration when the user
   explicitly requests delegation, or when a user-enabled local hook policy
-  injects that request, and subagents are available and useful. Use a
+  adds a lightweight delegation hint, and subagents are available and useful. Use a
   read-only risk review before finalizing non-trivial changes only when
   delegation is authorized and permitted.
 - When subagents are used, ask them for concise final summaries, wait for the
@@ -149,12 +149,11 @@ local-only policy file:
 Save it as `$CODEX_HOME/hooks/global_context_policy.json`. The hook will read
 `$CODEX_HOME/config.toml`, discover configured `[agents.<name>]` entries whose
 referenced configs under `$CODEX_HOME` have `sandbox_mode = "read-only"`, and
-inject a request to use those read-only roles by name. It does not inject local
-agent config paths and does not directly call the subagent tool. The injected
-request is the local-policy delegation request for that turn, so the main
-agent should not wait for another manual prompt phrase before using useful,
-available, and permitted read-only helpers. The injected request tells Codex
-not to spawn every configured role by default. The parent agent still owns
+add those read-only role names as a model-visible hint. It does not inject local
+agent config paths and does not directly call the subagent tool. The hint is
+local-policy context for that turn, so the main agent still uses read-only
+helpers only when useful, available, and permitted. The hint tells Codex not to
+spawn every configured role by default. The parent agent still owns
 lifecycle cleanup: wait for returned summaries, consolidate them, and close
 completed subagent threads when close controls are available and no follow-up
 is needed. With multiple subagents, close each completed handle as its
@@ -198,9 +197,9 @@ injected task-state path appears. Treat runtime activation as unverified until
 observed in the target Codex surface.
 
 Direct hook unit probes against a live `$CODEX_HOME` with synthetic
-`session_id` values can create scaffold-only task-state directories named after
-those IDs when they exercise the complex-prompt hook. They validate hook path
-calculation, not active persistent model state. Prefer
+`session_id` values should not create task-state files or directories. They
+validate hook path calculation and prompt-time hints, not active persistent
+model state. Prefer
 `scripts/validate-local-templates.py` for hook-unit validation because it uses
 disposable temporary homes. If a hook payload has no `session_id`, task state is
 unavailable and no manual or legacy fallback path is created.
@@ -224,8 +223,8 @@ If the probe does not spawn a subagent, check:
 - If multi-agent tools are not exposed directly, `tool_search` is available and
   can discover deferred multi-agent/subagent tools.
 - The user prompt explicitly asks Codex to use or spawn subagents, use
-  delegation, or run parallel agents, or the enabled local hook policy injects
-  that request for the prompt.
+  delegation, or run parallel agents, or the enabled local hook policy adds a
+  delegation hint for the prompt.
 - The current user or developer instructions permit delegation for the task.
 
 If `$CODEX_HOME/hooks/global_context_policy.json` is enabled, also run a

--- a/skills/global-context-management/references/local-setup.md
+++ b/skills/global-context-management/references/local-setup.md
@@ -72,8 +72,8 @@ global file.
   the parent thread.
 - Use bounded read-only subagents for noisy exploration when the user
   explicitly requests delegation, or when a user-enabled local hook policy
-  adds a lightweight delegation hint, and subagents are available and useful. Use a
-  read-only risk review before finalizing non-trivial changes only when
+  injects that request, and subagents are available and useful. Use a read-only
+  risk review before finalizing non-trivial changes only when
   delegation is authorized and permitted.
 - When subagents are used, ask them for concise final summaries, wait for the
   result, consolidate it in the parent thread, and close completed subagent
@@ -196,6 +196,13 @@ Then run a non-mutating Codex probe from a test repository and confirm the
 injected task-state path appears. Treat runtime activation as unverified until
 observed in the target Codex surface.
 
+For persistence, also confirm any installed PreToolUse write guard allows
+agent edits under `$CODEX_HOME/task-state`. The global-context hooks only
+advertise or reuse the session-scoped `current.md`; the parent agent creates
+and updates that file when continuity is useful. Keep broader runtime paths
+such as `$CODEX_HOME/hooks` protected unless the user deliberately syncs hook
+sources.
+
 Direct hook unit probes against a live `$CODEX_HOME` with synthetic
 `session_id` values should not create task-state files or directories. They
 validate hook path calculation and prompt-time hints, not active persistent
@@ -224,7 +231,7 @@ If the probe does not spawn a subagent, check:
   can discover deferred multi-agent/subagent tools.
 - The user prompt explicitly asks Codex to use or spawn subagents, use
   delegation, or run parallel agents, or the enabled local hook policy adds a
-  delegation hint for the prompt.
+  delegation request for the prompt.
 - The current user or developer instructions permit delegation for the task.
 
 If `$CODEX_HOME/hooks/global_context_policy.json` is enabled, also run a

--- a/skills/global-context-management/references/local-setup.md
+++ b/skills/global-context-management/references/local-setup.md
@@ -72,9 +72,11 @@ global file.
   the parent thread.
 - Use bounded read-only subagents for noisy exploration when the user
   explicitly requests delegation, or when a user-enabled local hook policy
-  injects that request, and subagents are available and useful. Use a read-only
-  risk review before finalizing non-trivial changes only when
-  delegation is authorized and permitted.
+  injects that request, and subagents are useful, available, and permitted.
+  After authorization, choose targeted helper roles yourself instead of waiting
+  for the user to name an exact role. Use a read-only risk review before
+  finalizing non-trivial changes only when delegation is authorized, useful,
+  available, and permitted.
 - When subagents are used, ask them for concise final summaries, wait for the
   result, consolidate it in the parent thread, and close completed subagent
   threads when close controls are available and no follow-up is needed.
@@ -125,7 +127,9 @@ they do not count as authorization, and they do not guarantee a separate
 user-visible control in every Codex surface. Current public Codex docs say
 Codex only spawns subagents when explicitly asked. In this workflow, that
 explicit request can come from the prompt, or from the optional local hook
-policy below when active runtime instructions accept the hook context.
+policy below when active runtime instructions accept the hook context. Once
+delegation is authorized, Codex should choose targeted helper roles when they
+are useful; the prompt does not need to name a specific role.
 When delegation is authorized and useful but the active tool list does not show
 subagent controls, and `tool_search` is available, Codex should search for
 multi-agent/subagent tools before reporting delegation unavailable.
@@ -149,11 +153,12 @@ local-only policy file:
 Save it as `$CODEX_HOME/hooks/global_context_policy.json`. The hook will read
 `$CODEX_HOME/config.toml`, discover configured `[agents.<name>]` entries whose
 referenced configs under `$CODEX_HOME` have `sandbox_mode = "read-only"`, and
-add those read-only role names as a model-visible hint. It does not inject local
-agent config paths and does not directly call the subagent tool. The hint is
-local-policy context for that turn, so the main agent still uses read-only
-helpers only when useful, available, and permitted. The hint tells Codex not to
-spawn every configured role by default. The parent agent still owns
+add those read-only role names as a model-visible delegation request. It does
+not inject local agent config paths and does not directly call the subagent
+tool. The hint is local-policy context for that turn, so the main agent still
+uses targeted read-only helpers only when useful, available, and permitted. The
+hint tells Codex not to spawn every configured role by default. The parent
+agent still owns
 lifecycle cleanup: wait for returned summaries, consolidate them, and close
 completed subagent threads when close controls are available and no follow-up
 is needed. With multiple subagents, close each completed handle as its
@@ -231,14 +236,15 @@ If the probe does not spawn a subagent, check:
   can discover deferred multi-agent/subagent tools.
 - The user prompt explicitly asks Codex to use or spawn subagents, use
   delegation, or run parallel agents, or the enabled local hook policy adds a
-  delegation request for the prompt.
+  bounded read-only delegation request for the prompt.
 - The current user or developer instructions permit delegation for the task.
 
 If `$CODEX_HOME/hooks/global_context_policy.json` is enabled, also run a
 complex prompt without naming a specific subagent and confirm the hook-injected
-context discovers the configured read-only agent names. If it does not, check
-that the hook was trusted after the file changed and that each referenced
-agent config uses `sandbox_mode = "read-only"`.
+context discovers the configured read-only agent names and requests bounded
+read-only delegation. Codex may then choose useful targeted roles itself. If it
+does not, check that the hook was trusted after the file changed and that each
+referenced agent config uses `sandbox_mode = "read-only"`.
 
 Even when the probe succeeds, context can still grow quickly if broad command
 output, long logs, large file dumps, or repeated exploration are returned in

--- a/skills/global-context-management/scripts/validate-local-templates.py
+++ b/skills/global-context-management/scripts/validate-local-templates.py
@@ -188,7 +188,10 @@ def assert_agent_delegation_context(context: str) -> None:
         raise AssertionError("non-read-only agent leaked into context")
     if "agents/alpha_mapper.toml" in context:
         raise AssertionError("agent config path leaked into context")
-    if "Local policy permits read-only subagent delegation" not in context:
+    if (
+        "Local policy requests bounded read-only subagent delegation"
+        not in context
+    ):
         raise AssertionError("delegation policy context missing")
     if "Available read-only roles:" not in context:
         raise AssertionError("read-only role list missing")
@@ -517,7 +520,7 @@ def validate_direct_hooks(root: Path, codex_home: Path, home: Path) -> None:
         raise AssertionError("UserPromptSubmit should not route sdlc-start")
     if "Apply the `global-context-management` skill" in context:
         raise AssertionError("UserPromptSubmit should not directly select skills")
-    if "Local policy permits read-only subagent delegation" in context:
+    if "Local policy requests bounded read-only subagent delegation" in context:
         raise AssertionError("delegation context appeared before policy opt-in")
     if "For every subagent you spawn" in context:
         raise AssertionError("UserPromptSubmit repeated subagent workflow detail")
@@ -576,7 +579,10 @@ def validate_direct_hooks(root: Path, codex_home: Path, home: Path) -> None:
     env_override_context = json.loads(env_override_result.stdout)["hookSpecificOutput"][
         "additionalContext"
     ]
-    if "Local policy permits read-only subagent delegation" in env_override_context:
+    if (
+        "Local policy requests bounded read-only subagent delegation"
+        in env_override_context
+    ):
         raise AssertionError("environment override unexpectedly enabled delegation")
 
     write_agent_fixture(codex_home, enable_policy=True)

--- a/skills/global-context-management/scripts/validate-local-templates.py
+++ b/skills/global-context-management/scripts/validate-local-templates.py
@@ -343,6 +343,7 @@ def assert_doc_contracts(root: Path) -> None:
 
     required_skill = (
         "No legacy task-state",
+        "it must allow writes under\n`$CODEX_HOME/task-state`",
     )
     for needle in required_skill:
         if needle not in gcm_skill:
@@ -355,6 +356,7 @@ def assert_doc_contracts(root: Path) -> None:
         "hidden state automatically active",
         "continuity note",
         "should not create task-state files or directories",
+        "Any local PreToolUse write guard must explicitly allow\n`$CODEX_HOME/task-state` writes",
     )
     for needle in required_gcm:
         if needle not in gcm_readme:

--- a/skills/global-context-management/scripts/validate-local-templates.py
+++ b/skills/global-context-management/scripts/validate-local-templates.py
@@ -94,6 +94,10 @@ def assert_no_prompt_leak(state_file: Path) -> None:
 def assert_missing_state_path(state_file: Path, codex_home: Path) -> None:
     if state_file.exists():
         raise AssertionError(f"hook unexpectedly created task-state file: {state_file}")
+    if state_file.parent.exists():
+        raise AssertionError(
+            f"hook unexpectedly created task-state directory: {state_file.parent}"
+        )
     try:
         state_file.relative_to(codex_home)
     except ValueError as exc:
@@ -173,6 +177,8 @@ config_file = "agents/write_worker.toml"
 
 
 def assert_agent_delegation_context(context: str) -> None:
+    if len(context) > 1200:
+        raise AssertionError("delegation context is too large for a lightweight hint")
     expected = ("alpha_mapper", "beta_test_planner", "gamma_risk_reviewer")
     for name in expected:
         if f"`{name}`" not in context:
@@ -182,29 +188,25 @@ def assert_agent_delegation_context(context: str) -> None:
         raise AssertionError("non-read-only agent leaked into context")
     if "agents/alpha_mapper.toml" in context:
         raise AssertionError("agent config path leaked into context")
-    if "Hook-assisted read-only subagent delegation is enabled" not in context:
+    if "Local policy permits read-only subagent delegation" not in context:
         raise AssertionError("delegation policy context missing")
-    if "local-policy delegation request for this turn" not in context:
-        raise AssertionError("local-policy delegation request guidance missing")
-    if "another manual user request" not in context:
-        raise AssertionError("manual delegation prompt fallback guidance missing")
-    if "explicitly use all discovered read-only roles" in context:
-        raise AssertionError("over-broad all-role subagent guidance returned")
-    if "Do not spawn every configured role by default" not in context:
+    if "Available read-only roles:" not in context:
+        raise AssertionError("read-only role list missing")
+    if "Suggested role timing:" not in context:
+        raise AssertionError("role timing hint missing")
+    if "do not spawn every role by default" not in context:
         raise AssertionError("bounded subagent selection guidance missing")
-    if "parallel only when their work is independent and useful" not in context:
-        raise AssertionError("useful early exploration guidance missing")
-    if "near the end for non-trivial or risky changes" not in context:
-        raise AssertionError("late risk-review guidance missing")
-    if "close the completed subagent thread" not in context:
-        raise AssertionError("subagent cleanup guidance missing")
-    if "continue waiting on the remaining handles" not in context:
-        raise AssertionError("multi-subagent cleanup guidance missing")
-    if "`wait_agent` completions" not in context:
-        raise AssertionError("wait_agent cleanup guidance missing")
-    if "asynchronous subagent completion notifications" not in context:
-        raise AssertionError("async subagent cleanup guidance missing")
-    assert_tool_search_discovery_guidance(context, "delegation context")
+    forbidden = (
+        "For every subagent you spawn",
+        "close the completed subagent thread",
+        "continue waiting on the remaining handles",
+        "`wait_agent` completions",
+        "asynchronous subagent completion notifications",
+        "`tool_search` is available",
+    )
+    for needle in forbidden:
+        if needle in context:
+            raise AssertionError(f"delegation context repeats workflow detail: {needle}")
 
 
 def assert_no_default_agent_names(context: str) -> None:
@@ -352,7 +354,7 @@ def assert_doc_contracts(root: Path) -> None:
         "manual or legacy fallback path",
         "hidden state automatically active",
         "continuity note",
-        "Synthetic complex-prompt hook probes that pass a made-up `session_id`",
+        "should not create task-state files or directories",
     )
     for needle in required_gcm:
         if needle not in gcm_readme:
@@ -362,8 +364,8 @@ def assert_doc_contracts(root: Path) -> None:
         "Treat runtime activation as unverified",
         "task-state path under",
         "Direct hook unit probes against a live `$CODEX_HOME`",
-        "checks that `SessionStart` does not create missing scaffold files",
-        "manual or legacy task-state path",
+        "do not create missing scaffold",
+        "No manual or legacy",
     )
     for needle in required_config:
         if needle not in config_readme:
@@ -420,10 +422,17 @@ def validate_direct_hooks(root: Path, codex_home: Path, home: Path) -> None:
         "additionalContext"
     ]
     assert_no_default_agent_names(session_context)
-    assert_tool_search_discovery_guidance(session_context, "SessionStart")
     state_file = extract_state_path(session_result.stdout)
     if not str(state_file).startswith(str(codex_home / "task-state") + os.sep):
         raise AssertionError(f"state file is outside CODEX_HOME: {state_file}")
+    if len(session_context) > 800:
+        raise AssertionError("SessionStart context is too large")
+    if "Apply the `global-context-management` skill" in session_context:
+        raise AssertionError("SessionStart should not directly select skills")
+    if "subagent" in session_context.lower():
+        raise AssertionError("SessionStart should not inject subagent workflow detail")
+    if "sdlc-start" in session_context:
+        raise AssertionError("SessionStart should not route SDLC")
     assert_missing_state_path(state_file, codex_home)
     preserved_state = (
         "# Current Codex task state\n\n"
@@ -498,10 +507,18 @@ def validate_direct_hooks(root: Path, codex_home: Path, home: Path) -> None:
         state_file=state_file,
         expected_text=preserved_state,
     )
-    if "Apply the `global-context-management` skill" not in context:
-        raise AssertionError("complex prompt did not request the skill")
-    if "Hook-assisted read-only subagent delegation is enabled" in context:
+    if "Global context hint for a complex prompt." not in context:
+        raise AssertionError("complex prompt did not provide global context hint")
+    if len(context) > 900:
+        raise AssertionError("non-delegated UserPromptSubmit context is too large")
+    if "sdlc-start" in context:
+        raise AssertionError("UserPromptSubmit should not route sdlc-start")
+    if "Apply the `global-context-management` skill" in context:
+        raise AssertionError("UserPromptSubmit should not directly select skills")
+    if "Local policy permits read-only subagent delegation" in context:
         raise AssertionError("delegation context appeared before policy opt-in")
+    if "For every subagent you spawn" in context:
+        raise AssertionError("UserPromptSubmit repeated subagent workflow detail")
     if SENTINEL_MARKER in context:
         raise AssertionError("hook echoed prompt content into model context")
     assert_no_prompt_leak(state_file)
@@ -526,12 +543,7 @@ def validate_direct_hooks(root: Path, codex_home: Path, home: Path) -> None:
             "fresh complex prompt used unexpected state path: "
             f"{fresh_complex_state} != {expected_fresh_complex_state}"
         )
-    if not fresh_complex_state.exists():
-        raise AssertionError(
-            f"fresh complex prompt did not create: {fresh_complex_state}"
-        )
-    assert_private_file(fresh_complex_state)
-    assert_no_prompt_leak(fresh_complex_state)
+    assert_missing_state_path(fresh_complex_state, codex_home)
 
     missing_session_complex_payload = {
         "cwd": cwd,
@@ -562,7 +574,7 @@ def validate_direct_hooks(root: Path, codex_home: Path, home: Path) -> None:
     env_override_context = json.loads(env_override_result.stdout)["hookSpecificOutput"][
         "additionalContext"
     ]
-    if "Hook-assisted read-only subagent delegation is enabled" in env_override_context:
+    if "Local policy permits read-only subagent delegation" in env_override_context:
         raise AssertionError("environment override unexpectedly enabled delegation")
 
     write_agent_fixture(codex_home, enable_policy=True)

--- a/skills/helmchart/SKILL.md
+++ b/skills/helmchart/SKILL.md
@@ -156,6 +156,23 @@ When using this skill, provide:
 3. Validation results (`helm lint`, `helm template`, and CI checks if applicable).
 4. Explicit list of deferred items and why they were deferred.
 
+## Learning Loop
+
+When using this skill, capture durable, reusable, public-safe learnings back
+into this skill's local source materials before completion when the current task
+contract allows source edits. Update the narrowest appropriate surface:
+`SKILL.md` for runtime rules, `references/` for detailed guidance, `assets/`
+for reusable templates, `scripts/` for deterministic helpers, and README or
+changelog entries for human-facing or release-note updates.
+
+If the current task is explicitly read-only/report-only, or source writes are
+outside this skill's task contract, do not edit skill sources; report the
+skipped source update instead.
+
+Do not capture secrets, private URLs, customer data, raw logs, one-off local
+state, or unverified/vendor-specific claims. If a useful learning is not safe,
+not evidence-backed, or outside this skill's scope, report that it was skipped.
+
 ## Guardrails
 
 - Never put real secrets in `values.yaml`, templates, tests, or docs.

--- a/skills/install-grafana-mcp-for-nebius/SKILL.md
+++ b/skills/install-grafana-mcp-for-nebius/SKILL.md
@@ -135,6 +135,23 @@ Nebius trace querying through `mcp-grafana` until the configured server lists
 usable `tempo_*` proxied tools, or until a current Nebius doc explicitly says
 its Tempo endpoint supports the Grafana Tempo MCP proxy path.
 
+## Learning Loop
+
+When using this skill, capture durable, reusable, public-safe learnings back
+into this skill's local source materials before completion when the current task
+contract allows source edits. Update the narrowest appropriate surface:
+`SKILL.md` for runtime rules, `references/` for detailed guidance, `assets/`
+for reusable templates, `scripts/` for deterministic helpers, and README or
+changelog entries for human-facing or release-note updates.
+
+If the current task is explicitly read-only/report-only, or source writes are
+outside this skill's task contract, do not edit skill sources; report the
+skipped source update instead.
+
+Do not capture secrets, private URLs, customer data, raw logs, one-off local
+state, or unverified/vendor-specific claims. If a useful learning is not safe,
+not evidence-backed, or outside this skill's scope, report that it was skipped.
+
 ## Validation
 
 Run safe static and local checks first:

--- a/skills/install-skills.sh
+++ b/skills/install-skills.sh
@@ -5,6 +5,8 @@ set -euo pipefail
 #
 # Usage: ./install-skills.sh [source] [destination_dir]
 #        ./install-skills.sh --remove-skill <skill_name> [destination_dir]
+#        ./install-skills.sh --install-hooks <source_hook_dir>
+#        ./install-skills.sh --install-all-hooks
 #        ./install-skills.sh --help
 # No-argument install: source is this script's directory and destination is
 # ~/.agents/skills. --remove-skill without a destination removes from the same
@@ -13,7 +15,8 @@ set -euo pipefail
 #   - https://github.com/<owner>/<repo>
 #   - https://github.com/<owner>/<repo>/tree/<ref>/<subpath>
 #
-# Requirements: bash, rsync, and git (GitHub sources only).
+# Requirements: bash, rsync, and git (GitHub sources only). Hook installation
+# also uses install, find, cmp, chmod, awk, cut, sort, and mktemp.
 # How behavior is enforced:
 #   - Skill detection: only directories containing SKILL.md are treated as skills.
 #   - Idempotency: rsync keeps destination in sync (--delete, --omit-dir-times) and
@@ -81,6 +84,8 @@ show_usage() {
   printf '%b\n' "${S_BOLD}Usage:${S_RESET}"
   printf '%b\n' "  ${S_CYAN}./install-skills.sh${S_RESET} ${S_DIM}[source] [destination_dir]${S_RESET}"
   printf '%b\n' "  ${S_CYAN}./install-skills.sh${S_RESET} ${S_DIM}--remove-skill <skill_name> [destination_dir]${S_RESET}"
+  printf '%b\n' "  ${S_CYAN}./install-skills.sh${S_RESET} ${S_DIM}--install-hooks <source_hook_dir>${S_RESET}"
+  printf '%b\n' "  ${S_CYAN}./install-skills.sh${S_RESET} ${S_DIM}--install-all-hooks${S_RESET}"
   printf '%b\n' "  ${S_CYAN}./install-skills.sh${S_RESET} ${S_DIM}--help${S_RESET}"
   printf '\n'
 
@@ -103,6 +108,12 @@ show_usage() {
   printf '%b\n' "${S_BOLD}Options:${S_RESET}"
   printf '%b\n' "  ${S_YELLOW}-h, --help${S_RESET}       Show this help"
   printf '%b\n' "  ${S_YELLOW}--remove-skill${S_RESET}   Remove one skill by its visible Codex skill name or folder name"
+  printf '%b\n' "  ${S_YELLOW}--install-hooks${S_RESET}  Copy hook files from a source hook directory into"
+  printf '%b\n' "                    ${S_CYAN}\${CODEX_HOME:-~/.codex}/hooks${S_RESET}, stripping .template suffixes"
+  printf '%b\n' "                    without modifying hooks.json"
+  printf '%b\n' "  ${S_YELLOW}--install-all-hooks${S_RESET}"
+  printf '%b\n' "                    Copy hook files from every ${S_CYAN}*/assets/hooks${S_RESET} directory"
+  printf '%b\n' "                    under this source skills folder"
   printf '\n'
 
   printf '%b\n' "${S_BOLD}Examples:${S_RESET}"
@@ -112,6 +123,9 @@ show_usage() {
   printf '%b\n' "  ${S_CYAN}./install-skills.sh \"https://github.com/openai/skills/tree/main/skills\" \"~/custom-skills\"${S_RESET}"
   printf '%b\n' "  ${S_CYAN}./install-skills.sh --remove-skill nebius${S_RESET}"
   printf '%b\n' "  ${S_CYAN}./install-skills.sh --remove-skill nebius \"~/custom-skills\"${S_RESET}"
+  printf '%b\n' "  ${S_CYAN}./install-skills.sh --install-hooks sdlc-start/assets/hooks${S_RESET}"
+  printf '%b\n' "  ${S_CYAN}./install-skills.sh --install-hooks config-codex/assets/hooks${S_RESET}"
+  printf '%b\n' "  ${S_CYAN}./install-skills.sh --install-all-hooks${S_RESET}"
   printf '\n'
 
   printf '%b\n' "${S_BOLD}Notes:${S_RESET}"
@@ -122,6 +136,9 @@ show_usage() {
   printf '%b\n' "  - ${S_CYAN}--remove-skill${S_RESET} accepts the exact skill name from ${S_CYAN}SKILL.md${S_RESET} ${S_DIM}(the name Codex shows in VS Code)${S_RESET} or the installed folder name."
   printf '%b\n' "  - ${S_CYAN}--remove-skill${S_RESET} removes the skill folder and local manifest entries from the selected destination."
   printf '%b\n' "  - Reinstalling from a source that still contains the skill will add it back."
+  printf '%b\n' "  - ${S_CYAN}--install-hooks${S_RESET} is opt-in because hooks are runtime guardrails, not skills."
+  printf '%b\n' "  - ${S_CYAN}--install-all-hooks${S_RESET} discovers only hook-only ${S_CYAN}*/assets/hooks${S_RESET} directories under this source."
+  printf '%b\n' "  - After installing hooks, restart Codex and review/trust the hook entries in ${S_CYAN}/hooks${S_RESET}."
   printf '%b\n' "  - If newly installed skills are not visible, restart the VS Code extension host ${S_DIM}(Developer: Restart Extension Host)${S_RESET}."
 }
 
@@ -479,9 +496,215 @@ print_extra_destination_skills() {
   fi
 }
 
+resolve_hook_source_dir() {
+  local value="$1"
+  local expanded=""
+  local from_script=""
+
+  expanded="$(expand_home_path "${value}")"
+  if [[ -d "${expanded}" ]]; then
+    (cd "${expanded}" && pwd -P)
+    return 0
+  fi
+
+  from_script="${DEFAULT_SRC_DIR}/${value}"
+  if [[ -d "${from_script}" ]]; then
+    (cd "${from_script}" && pwd -P)
+    return 0
+  fi
+
+  return 1
+}
+
+is_installable_hook_rel() {
+  local rel="$1"
+
+  case "${rel}" in
+    README.md|*/README.md|hooks.json|*/hooks.json|hooks.json.template|*/hooks.json.template|*__pycache__*|*.pyc|*.pyo|*.DS_Store)
+      return 1
+      ;;
+    *.py|*.json|*.py.template|*.json.template)
+      return 0
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
+install_hooks() {
+  local hook_source_arg="$1"
+  local codex_home="$2"
+  local hook_src=""
+  local hook_dest="${codex_home}/hooks"
+  local src=""
+  local rel=""
+  local dest_rel=""
+  local installed=0
+  local unchanged=0
+  local total=0
+
+  require_command "install" "for hook installation"
+  require_command "cmp" "for hook idempotency checks"
+  require_command "chmod" "for hook permission repair"
+  require_command "find" "for hook source discovery"
+
+  if ! hook_src="$(resolve_hook_source_dir "${hook_source_arg}")"; then
+    log_error "hook source directory not found: ${hook_source_arg}"
+    log_note "Pass a hook-only source directory, for example sdlc-start/assets/hooks or config-codex/assets/hooks."
+    exit 1
+  fi
+
+  mkdir -p "${hook_dest}"
+
+  while IFS= read -r -d '' src; do
+    rel="${src#"${hook_src}/"}"
+    is_installable_hook_rel "${rel}" || continue
+
+    dest_rel="${rel%.template}"
+    total=$((total + 1))
+    if [[ -f "${hook_dest}/${dest_rel}" ]] && cmp -s "${src}" "${hook_dest}/${dest_rel}"; then
+      chmod 0644 "${hook_dest}/${dest_rel}"
+      unchanged=$((unchanged + 1))
+      continue
+    fi
+
+    mkdir -p "$(dirname "${hook_dest}/${dest_rel}")"
+    install -m 0644 "${src}" "${hook_dest}/${dest_rel}"
+    installed=$((installed + 1))
+  done < <(find "${hook_src}" -type f -print0)
+
+  if [[ "${total}" -eq 0 ]]; then
+    log_error "no hook files found in source directory: ${hook_src}"
+    log_note "Expected files ending in .py, .json, .py.template, or .json.template."
+    exit 1
+  fi
+
+  log_success "Done. Hook files installed/updated: ${installed}, unchanged: ${unchanged} from ${hook_src} -> ${hook_dest}"
+  log_note "Template suffixes were stripped for installed hook files."
+  log_note "This did not modify hooks.json or trust hooks."
+  log_note "Restart Codex, open /hooks, and review the hook entries before relying on them."
+}
+
+discover_hook_source_dirs() {
+  local source_root="$1"
+  local d=""
+  local hook_dir=""
+
+  if [[ -f "${source_root}/SKILL.md" ]]; then
+    hook_dir="${source_root}/assets/hooks"
+    if [[ -d "${hook_dir}" ]]; then
+      (cd "${hook_dir}" && pwd -P)
+    fi
+    return 0
+  fi
+
+  shopt -s nullglob
+  for d in "${source_root}"/*; do
+    [[ -d "${d}" ]] || continue
+    [[ -f "${d}/SKILL.md" ]] || continue
+    hook_dir="${d}/assets/hooks"
+    if [[ -d "${hook_dir}" ]]; then
+      (cd "${hook_dir}" && pwd -P)
+    fi
+  done
+  shopt -u nullglob
+}
+
+validate_hook_dest_collisions() {
+  local manifest=""
+  local hook_src=""
+  local src=""
+  local rel=""
+  local dest_rel=""
+  local key=""
+  local first=""
+  local duplicate=""
+
+  require_command "cmp" "for hook collision checks"
+  require_command "find" "for hook source discovery"
+
+  manifest="$(mktemp)"
+  for hook_src in "$@"; do
+    while IFS= read -r -d '' src; do
+      rel="${src#"${hook_src}/"}"
+      is_installable_hook_rel "${rel}" || continue
+      dest_rel="${rel%.template}"
+      printf '%s\t%s\n' "${dest_rel}" "${src}" >> "${manifest}"
+    done < <(find "${hook_src}" -type f -print0)
+  done
+
+  while IFS= read -r key; do
+    [[ -n "${key}" ]] || continue
+    first=""
+    duplicate=0
+    while IFS=$'\t' read -r _ src; do
+      if [[ -z "${first}" ]]; then
+        first="${src}"
+        continue
+      fi
+      duplicate=1
+      if ! cmp -s "${first}" "${src}"; then
+        log_error "--install-all-hooks found conflicting hook destination: ${key}"
+        log_note "First source: ${first}"
+        log_note "Conflicting source: ${src}"
+        rm -f "${manifest}"
+        exit 1
+      fi
+    done < <(awk -F '\t' -v k="${key}" '$1 == k { print $0 }' "${manifest}")
+    if [[ "${duplicate}" -eq 1 ]]; then
+      log_note "Duplicate hook destination has identical content: ${key}"
+    fi
+  done < <(cut -f 1 "${manifest}" | sort -u)
+
+  rm -f "${manifest}"
+}
+
+install_all_hooks() {
+  local source_root_arg="$1"
+  local codex_home="$2"
+  local source_root=""
+  local hook_src=""
+  local hook_dirs=()
+  local displayed=""
+
+  if [[ ! -d "${source_root_arg}" ]]; then
+    log_error "source skills folder not found: ${source_root_arg}"
+    exit 1
+  fi
+  source_root="$(cd "${source_root_arg}" && pwd -P)"
+
+  while IFS= read -r hook_src; do
+    [[ -n "${hook_src}" ]] || continue
+    hook_dirs+=("${hook_src}")
+  done < <(discover_hook_source_dirs "${source_root}" | sort)
+
+  if [[ "${#hook_dirs[@]}" -eq 0 ]]; then
+    log_error "no hook source directories found under ${source_root}"
+    log_note "Expected skill-owned hook bundles at */assets/hooks."
+    exit 1
+  fi
+
+  validate_hook_dest_collisions "${hook_dirs[@]}"
+
+  log_note "Discovered hook source directories:"
+  for hook_src in "${hook_dirs[@]}"; do
+    displayed="${hook_src#"${source_root}/"}"
+    log_note "  - ${displayed}"
+  done
+
+  for hook_src in "${hook_dirs[@]}"; do
+    install_hooks "${hook_src}" "${codex_home}"
+  done
+
+  log_success "Done. Processed all hooks from ${#hook_dirs[@]} source directorie(s)."
+}
+
 init_output_style
 
 REMOVE_SKILL=""
+HOOK_INSTALL_SOURCE=""
+INSTALL_ALL_HOOKS=0
 POSITIONAL=()
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -503,6 +726,29 @@ while [[ $# -gt 0 ]]; do
       REMOVE_SKILL="$2"
       shift 2
       ;;
+    --install-hooks)
+      if [[ $# -lt 2 ]]; then
+        log_error "--install-hooks requires a source hook directory."
+        show_usage >&2
+        exit 1
+      fi
+      if [[ -n "${HOOK_INSTALL_SOURCE}" ]]; then
+        log_error "--install-hooks may only be specified once."
+        show_usage >&2
+        exit 1
+      fi
+      HOOK_INSTALL_SOURCE="$2"
+      shift 2
+      ;;
+    --install-all-hooks)
+      if [[ "${INSTALL_ALL_HOOKS}" -eq 1 ]]; then
+        log_error "--install-all-hooks may only be specified once."
+        show_usage >&2
+        exit 1
+      fi
+      INSTALL_ALL_HOOKS=1
+      shift
+      ;;
     --)
       shift
       while [[ $# -gt 0 ]]; do
@@ -521,6 +767,43 @@ while [[ $# -gt 0 ]]; do
       ;;
   esac
 done
+
+if [[ -n "${HOOK_INSTALL_SOURCE}" && "${INSTALL_ALL_HOOKS}" -eq 1 ]]; then
+  log_error "--install-hooks cannot be combined with --install-all-hooks."
+  show_usage >&2
+  exit 1
+fi
+
+if [[ ( -n "${HOOK_INSTALL_SOURCE}" || "${INSTALL_ALL_HOOKS}" -eq 1 ) && -n "${REMOVE_SKILL}" ]]; then
+  log_error "hook installation cannot be combined with --remove-skill."
+  show_usage >&2
+  exit 1
+fi
+
+if [[ "${INSTALL_ALL_HOOKS}" -eq 1 ]]; then
+  if [[ "${#POSITIONAL[@]}" -gt 0 ]]; then
+    log_error "--install-all-hooks does not accept positional arguments."
+    log_note "It installs from hook-only */assets/hooks directories under this script's source folder."
+    log_note "Set CODEX_HOME to choose a non-default Codex home."
+    show_usage >&2
+    exit 1
+  fi
+  CODEX_HOME_DIR="$(expand_home_path "${CODEX_HOME:-${HOME}/.codex}")"
+  install_all_hooks "${DEFAULT_SRC_DIR}" "${CODEX_HOME_DIR}"
+  exit 0
+fi
+
+if [[ -n "${HOOK_INSTALL_SOURCE}" ]]; then
+  if [[ "${#POSITIONAL[@]}" -gt 0 ]]; then
+    log_error "--install-hooks does not accept positional arguments."
+    log_note "Set CODEX_HOME to choose a non-default Codex home."
+    show_usage >&2
+    exit 1
+  fi
+  CODEX_HOME_DIR="$(expand_home_path "${CODEX_HOME:-${HOME}/.codex}")"
+  install_hooks "${HOOK_INSTALL_SOURCE}" "${CODEX_HOME_DIR}"
+  exit 0
+fi
 
 if [[ -n "${REMOVE_SKILL}" ]]; then
   if [[ "${#POSITIONAL[@]}" -gt 1 ]]; then

--- a/skills/linter/SKILL.md
+++ b/skills/linter/SKILL.md
@@ -44,3 +44,20 @@ scripts/lint-repo.sh --root .
 # Check-only mode
 scripts/lint-repo.sh --root . --no-fix --no-config-fallback
 ```
+
+## Learning Loop
+
+When using this skill, capture durable, reusable, public-safe learnings back
+into this skill's local source materials before completion when the current task
+contract allows source edits. Update the narrowest appropriate surface:
+`SKILL.md` for runtime rules, `references/` for detailed guidance, `assets/`
+for reusable templates, `scripts/` for deterministic helpers, and README or
+changelog entries for human-facing or release-note updates.
+
+If the current task is explicitly read-only/report-only, or source writes are
+outside this skill's task contract, do not edit skill sources; report the
+skipped source update instead.
+
+Do not capture secrets, private URLs, customer data, raw logs, one-off local
+state, or unverified/vendor-specific claims. If a useful learning is not safe,
+not evidence-backed, or outside this skill's scope, report that it was skipped.

--- a/skills/nebius/SKILL.md
+++ b/skills/nebius/SKILL.md
@@ -116,6 +116,23 @@ Implement Nebius IAM/Object Storage, VPC networking, quota-management, and MK8s 
    - aggregate shared quota consumers before comparing against available capacity
    - treat unresolved limits as warnings or coverage gaps, not as proof that quota is sufficient
 
+## Learning Loop
+
+When using this skill, capture durable, reusable, public-safe learnings back
+into this skill's local source materials before completion when the current task
+contract allows source edits. Update the narrowest appropriate surface:
+`SKILL.md` for runtime rules, `references/` for detailed guidance, `assets/`
+for reusable templates, `scripts/` for deterministic helpers, and README or
+changelog entries for human-facing or release-note updates.
+
+If the current task is explicitly read-only/report-only, or source writes are
+outside this skill's task contract, do not edit skill sources; report the
+skipped source update instead.
+
+Do not capture secrets, private URLs, customer data, raw logs, one-off local
+state, or unverified/vendor-specific claims. If a useful learning is not safe,
+not evidence-backed, or outside this skill's scope, report that it was skipped.
+
 ## Guardrails
 
 - Never print or commit private keys, tokens, or access key secrets.

--- a/skills/onboard-nebius-cxcli/SKILL.md
+++ b/skills/onboard-nebius-cxcli/SKILL.md
@@ -61,6 +61,23 @@ Start with `references/touchpoints.md`.
    Touch focused tests plus `README.md`, `docs/design.md`, and `CHANGELOG.md`
    under `services/nebius-cxcli`.
 
+## Learning Loop
+
+When using this skill, capture durable, reusable, public-safe learnings back
+into this skill's local source materials before completion when the current task
+contract allows source edits. Update the narrowest appropriate surface:
+`SKILL.md` for runtime rules, `references/` for detailed guidance, `assets/`
+for reusable templates, `scripts/` for deterministic helpers, and README or
+changelog entries for human-facing or release-note updates.
+
+If the current task is explicitly read-only/report-only, or source writes are
+outside this skill's task contract, do not edit skill sources; report the
+skipped source update instead.
+
+Do not capture secrets, private URLs, customer data, raw logs, one-off local
+state, or unverified/vendor-specific claims. If a useful learning is not safe,
+not evidence-backed, or outside this skill's scope, report that it was skipped.
+
 ## Guardrails
 
 - `wizard_profile` names are one-to-one with infra component ids.

--- a/skills/publish-helm/SKILL.md
+++ b/skills/publish-helm/SKILL.md
@@ -71,6 +71,23 @@ variables and secret:
      `Chart.yaml`
    - note that the publish step only tags; CI does the OCI package/push work
 
+## Learning Loop
+
+When using this skill, capture durable, reusable, public-safe learnings back
+into this skill's local source materials before completion when the current task
+contract allows source edits. Update the narrowest appropriate surface:
+`SKILL.md` for runtime rules, `references/` for detailed guidance, `assets/`
+for reusable templates, `scripts/` for deterministic helpers, and README or
+changelog entries for human-facing or release-note updates.
+
+If the current task is explicitly read-only/report-only, or source writes are
+outside this skill's task contract, do not edit skill sources; report the
+skipped source update instead.
+
+Do not capture secrets, private URLs, customer data, raw logs, one-off local
+state, or unverified/vendor-specific claims. If a useful learning is not safe,
+not evidence-backed, or outside this skill's scope, report that it was skipped.
+
 ## Guardrails
 
 - Keep one canonical release path. Do not add a chart-specific publish workflow

--- a/skills/publish-image/SKILL.md
+++ b/skills/publish-image/SKILL.md
@@ -58,6 +58,23 @@ Generate exactly these artifacts in the target project:
    - `./publish-image.sh --prep X.Y.Z`
    - `./publish-image.sh --publish X.Y.Z`
 
+## Learning Loop
+
+When using this skill, capture durable, reusable, public-safe learnings back
+into this skill's local source materials before completion when the current task
+contract allows source edits. Update the narrowest appropriate surface:
+`SKILL.md` for runtime rules, `references/` for detailed guidance, `assets/`
+for reusable templates, `scripts/` for deterministic helpers, and README or
+changelog entries for human-facing or release-note updates.
+
+If the current task is explicitly read-only/report-only, or source writes are
+outside this skill's task contract, do not edit skill sources; report the
+skipped source update instead.
+
+Do not capture secrets, private URLs, customer data, raw logs, one-off local
+state, or unverified/vendor-specific claims. If a useful learning is not safe,
+not evidence-backed, or outside this skill's scope, report that it was skipped.
+
 ## Guardrails
 
 - Do not commit changelog edits directly on `main`.

--- a/skills/publish-release/SKILL.md
+++ b/skills/publish-release/SKILL.md
@@ -60,6 +60,23 @@ Generate exactly these artifacts in the target project:
    - note that `--publish` fails locally if the target release section is empty
    - note that `--publish` verifies the tagged source checkout resolves the package runtime version to `X.Y.Z` before pushing the tag
 
+## Learning Loop
+
+When using this skill, capture durable, reusable, public-safe learnings back
+into this skill's local source materials before completion when the current task
+contract allows source edits. Update the narrowest appropriate surface:
+`SKILL.md` for runtime rules, `references/` for detailed guidance, `assets/`
+for reusable templates, `scripts/` for deterministic helpers, and README or
+changelog entries for human-facing or release-note updates.
+
+If the current task is explicitly read-only/report-only, or source writes are
+outside this skill's task contract, do not edit skill sources; report the
+skipped source update instead.
+
+Do not capture secrets, private URLs, customer data, raw logs, one-off local
+state, or unverified/vendor-specific claims. If a useful learning is not safe,
+not evidence-backed, or outside this skill's scope, report that it was skipped.
+
 ## Guardrails
 
 - Do not edit changelog directly on `main`.

--- a/skills/python-project/SKILL.md
+++ b/skills/python-project/SKILL.md
@@ -95,6 +95,23 @@ Add these when selected:
   - CI should keep PR validation fast and move integration/coverage to release or manual runs.
 - `ai-ml`: `src/<package>/ml/` split for train/eval/infer pipelines.
 
+## Learning Loop
+
+When using this skill, capture durable, reusable, public-safe learnings back
+into this skill's local source materials before completion when the current task
+contract allows source edits. Update the narrowest appropriate surface:
+`SKILL.md` for runtime rules, `references/` for detailed guidance, `assets/`
+for reusable templates, `scripts/` for deterministic helpers, and README or
+changelog entries for human-facing or release-note updates.
+
+If the current task is explicitly read-only/report-only, or source writes are
+outside this skill's task contract, do not edit skill sources; report the
+skipped source update instead.
+
+Do not capture secrets, private URLs, customer data, raw logs, one-off local
+state, or unverified/vendor-specific claims. If a useful learning is not safe,
+not evidence-backed, or outside this skill's scope, report that it was skipped.
+
 ## Non-Negotiable Guardrails
 
 - No secret material in repo, samples, logs, tests, or docs.

--- a/skills/release-generator/SKILL.md
+++ b/skills/release-generator/SKILL.md
@@ -89,6 +89,23 @@ Note: If execute mode is not clearly requested, do not run anything. The user
 must explicitly begin the request with Run/Execute (or equivalent). Example:
 `$release-generator Run the release script now.`
 
+## Learning Loop
+
+When using this skill, capture durable, reusable, public-safe learnings back
+into this skill's local source materials before completion when the current task
+contract allows source edits. Update the narrowest appropriate surface:
+`SKILL.md` for runtime rules, `references/` for detailed guidance, `assets/`
+for reusable templates, `scripts/` for deterministic helpers, and README or
+changelog entries for human-facing or release-note updates.
+
+If the current task is explicitly read-only/report-only, or source writes are
+outside this skill's task contract, do not edit skill sources; report the
+skipped source update instead.
+
+Do not capture secrets, private URLs, customer data, raw logs, one-off local
+state, or unverified/vendor-specific claims. If a useful learning is not safe,
+not evidence-backed, or outside this skill's scope, report that it was skipped.
+
 ## Resources
 
 1. `scripts/release.sh` contains the canonical release workflow. Copy it to the

--- a/skills/review-pr/README.md
+++ b/skills/review-pr/README.md
@@ -9,6 +9,10 @@ merge-readiness when permissions allow.
 - Inspects base branch, checks, review state, conflicts, and open concerns.
 - Fixes safe issues on writable branches.
 - Resolves straightforward conflicts when safe.
+- For Agentic SDLC PRs, checks requirements, design, validation, tests,
+  evaluation, UAT, and commit evidence when available.
+- When Agentic SDLC local state is available, records readiness and blocker
+  summaries in run evidence.
 - Reports whether the PR is ready to merge and what blockers remain.
 
 ## Architecture
@@ -31,9 +35,10 @@ Review checks, diffs, conflicts, and comments
 1. Resolve the PR target and base branch.
 2. Inspect working tree state and branch ownership.
 3. Review checks, comments, diff, and conflicts.
-4. Apply relevant sibling skills for concrete file types.
-5. Fix safe issues and rerun focused validation.
-6. Report readiness, remaining blockers, and merge guidance.
+4. For Agentic SDLC PRs, inspect local SDLC specs and evidence summaries.
+5. Apply relevant sibling skills for concrete file types.
+6. Fix safe issues and rerun focused validation.
+7. Report readiness, remaining blockers, and merge guidance.
 
 ## Core Concepts
 

--- a/skills/review-pr/SKILL.md
+++ b/skills/review-pr/SKILL.md
@@ -23,6 +23,9 @@ permissions allow, and leave it closer to merge-ready.
   the correct resolution is clear and push permissions allow it.
 - Reporting review findings and exact blockers when the branch cannot be
   updated safely.
+- In an Agentic SDLC run, checking the PR against requirements, design, local
+  validation, tests, evaluation, UAT, and commit evidence when that evidence is
+  available.
 
 ## Requirements
 
@@ -88,6 +91,9 @@ surfaces.
    Read the changed files, diff, existing review comments, and failing checks.
    Compare the branch locally against `origin/<base>`, not only against the PR
    summary UI.
+   If this PR belongs to an Agentic SDLC run, also inspect the relevant
+   `docs/requirements.md`, `docs/design.md`, and local evidence summaries
+   before calling the PR ready.
 3. Select sibling skills for the changed surface.
    Based on the files touched and the kind of breakage in the PR, explicitly
    apply the smallest relevant set of sibling skills from this repo. Keep
@@ -154,6 +160,11 @@ surfaces.
    - what validation ran
    - whether the PR is ready to merge
    - any remaining blockers
+   For Agentic SDLC PRs, include whether requirements, design, validation,
+   tests, evaluation, and UAT evidence all support merge readiness.
+   When Agentic SDLC local state is available, record the readiness summary and
+   remaining blockers in run evidence; if local state cannot be updated, report
+   that explicitly.
 
 ## Recommended Commands
 

--- a/skills/review-pr/SKILL.md
+++ b/skills/review-pr/SKILL.md
@@ -181,6 +181,23 @@ surfaces.
   - after an intentional safe rebase:
     `git push --force-with-lease <head-remote> HEAD:<head-branch>`
 
+## Learning Loop
+
+When using this skill, capture durable, reusable, public-safe learnings back
+into this skill's local source materials before completion when the current task
+contract allows source edits. Update the narrowest appropriate surface:
+`SKILL.md` for runtime rules, `references/` for detailed guidance, `assets/`
+for reusable templates, `scripts/` for deterministic helpers, and README or
+changelog entries for human-facing or release-note updates.
+
+If the current task is explicitly read-only/report-only, or source writes are
+outside this skill's task contract, do not edit skill sources; report the
+skipped source update instead.
+
+Do not capture secrets, private URLs, customer data, raw logs, one-off local
+state, or unverified/vendor-specific claims. If a useful learning is not safe,
+not evidence-backed, or outside this skill's scope, report that it was skipped.
+
 ## Guardrails
 
 - Default behavior is review-and-fix, not report-only, unless the user asks for

--- a/skills/sdlc-align-specs/README.md
+++ b/skills/sdlc-align-specs/README.md
@@ -1,0 +1,26 @@
+# Align Specs
+
+`sdlc-align-specs` is an Agentic SDLC skill. It is authored in this repository and is
+installed into a Codex runtime only when `install-skills.sh` is run.
+
+## What It Does
+
+Verify that SDLC specs, plans, implementation, tests, and evidence tell one consistent story.
+
+## Main Boundaries
+
+- Free-edit requirements or design.
+- Modify locked plans.
+- Pretend unchecked evidence passed.
+- Replace the general `align` workflow.
+
+## Primary Inputs
+
+- Requirements, design, current feature plan, changed files, tests, and evidence.
+- Current feature ID or full-run scope.
+
+## Output
+
+- Alignment report exists.
+- Each drift item has an owner skill or blocker.
+- No unresolved inconsistency remains before commit or PR readiness is claimed.

--- a/skills/sdlc-align-specs/SKILL.md
+++ b/skills/sdlc-align-specs/SKILL.md
@@ -1,0 +1,118 @@
+---
+name: sdlc-align-specs
+description: "Use only as part of the Agentic SDLC workflow; use when Agentic SDLC requirements, design, plans, tests, implementation, and evidence must be checked for consistency. This is SDLC-specific and does not replace the general `align` skill."
+---
+
+# Align Specs
+
+## Purpose
+
+Verify that SDLC specs, plans, implementation, tests, and evidence tell one consistent story.
+
+## When To Use
+
+- Before committing or PR creation, specs and evidence need consistency review.
+- A failure suggests drift between requirements, design, tests, implementation, or evidence.
+- The user asks for SDLC spec alignment.
+
+## When Not To Use
+
+- Do not use for general project-wide alignment outside SDLC artifacts; use `align`.
+- Do not rewrite requirements or design directly.
+- Do not implement broad fixes without routing to the responsible skill.
+
+## Inputs
+
+- Requirements, design, current feature plan, changed files, tests, and evidence.
+- Current feature ID or full-run scope.
+
+## Required Reads
+
+- `docs/requirements.md`.
+- `docs/design.md`.
+- Locked plans.
+- Validation, test, evaluation, UAT, and commit evidence.
+- Changed implementation and tests.
+
+## Writes
+
+- Alignment report.
+- Failure classification or next recommended skill when drift is found.
+
+## Process
+
+- Map `REQ-*` to `FEAT-*`, plans, tests, implementation, and evidence.
+- Check stable IDs and status fields.
+- Check that no manual spec edits bypassed owner skills.
+- Check that evidence supports claimed state transitions.
+- Classify drift and route to the responsible SDLC skill.
+
+## Idempotency
+
+- Rerunning alignment updates the report without duplicating findings.
+- Unchanged specs and evidence should produce stable conclusions.
+- Resolved drift should be marked resolved instead of erased from history.
+
+## Failure Handling
+
+- Missing requirements or design routes to their owner skills.
+- Missing evidence routes to the responsible phase.
+- Spec contradiction maps to `SPEC_GAP`.
+- Plan/design mismatch maps to `DESIGN_DEFECT` or `PLAN_DEFECT`.
+
+## Must Not
+
+- Free-edit requirements or design.
+- Modify locked plans.
+- Pretend unchecked evidence passed.
+- Replace the general `align` workflow.
+
+## Completion Criteria
+
+- Alignment report exists.
+- Each drift item has an owner skill or blocker.
+- No unresolved inconsistency remains before commit or PR readiness is claimed.
+
+## SDLC Invariants
+
+- Treat `docs/requirements.md` and `docs/design.md` as committed product truth.
+- Only `sdlc-create-requirements` writes `docs/requirements.md`; only `sdlc-create-design`
+  writes `docs/design.md`. Other skills route spec changes to those owners.
+- Keep run state, plans, evidence, steering, screenshots, and transcripts under `~/.codex/sdlc-runs/<project-id>/<run-id>/`.
+- When an active run exists, reload `current-state.json` and the latest
+  checkpoint before changing phase or writing evidence.
+- Work on one feature at a time unless the user explicitly asks for a different SDLC shape.
+- Classify every failure before retrying or routing backward.
+- Use MCP servers for browser, GitHub, internal docs, Slack, Confluence, Jira, and other external systems when they are available and appropriate.
+- Treat hooks as invariant guardrails only; do not make hooks orchestrate the workflow.
+
+## Learning Loop
+
+When using this skill, capture durable, reusable, public-safe learnings back
+into this skill's local source materials before completion when the current task
+contract allows source edits. Update the narrowest appropriate surface:
+`SKILL.md` for runtime rules, `references/` for detailed guidance, `assets/`
+for reusable templates, `scripts/` for deterministic helpers, and README or
+changelog entries for human-facing or release-note updates.
+
+If the current task is explicitly read-only/report-only, or source writes are
+outside this skill's task contract, do not edit skill sources; report the
+skipped source update instead.
+
+Do not capture secrets, private URLs, customer data, raw logs, one-off local
+state, or unverified/vendor-specific claims. If a useful learning is not safe,
+not evidence-backed, or outside this skill's scope, report that it was skipped.
+
+## Output Contract
+
+Return a concise result with:
+
+- Scope handled and current `REQ-*` or `FEAT-*` IDs.
+- Files or local state written.
+- Evidence created or checked.
+- Failure classification and next recommended skill when blocked.
+- Confirmation that private SDLC state was kept out of committed project files.
+
+## References
+
+- No skill-local references are required by default; use project files and current official documentation as needed.

--- a/skills/sdlc-align-specs/agents/openai.yaml
+++ b/skills/sdlc-align-specs/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "SDLC Align Specs"
+  short_description: "Check SDLC spec consistency"
+  default_prompt: "Use $sdlc-align-specs to verify that Agentic SDLC specs, plans, implementation, tests, and evidence tell one consistent story."

--- a/skills/sdlc-classify-failure/README.md
+++ b/skills/sdlc-classify-failure/README.md
@@ -1,0 +1,28 @@
+# Classify Failure
+
+`sdlc-classify-failure` is an Agentic SDLC skill. It is authored in this repository and is
+installed into a Codex runtime only when `install-skills.sh` is run.
+
+## What It Does
+
+Classify failures and select the correct retry or stop route before any SDLC loop retry.
+
+## Main Boundaries
+
+- Retry without classification.
+- Overwrite old failure history.
+- Persist raw secrets, logs, or private data.
+- Route to merge or PR creation.
+
+## Primary Inputs
+
+- Current feature and phase.
+- Failure evidence.
+- Retry counts.
+- Latest validation, test, evaluation, UAT, or policy output.
+
+## Output
+
+- Failure class is recorded.
+- Next skill or blocker is explicit.
+- Retry budget state is updated.

--- a/skills/sdlc-classify-failure/SKILL.md
+++ b/skills/sdlc-classify-failure/SKILL.md
@@ -1,0 +1,118 @@
+---
+name: sdlc-classify-failure
+description: "Use only as part of the Agentic SDLC workflow; use when an Agentic SDLC phase fails and the loop must classify the failure before retrying. Routes failures to requirements, context, design, plan, TDD, implementation, validation, tests, evaluation, UAT, environment, policy, or human input."
+---
+
+# Classify Failure
+
+## Purpose
+
+Classify failures and select the correct retry or stop route before any SDLC loop retry.
+
+## When To Use
+
+- Any SDLC phase fails.
+- A retry budget might be consumed.
+- The loop needs to choose between repair, reroute, blocker, or human input.
+
+## When Not To Use
+
+- Do not use to hide or ignore failures.
+- Do not use to change specs or code directly.
+- Do not use as a generic issue triage skill outside SDLC state.
+
+## Inputs
+
+- Current feature and phase.
+- Failure evidence.
+- Retry counts.
+- Latest validation, test, evaluation, UAT, or policy output.
+
+## Required Reads
+
+- `references/failure-taxonomy.md`.
+- Current state and retry counts.
+- Relevant evidence file.
+- Requirement, design, and plan context.
+
+## Writes
+
+- Updated `failure-log.md`.
+- Updated failure class and next recommended skill in state.
+- Blocker summary when needed.
+
+## Process
+
+- Read `references/failure-taxonomy.md`.
+- Classify the primary failure cause, not just the last command that failed.
+- Map the failure to the earliest responsible SDLC phase.
+- Increment retry count for the responsible phase.
+- Stop when human input, policy block, environment block, or retry budget requires it.
+
+## Idempotency
+
+- Reclassifying unchanged evidence should not add duplicate failure entries.
+- If new evidence changes the root cause, append a new classification with reason.
+- Do not reset retry counts without explicit state repair.
+
+## Failure Handling
+
+- If evidence is insufficient, classify as `UNKNOWN_DEFECT` and request the minimum missing evidence.
+- If the failure is human-owned, set status to blocked and summarize the question.
+
+## Must Not
+
+- Retry without classification.
+- Overwrite old failure history.
+- Persist raw secrets, logs, or private data.
+- Route to merge or PR creation.
+
+## Completion Criteria
+
+- Failure class is recorded.
+- Next skill or blocker is explicit.
+- Retry budget state is updated.
+
+## SDLC Invariants
+
+- Treat `docs/requirements.md` and `docs/design.md` as committed product truth.
+- Only `sdlc-create-requirements` writes `docs/requirements.md`; only `sdlc-create-design`
+  writes `docs/design.md`. Other skills route spec changes to those owners.
+- Keep run state, plans, evidence, steering, screenshots, and transcripts under `~/.codex/sdlc-runs/<project-id>/<run-id>/`.
+- When an active run exists, reload `current-state.json` and the latest
+  checkpoint before changing phase or writing evidence.
+- Work on one feature at a time unless the user explicitly asks for a different SDLC shape.
+- Classify every failure before retrying or routing backward.
+- Use MCP servers for browser, GitHub, internal docs, Slack, Confluence, Jira, and other external systems when they are available and appropriate.
+- Treat hooks as invariant guardrails only; do not make hooks orchestrate the workflow.
+
+## Learning Loop
+
+When using this skill, capture durable, reusable, public-safe learnings back
+into this skill's local source materials before completion when the current task
+contract allows source edits. Update the narrowest appropriate surface:
+`SKILL.md` for runtime rules, `references/` for detailed guidance, `assets/`
+for reusable templates, `scripts/` for deterministic helpers, and README or
+changelog entries for human-facing or release-note updates.
+
+If the current task is explicitly read-only/report-only, or source writes are
+outside this skill's task contract, do not edit skill sources; report the
+skipped source update instead.
+
+Do not capture secrets, private URLs, customer data, raw logs, one-off local
+state, or unverified/vendor-specific claims. If a useful learning is not safe,
+not evidence-backed, or outside this skill's scope, report that it was skipped.
+
+## Output Contract
+
+Return a concise result with:
+
+- Scope handled and current `REQ-*` or `FEAT-*` IDs.
+- Files or local state written.
+- Evidence created or checked.
+- Failure classification and next recommended skill when blocked.
+- Confirmation that private SDLC state was kept out of committed project files.
+
+## References
+
+- Read `references/failure-taxonomy.md` when this skill needs that local policy or schema.

--- a/skills/sdlc-classify-failure/agents/openai.yaml
+++ b/skills/sdlc-classify-failure/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "SDLC Classify Failure"
+  short_description: "Route SDLC failures"
+  default_prompt: "Use $sdlc-classify-failure to classify Agentic SDLC failures and select the correct retry or stop route before any loop retry."

--- a/skills/sdlc-classify-failure/references/failure-taxonomy.md
+++ b/skills/sdlc-classify-failure/references/failure-taxonomy.md
@@ -1,0 +1,23 @@
+# Agentic SDLC Failure Taxonomy
+
+Classify the root cause before retrying. Route to the earliest SDLC phase that
+can fix the cause.
+
+| Class | Meaning | Route |
+| --- | --- | --- |
+| SPEC_GAP | Requirements are missing, ambiguous, contradictory, or not testable. | sdlc-create-requirements |
+| CONTEXT_GAP | Vendor, internal, codebase, or test context is missing or unverifiable. | sdlc-gather-context |
+| DESIGN_DEFECT | Design cannot satisfy requirements or lacks implementable boundaries. | sdlc-create-design |
+| PLAN_DEFECT | Locked plan is stale, incomplete, unsafe, or inconsistent with design. | sdlc-create-plan |
+| TEST_DEFECT | Test expectation, fixture, harness, or assertion is wrong. | sdlc-tdd |
+| IMPLEMENTATION_DEFECT | Production code does not satisfy tests or acceptance behavior. | sdlc-implement-plan |
+| VALIDATION_DEFECT | Syntax, lint, type, import, config, dependency, or build check fails. | sdlc-validate-codes or sdlc-implement-plan |
+| EVALUATION_DEFECT | Observed behavior fails acceptance despite tests or validation. | sdlc-implement-plan or sdlc-create-design |
+| UAT_DEFECT | Cross-feature or product-level acceptance fails. | classify to responsible phase |
+| ENVIRONMENT_DEFECT | Tooling, dependency, auth, service, or local environment blocks proof. | human input or environment setup |
+| POLICY_BLOCK | Safety policy, branch policy, hook, or explicit guardrail blocks action. | human input or safer workflow |
+| HUMAN_INPUT_REQUIRED | A product, priority, credential, access, or approval decision is human-owned. | stop and ask |
+| UNKNOWN_DEFECT | Evidence is insufficient to classify confidently. | gather minimum evidence |
+
+Do not collapse all failures into implementation. Preserve the evidence path and
+retry count for the responsible phase.

--- a/skills/sdlc-commit/README.md
+++ b/skills/sdlc-commit/README.md
@@ -1,0 +1,29 @@
+# SDLC Commit
+
+`sdlc-commit` is an Agentic SDLC skill. It is authored in this repository and is
+installed into a Codex runtime only when `install-skills.sh` is run.
+
+## What It Does
+
+Create a local commit for one completed feature as a durable checkpoint without pushing.
+
+## Main Boundaries
+
+- Push.
+- Create PRs.
+- Merge.
+- Commit local run state.
+
+## Primary Inputs
+
+- Current feature ID.
+- Validation, test, and evaluation evidence.
+- Changed files.
+- Current branch.
+
+## Output
+
+- Local commit exists or no-op is justified.
+- Commit message references feature and requirement IDs.
+- Commit evidence records commit hash.
+- Feature state is `committed`.

--- a/skills/sdlc-commit/SKILL.md
+++ b/skills/sdlc-commit/SKILL.md
@@ -1,0 +1,135 @@
+---
+name: sdlc-commit
+description: "Use only as part of the Agentic SDLC workflow; use after a single Agentic SDLC feature has passed validation, tests, and evaluation to create a local feature-scoped Git commit. This skill does not push and does not replace `commit-push`."
+---
+
+# SDLC Commit
+
+## Purpose
+
+Create a local commit for one completed feature as a durable checkpoint without pushing.
+
+## When To Use
+
+- A feature passed validation, tests, and evaluation.
+- The SDLC loop needs a local commit checkpoint before UAT or PR creation.
+- A follow-up feature fix has fresh evidence and needs its own local commit.
+
+## When Not To Use
+
+- Do not use to push; use `commit-push` only when explicitly requested outside this SDLC local-commit path.
+- Do not use to create or merge PRs.
+- Do not use before evidence passes.
+
+## Inputs
+
+- Current feature ID.
+- Validation, test, and evaluation evidence.
+- Changed files.
+- Current branch.
+
+## Required Reads
+
+- Git status and current branch.
+- Feature design and requirement IDs.
+- Evidence files.
+- PreToolUse policy expectations.
+
+## Writes
+
+- Local Git commit.
+- `evidence/FEAT-*/commit.md`.
+- `permissions/commit-authorization.json`, immediately before the commit, with
+  a short expiry and branch scope.
+- State transition to `committed`.
+
+## Process
+
+- Use `assets/templates/commit.md.template` for commit evidence.
+- Verify current branch is not the default branch.
+- Verify validation, tests, and evaluation passed.
+- Verify changed files match feature scope.
+- Verify private state under `~/.codex/sdlc-runs/` is not staged.
+- Stage appropriate project files only.
+- Write `permissions/commit-authorization.json` in the active run directory
+  only after evidence passes. Include `allowed: true`, feature ID, requirement
+  IDs, branch, expiry, and validation/test/evaluation pass status.
+- Create a concise commit message referencing `FEAT-*` and `REQ-*`.
+- Remove or expire `permissions/commit-authorization.json` after the commit
+  attempt.
+- Record commit hash locally.
+
+## Idempotency
+
+- If the feature already has a matching commit and no new changes, do not create another commit.
+- If additional fixes exist, create a follow-up commit only after evidence reruns.
+- Do not amend previous commits by default.
+
+## Failure Handling
+
+- Dirty unrelated files map to a blocker.
+- Default branch maps to `POLICY_BLOCK`.
+- Missing evidence maps to workflow blocker.
+- Hook denial maps to `POLICY_BLOCK`.
+- Missing or expired `commit-authorization.json` maps to `POLICY_BLOCK`.
+
+## Must Not
+
+- Push.
+- Create PRs.
+- Merge.
+- Commit local run state.
+- Commit secrets.
+- Commit from default branch.
+- Commit incomplete features.
+
+## Completion Criteria
+
+- Local commit exists or no-op is justified.
+- Commit message references feature and requirement IDs.
+- Commit evidence records commit hash.
+- Feature state is `committed`.
+
+## SDLC Invariants
+
+- Treat `docs/requirements.md` and `docs/design.md` as committed product truth.
+- Only `sdlc-create-requirements` writes `docs/requirements.md`; only `sdlc-create-design`
+  writes `docs/design.md`. Other skills route spec changes to those owners.
+- Keep run state, plans, evidence, steering, screenshots, and transcripts under `~/.codex/sdlc-runs/<project-id>/<run-id>/`.
+- When an active run exists, reload `current-state.json` and the latest
+  checkpoint before changing phase or writing evidence.
+- Work on one feature at a time unless the user explicitly asks for a different SDLC shape.
+- Classify every failure before retrying or routing backward.
+- Use MCP servers for browser, GitHub, internal docs, Slack, Confluence, Jira, and other external systems when they are available and appropriate.
+- Treat hooks as invariant guardrails only; do not make hooks orchestrate the workflow.
+
+## Learning Loop
+
+When using this skill, capture durable, reusable, public-safe learnings back
+into this skill's local source materials before completion when the current task
+contract allows source edits. Update the narrowest appropriate surface:
+`SKILL.md` for runtime rules, `references/` for detailed guidance, `assets/`
+for reusable templates, `scripts/` for deterministic helpers, and README or
+changelog entries for human-facing or release-note updates.
+
+If the current task is explicitly read-only/report-only, or source writes are
+outside this skill's task contract, do not edit skill sources; report the
+skipped source update instead.
+
+Do not capture secrets, private URLs, customer data, raw logs, one-off local
+state, or unverified/vendor-specific claims. If a useful learning is not safe,
+not evidence-backed, or outside this skill's scope, report that it was skipped.
+
+## Output Contract
+
+Return a concise result with:
+
+- Scope handled and current `REQ-*` or `FEAT-*` IDs.
+- Files or local state written.
+- Evidence created or checked.
+- Failure classification and next recommended skill when blocked.
+- Confirmation that private SDLC state was kept out of committed project files.
+
+## References
+
+- Use `assets/templates/commit.md.template` when creating the corresponding artifact.

--- a/skills/sdlc-commit/agents/openai.yaml
+++ b/skills/sdlc-commit/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "SDLC Commit"
+  short_description: "Create local feature commits"
+  default_prompt: "Use $sdlc-commit to create a local Agentic SDLC commit for one completed feature as a durable checkpoint without pushing."

--- a/skills/sdlc-commit/assets/templates/commit.md.template
+++ b/skills/sdlc-commit/assets/templates/commit.md.template
@@ -1,0 +1,23 @@
+# FEAT-<id> Commit Evidence
+
+## Preconditions
+
+- Validation: <pass>
+- Tests: <pass>
+- Evaluation: <pass>
+- Branch: <branch>
+
+## Commit
+
+- Hash: <hash>
+- Message: <message>
+- Requirements: REQ-<id>
+- Feature: FEAT-<id>
+
+## Files Included
+
+- <path>: <reason>
+
+## Files Excluded
+
+- <path>: <reason>

--- a/skills/sdlc-create-design/README.md
+++ b/skills/sdlc-create-design/README.md
@@ -1,0 +1,29 @@
+# Create Design
+
+`sdlc-create-design` is an Agentic SDLC skill. It is authored in this repository and is
+installed into a Codex runtime only when `install-skills.sh` is run.
+
+## What It Does
+
+Convert requirements and gathered context into implementable architecture and feature designs in `docs/design.md`.
+
+## Main Boundaries
+
+- Create local execution plans.
+- Implement code.
+- Modify tests.
+- Delete feature blocks without explicit requirement removal.
+
+## Primary Inputs
+
+- `docs/requirements.md`.
+- Feature context packs.
+- Existing `docs/design.md` when present.
+- Current codebase shape.
+
+## Output
+
+- `docs/design.md` exists.
+- Every P0 requirement maps to at least one feature.
+- Every ready feature has validation, test, evaluation, and implementation boundaries.
+- Open design questions are explicit.

--- a/skills/sdlc-create-design/SKILL.md
+++ b/skills/sdlc-create-design/SKILL.md
@@ -1,0 +1,122 @@
+---
+name: sdlc-create-design
+description: "Use only as part of the Agentic SDLC workflow; use when `docs/design.md` must be created or updated from `docs/requirements.md` and gathered feature context. This Agentic SDLC skill owns design.md and stable FEAT IDs."
+---
+
+# Create Design
+
+## Purpose
+
+Convert requirements and gathered context into implementable architecture and feature designs in `docs/design.md`.
+
+## When To Use
+
+- Requirements exist but design is missing.
+- Approved requirements or context changed and design must be updated.
+- An SDLC failure classification routes to a design defect or spec gap.
+
+## When Not To Use
+
+- Do not use to create local execution plans.
+- Do not use to implement code or modify tests.
+- Do not use to rewrite requirements.
+
+## Inputs
+
+- `docs/requirements.md`.
+- Feature context packs.
+- Existing `docs/design.md` when present.
+- Current codebase shape.
+
+## Required Reads
+
+- Requirements.
+- Context packs.
+- Existing design.
+- Project structure, tests, and relevant source files.
+
+## Writes
+
+- `docs/design.md`.
+- Feature blocks using `FEAT-*`.
+- Design decisions, design change log, and local design fingerprint.
+
+## Process
+
+- Use `assets/templates/design.md.template` when creating the file.
+- Map `REQ-*` blocks to stable `FEAT-*` blocks.
+- Preserve existing feature IDs and append new IDs instead of renumbering.
+- Define architecture, component boundaries, data flow, control flow, state, error, security, and observability models.
+- Define validation, test, evaluation, TDD success criteria, rollback, and done definition per ready feature.
+- Mark features as ready, draft, blocked, or stale and update the change log.
+
+## Idempotency
+
+- Same requirements and context must not duplicate features.
+- Requirement changes update affected feature blocks only.
+- Existing feature IDs remain stable.
+
+## Failure Handling
+
+- If design cannot satisfy requirements, mark `DESIGN_DEFECT` or `SPEC_GAP`.
+- If context is missing, route to `sdlc-gather-context`.
+- If requirements are contradictory, route to `sdlc-create-requirements`.
+
+## Must Not
+
+- Create local execution plans.
+- Implement code.
+- Modify tests.
+- Delete feature blocks without explicit requirement removal.
+- Ignore acceptance criteria.
+
+## Completion Criteria
+
+- `docs/design.md` exists.
+- Every P0 requirement maps to at least one feature.
+- Every ready feature has validation, test, evaluation, and implementation boundaries.
+- Open design questions are explicit.
+
+## SDLC Invariants
+
+- Treat `docs/requirements.md` and `docs/design.md` as committed product truth.
+- Only `sdlc-create-requirements` writes `docs/requirements.md`; only `sdlc-create-design`
+  writes `docs/design.md`. Other skills route spec changes to those owners.
+- Keep run state, plans, evidence, steering, screenshots, and transcripts under `~/.codex/sdlc-runs/<project-id>/<run-id>/`.
+- When an active run exists, reload `current-state.json` and the latest
+  checkpoint before changing phase or writing evidence.
+- Work on one feature at a time unless the user explicitly asks for a different SDLC shape.
+- Classify every failure before retrying or routing backward.
+- Use MCP servers for browser, GitHub, internal docs, Slack, Confluence, Jira, and other external systems when they are available and appropriate.
+- Treat hooks as invariant guardrails only; do not make hooks orchestrate the workflow.
+
+## Learning Loop
+
+When using this skill, capture durable, reusable, public-safe learnings back
+into this skill's local source materials before completion when the current task
+contract allows source edits. Update the narrowest appropriate surface:
+`SKILL.md` for runtime rules, `references/` for detailed guidance, `assets/`
+for reusable templates, `scripts/` for deterministic helpers, and README or
+changelog entries for human-facing or release-note updates.
+
+If the current task is explicitly read-only/report-only, or source writes are
+outside this skill's task contract, do not edit skill sources; report the
+skipped source update instead.
+
+Do not capture secrets, private URLs, customer data, raw logs, one-off local
+state, or unverified/vendor-specific claims. If a useful learning is not safe,
+not evidence-backed, or outside this skill's scope, report that it was skipped.
+
+## Output Contract
+
+Return a concise result with:
+
+- Scope handled and current `REQ-*` or `FEAT-*` IDs.
+- Files or local state written.
+- Evidence created or checked.
+- Failure classification and next recommended skill when blocked.
+- Confirmation that private SDLC state was kept out of committed project files.
+
+## References
+
+- Use `assets/templates/design.md.template` when creating the corresponding artifact.

--- a/skills/sdlc-create-design/agents/openai.yaml
+++ b/skills/sdlc-create-design/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "SDLC Create Design"
+  short_description: "Generate SDLC design"
+  default_prompt: "Use $sdlc-create-design to convert requirements and gathered context into implementable Agentic SDLC architecture and feature designs in `docs/design.md`."

--- a/skills/sdlc-create-design/assets/templates/design.md.template
+++ b/skills/sdlc-create-design/assets/templates/design.md.template
@@ -1,0 +1,127 @@
+---
+schema: agentic-sdlc.design.v1
+project: "<project-name>"
+owner: "<owner-or-team>"
+status: "draft"
+created_at: "<YYYY-MM-DD>"
+updated_at: "<YYYY-MM-DD>"
+created_by_skill: "sdlc-create-design"
+updated_by_skill: "sdlc-create-design"
+source_requirements: "docs/requirements.md"
+user_edit_policy: "Do not edit manually. Update through sdlc-create-design from requirements and gathered context."
+execution_plan_policy: "Execution plans are local runtime artifacts and must not be committed."
+id_policy: "Feature IDs are stable. Never renumber existing IDs."
+---
+
+# Design
+
+## Design Summary
+
+### Source Inputs
+
+- Requirements: docs/requirements.md
+- Context packs: local sdlc-gather-context outputs
+
+### Architecture Goal
+
+<Architecture goal.>
+
+### Product Behavior Summary
+
+<User-visible behavior.>
+
+## Technology Choices
+
+<Chosen stack, runtime, external dependencies, and internal dependencies.>
+
+## Architecture
+
+### Components
+
+- <component>: <responsibility>
+
+### Data Flow
+
+<Data movement.>
+
+### Control Flow
+
+<Trigger and execution flow.>
+
+### State Model
+
+<Persisted, generated, cached, and runtime state.>
+
+### Error Model
+
+<Failure handling and recovery.>
+
+### Security Model
+
+<Auth, authorization, secrets, input validation, network boundary.>
+
+### Observability Model
+
+<Logs, metrics, traces, screenshots, transcripts, evidence.>
+
+## Feature Designs
+
+<!-- FEATURE: FEAT-001 reqs=REQ-001 status=ready priority=P0 version=1 -->
+### FEAT-001: <feature name>
+
+#### Requirements Covered
+
+- REQ-001: <requirement name>
+
+#### Context Evidence
+
+- Official docs: <summary>
+- Internal docs: <summary>
+- Codebase evidence: <files, modules, tests, patterns>
+
+#### Design
+
+<Concrete design.>
+
+#### Implementation Boundaries
+
+- Must change: <file/module/component>
+- Must not change: <file/module/component>
+
+#### Test-First Success Criteria
+
+- TDD-001: <test expected to fail before implementation and pass after>
+
+#### Validation Plan
+
+<Syntax, lint, type, config, dependency, security, build.>
+
+#### Test Plan
+
+<Unit, integration, component, mock, regression.>
+
+#### Evaluation Plan
+
+<sdlc-gui-test | sdlc-tui-test | api-uat | performance | manual-review>
+
+#### Done Definition
+
+Requirement coverage: <REQ IDs>
+Validation: passing
+Tests: passing
+Evaluation: passing
+Commit: required
+UAT impact: included
+<!-- /FEATURE: FEAT-001 -->
+
+## Cross-Cutting Validation Strategy
+
+## UAT Strategy
+
+## Risks
+
+## Open Design Questions
+
+## Decision Log
+
+## Change Log

--- a/skills/sdlc-create-plan/README.md
+++ b/skills/sdlc-create-plan/README.md
@@ -1,0 +1,28 @@
+# Create Plan
+
+`sdlc-create-plan` is an Agentic SDLC skill. It is authored in this repository and is
+installed into a Codex runtime only when `install-skills.sh` is run.
+
+## What It Does
+
+Create a local, locked execution plan for exactly one feature.
+
+## Main Boundaries
+
+- Commit the plan.
+- Edit locked plans.
+- Implement code or write tests.
+- Expand feature scope.
+
+## Primary Inputs
+
+- One `FEAT-*`.
+- Corresponding `REQ-*` blocks.
+- Context pack.
+- Current repo and feature state.
+
+## Output
+
+- Local plan exists and is locked.
+- Plan contains test, implementation, validation, and evaluation steps.
+- Plan references exact feature and requirement IDs.

--- a/skills/sdlc-create-plan/SKILL.md
+++ b/skills/sdlc-create-plan/SKILL.md
@@ -1,0 +1,119 @@
+---
+name: sdlc-create-plan
+description: "Use only as part of the Agentic SDLC workflow; use when one ready Agentic SDLC feature from `docs/design.md` needs a locked local execution plan before tests or implementation. Plans are private local artifacts and must not be committed."
+---
+
+# Create Plan
+
+## Purpose
+
+Create a local, locked execution plan for exactly one feature.
+
+## When To Use
+
+- A ready `FEAT-*` needs an execution plan.
+- Design or context changed and the old plan must be superseded.
+- The SDLC loop reaches the planning phase for the current feature.
+
+## When Not To Use
+
+- Do not use for requirements or design authoring.
+- Do not use to write tests or code.
+- Do not use to create committed docs.
+
+## Inputs
+
+- One `FEAT-*`.
+- Corresponding `REQ-*` blocks.
+- Context pack.
+- Current repo and feature state.
+
+## Required Reads
+
+- `docs/requirements.md`.
+- `docs/design.md`.
+- `context/FEAT-*.context.md`.
+- Existing source, tests, and local plans for the feature.
+
+## Writes
+
+- `plans/FEAT-*.plan.vN.md`.
+- `plans/FEAT-*.plan.vN.lock`.
+- Plan fingerprint and state transition to `plan_locked`.
+
+## Process
+
+- Use `assets/templates/feature-plan.md.template` for plan shape.
+- Confirm feature status is ready and dependencies are complete or explicitly allowed.
+- Identify files to inspect, create, modify, and avoid.
+- Define test-first, implementation, validation, evaluation, rollback, and stop-condition steps.
+- Lock the plan.
+
+## Idempotency
+
+- If design and context fingerprints are unchanged, reuse the existing locked plan.
+- If design or context changed, create a new plan version.
+- Never modify an existing locked plan.
+
+## Failure Handling
+
+- If design is not implementable, route to `sdlc-create-design`.
+- If context is missing, route to `sdlc-gather-context`.
+- If project tooling is unknown, route to a relevant project skill.
+
+## Must Not
+
+- Commit the plan.
+- Edit locked plans.
+- Implement code or write tests.
+- Expand feature scope.
+
+## Completion Criteria
+
+- Local plan exists and is locked.
+- Plan contains test, implementation, validation, and evaluation steps.
+- Plan references exact feature and requirement IDs.
+
+## SDLC Invariants
+
+- Treat `docs/requirements.md` and `docs/design.md` as committed product truth.
+- Only `sdlc-create-requirements` writes `docs/requirements.md`; only `sdlc-create-design`
+  writes `docs/design.md`. Other skills route spec changes to those owners.
+- Keep run state, plans, evidence, steering, screenshots, and transcripts under `~/.codex/sdlc-runs/<project-id>/<run-id>/`.
+- When an active run exists, reload `current-state.json` and the latest
+  checkpoint before changing phase or writing evidence.
+- Work on one feature at a time unless the user explicitly asks for a different SDLC shape.
+- Classify every failure before retrying or routing backward.
+- Use MCP servers for browser, GitHub, internal docs, Slack, Confluence, Jira, and other external systems when they are available and appropriate.
+- Treat hooks as invariant guardrails only; do not make hooks orchestrate the workflow.
+
+## Learning Loop
+
+When using this skill, capture durable, reusable, public-safe learnings back
+into this skill's local source materials before completion when the current task
+contract allows source edits. Update the narrowest appropriate surface:
+`SKILL.md` for runtime rules, `references/` for detailed guidance, `assets/`
+for reusable templates, `scripts/` for deterministic helpers, and README or
+changelog entries for human-facing or release-note updates.
+
+If the current task is explicitly read-only/report-only, or source writes are
+outside this skill's task contract, do not edit skill sources; report the
+skipped source update instead.
+
+Do not capture secrets, private URLs, customer data, raw logs, one-off local
+state, or unverified/vendor-specific claims. If a useful learning is not safe,
+not evidence-backed, or outside this skill's scope, report that it was skipped.
+
+## Output Contract
+
+Return a concise result with:
+
+- Scope handled and current `REQ-*` or `FEAT-*` IDs.
+- Files or local state written.
+- Evidence created or checked.
+- Failure classification and next recommended skill when blocked.
+- Confirmation that private SDLC state was kept out of committed project files.
+
+## References
+
+- Use `assets/templates/feature-plan.md.template` when creating the corresponding artifact.

--- a/skills/sdlc-create-plan/agents/openai.yaml
+++ b/skills/sdlc-create-plan/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "SDLC Create Plan"
+  short_description: "Lock one feature plan"
+  default_prompt: "Use $sdlc-create-plan to create a local, locked Agentic SDLC execution plan for exactly one feature."

--- a/skills/sdlc-create-plan/assets/templates/feature-plan.md.template
+++ b/skills/sdlc-create-plan/assets/templates/feature-plan.md.template
@@ -1,0 +1,48 @@
+# FEAT-<id> Plan v<N>
+
+## Scope
+
+- Feature: FEAT-<id>
+- Requirements: REQ-<id>
+- Plan status: locked when matching `.lock` exists
+
+## Files To Inspect
+
+- <path>: <reason>
+
+## Files To Change
+
+- <path>: <expected change>
+
+## Files To Avoid
+
+- <path>: <reason>
+
+## TDD Steps
+
+1. <test-first step>
+
+## Implementation Steps
+
+1. <implementation step>
+
+## Validation Commands
+
+- `<command>`: <purpose>
+
+## Evaluation Procedure
+
+<How to observe acceptance behavior.>
+
+## Rollback
+
+<Safe revert or disablement path.>
+
+## Stop Conditions
+
+- <condition>
+
+## Fingerprints
+
+- Design: <hash-or-summary>
+- Context: <hash-or-summary>

--- a/skills/sdlc-create-requirements/README.md
+++ b/skills/sdlc-create-requirements/README.md
@@ -1,0 +1,28 @@
+# Create Requirements
+
+`sdlc-create-requirements` is an Agentic SDLC skill. It is authored in this repository and is
+installed into a Codex runtime only when `install-skills.sh` is run.
+
+## What It Does
+
+Convert user intent into durable, testable product requirements in `docs/requirements.md`.
+
+## Main Boundaries
+
+- Edit `docs/design.md`.
+- Create execution plans.
+- Implement code or tests.
+- Rename existing requirement IDs.
+
+## Primary Inputs
+
+- User prompt or approved change request.
+- Existing `docs/requirements.md` when present.
+- Existing `docs/design.md` for impact awareness only.
+- Optional Jira, Slack, Confluence, GitHub, or pasted context.
+
+## Output
+
+- `docs/requirements.md` exists.
+- Every requirement has acceptance criteria, validation method, test method, and evaluation method.
+- Open questions and change log are explicit.

--- a/skills/sdlc-create-requirements/SKILL.md
+++ b/skills/sdlc-create-requirements/SKILL.md
@@ -1,0 +1,121 @@
+---
+name: sdlc-create-requirements
+description: "Use only as part of the Agentic SDLC workflow; use when the user provides a product idea, ticket, rough prompt, user story, change request, or feature request and needs `docs/requirements.md` created or updated. This Agentic SDLC skill owns requirements.md and preserves stable REQ IDs."
+---
+
+# Create Requirements
+
+## Purpose
+
+Convert user intent into durable, testable product requirements in `docs/requirements.md`.
+
+## When To Use
+
+- A project idea, ticket, issue, Slack thread, Confluence page, or rough prompt needs requirements.
+- An existing requirement needs an approved update from user feedback.
+- An active SDLC run discovers a spec gap that must be reflected in requirements.
+
+## When Not To Use
+
+- Do not use for design details; use `sdlc-create-design`.
+- Do not use for local execution plans; use `sdlc-create-plan`.
+- Do not use for implementation, validation, tests, UAT, PR, or merge work.
+
+## Inputs
+
+- User prompt or approved change request.
+- Existing `docs/requirements.md` when present.
+- Existing `docs/design.md` for impact awareness only.
+- Optional Jira, Slack, Confluence, GitHub, or pasted context.
+
+## Required Reads
+
+- Existing requirements file.
+- Existing design file if present.
+- Project README or docs if available.
+- Active SDLC run state if the change happens during a run.
+
+## Writes
+
+- `docs/requirements.md`.
+- A local run-history change summary when an SDLC run is active.
+
+## Process
+
+- Use `assets/templates/requirements.md.template` when creating the file.
+- Extract product goal, users, constraints, non-goals, assumptions, and external systems.
+- Break intent into stable `REQ-*` blocks with acceptance and negative criteria.
+- Add inputs, outputs, validation method, test method, evaluation method, priority, and risk to each requirement.
+- Preserve existing requirement IDs and append new IDs instead of renumbering.
+- Update the requirements decision log and change log.
+- Mark unclear items as open questions instead of guessing.
+
+## Idempotency
+
+- Reapplying the same prompt must not duplicate requirements.
+- If an existing requirement changes, update that `REQ-*` block and append a change-log entry.
+- If design must change, mark the affected requirements so `sdlc-create-design` can update related features.
+
+## Failure Handling
+
+- If ambiguity is non-blocking, create draft requirements and list open questions.
+- If ambiguity blocks meaningful progress, stop with the required questions.
+- If the existing requirements file is malformed, repair structure without changing intent.
+
+## Must Not
+
+- Edit `docs/design.md`.
+- Create execution plans.
+- Implement code or tests.
+- Rename existing requirement IDs.
+- Delete accepted requirements without explicit user instruction.
+
+## Completion Criteria
+
+- `docs/requirements.md` exists.
+- Every requirement has acceptance criteria, validation method, test method, and evaluation method.
+- Open questions and change log are explicit.
+
+## SDLC Invariants
+
+- Treat `docs/requirements.md` and `docs/design.md` as committed product truth.
+- Only `sdlc-create-requirements` writes `docs/requirements.md`; only `sdlc-create-design`
+  writes `docs/design.md`. Other skills route spec changes to those owners.
+- Keep run state, plans, evidence, steering, screenshots, and transcripts under `~/.codex/sdlc-runs/<project-id>/<run-id>/`.
+- When an active run exists, reload `current-state.json` and the latest
+  checkpoint before changing phase or writing evidence.
+- Work on one feature at a time unless the user explicitly asks for a different SDLC shape.
+- Classify every failure before retrying or routing backward.
+- Use MCP servers for browser, GitHub, internal docs, Slack, Confluence, Jira, and other external systems when they are available and appropriate.
+- Treat hooks as invariant guardrails only; do not make hooks orchestrate the workflow.
+
+## Learning Loop
+
+When using this skill, capture durable, reusable, public-safe learnings back
+into this skill's local source materials before completion when the current task
+contract allows source edits. Update the narrowest appropriate surface:
+`SKILL.md` for runtime rules, `references/` for detailed guidance, `assets/`
+for reusable templates, `scripts/` for deterministic helpers, and README or
+changelog entries for human-facing or release-note updates.
+
+If the current task is explicitly read-only/report-only, or source writes are
+outside this skill's task contract, do not edit skill sources; report the
+skipped source update instead.
+
+Do not capture secrets, private URLs, customer data, raw logs, one-off local
+state, or unverified/vendor-specific claims. If a useful learning is not safe,
+not evidence-backed, or outside this skill's scope, report that it was skipped.
+
+## Output Contract
+
+Return a concise result with:
+
+- Scope handled and current `REQ-*` or `FEAT-*` IDs.
+- Files or local state written.
+- Evidence created or checked.
+- Failure classification and next recommended skill when blocked.
+- Confirmation that private SDLC state was kept out of committed project files.
+
+## References
+
+- Use `assets/templates/requirements.md.template` when creating the corresponding artifact.

--- a/skills/sdlc-create-requirements/agents/openai.yaml
+++ b/skills/sdlc-create-requirements/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "SDLC Create Requirements"
+  short_description: "Generate SDLC requirements"
+  default_prompt: "Use $sdlc-create-requirements to convert user intent into durable, testable Agentic SDLC product requirements in `docs/requirements.md`."

--- a/skills/sdlc-create-requirements/assets/templates/requirements.md.template
+++ b/skills/sdlc-create-requirements/assets/templates/requirements.md.template
@@ -1,0 +1,110 @@
+---
+schema: agentic-sdlc.requirements.v1
+project: "<project-name>"
+owner: "<owner-or-team>"
+status: "draft"
+created_at: "<YYYY-MM-DD>"
+updated_at: "<YYYY-MM-DD>"
+created_by_skill: "sdlc-create-requirements"
+updated_by_skill: "sdlc-create-requirements"
+user_edit_policy: "Do not edit manually. Update through sdlc-create-requirements from user prompts."
+id_policy: "Requirement IDs are stable. Never renumber existing IDs."
+---
+
+# Requirements
+
+## Product Summary
+
+### Source Prompt
+
+<The user prompt summarized by sdlc-create-requirements.>
+
+### Problem
+
+<Problem to solve.>
+
+### Desired Outcome
+
+<Final expected outcome.>
+
+### Primary Users
+
+- <user>: <need>
+
+### Success Definition
+
+<What must be true for success.>
+
+## Constraints
+
+### Must Do
+
+- <constraint>: <description>
+
+### Must Not Do
+
+- <constraint>: <description>
+
+### Assumptions
+
+- <assumption>: <reason>
+
+### Out Of Scope
+
+- <item>: <reason>
+
+## Environment
+
+### Runtime Environment
+
+<Language, framework, platform, OS, browser, terminal, deployment target.>
+
+### Development Constraints
+
+<Tooling, tests, linting, CI, package manager, dependency rules.>
+
+### External Systems
+
+- <system>: <purpose and access method>
+
+## Requirement Blocks
+
+<!-- REQUIREMENT: REQ-001 status=draft priority=P0 type=feature -->
+### REQ-001: <requirement name>
+
+#### User Story
+
+As a <user>, I want <capability>, so that <outcome>.
+
+#### Acceptance Criteria
+
+- AC-001: <observable pass condition>
+
+#### Negative Criteria
+
+- NC-001: <behavior that must not happen>
+
+#### Validation Method
+
+<syntax | lint | type-check | config-check | build | runtime-check>
+
+#### Test Method
+
+<unit | integration | component | mock-based | contract | regression>
+
+#### Evaluation Method
+
+<gui-uat | tui-uat | api-uat | performance | manual-review | production-like-check>
+
+<!-- /REQUIREMENT: REQ-001 -->
+
+## Open Questions
+
+- Q-001: <question>
+  - Status: open
+  - Blocks: <REQ-ID or none>
+  - Owner: <human | agent | team>
+
+## Decision Log
+
+## Change Log

--- a/skills/sdlc-evaluate/README.md
+++ b/skills/sdlc-evaluate/README.md
@@ -1,0 +1,28 @@
+# SDLC Evaluate
+
+`sdlc-evaluate` is an Agentic SDLC skill. It is authored in this repository and is
+installed into a Codex runtime only when `install-skills.sh` is run.
+
+## What It Does
+
+Evaluate observed product behavior against real-world acceptance criteria.
+
+## Main Boundaries
+
+- Ignore negative criteria.
+- Mark pass without observable evidence.
+- Overwrite validation or test evidence.
+
+## Primary Inputs
+
+- Feature design.
+- Acceptance criteria.
+- Validation evidence.
+- Test evidence.
+- Product type.
+
+## Output
+
+- Evaluation evidence exists.
+- Acceptance criteria are explicitly pass or fail.
+- State moves to `evaluated` only when pass.

--- a/skills/sdlc-evaluate/SKILL.md
+++ b/skills/sdlc-evaluate/SKILL.md
@@ -1,0 +1,120 @@
+---
+name: sdlc-evaluate
+description: "Use only as part of the Agentic SDLC workflow; use after validation and tests in the Agentic SDLC loop to determine whether the current feature solves the real-world requirement using acceptance criteria and the correct evaluation harness."
+---
+
+# SDLC Evaluate
+
+## Purpose
+
+Evaluate observed product behavior against real-world acceptance criteria.
+
+## When To Use
+
+- Validation and tests pass and feature acceptance must be observed.
+- The product is GUI, TUI, CLI, API, library, service, or infrastructure and needs evidence.
+- A prior evaluation defect needs rerun evidence.
+
+## When Not To Use
+
+- Do not treat unit tests as evaluation.
+- Do not approve behavior without observation.
+- Do not change code directly unless routed back to implementation.
+
+## Inputs
+
+- Feature design.
+- Acceptance criteria.
+- Validation evidence.
+- Test evidence.
+- Product type.
+
+## Required Reads
+
+- Requirement block.
+- Feature design.
+- Locked plan.
+- Validation and test evidence.
+- App startup instructions.
+
+## Writes
+
+- `evidence/FEAT-*/evaluate.md`.
+- Screenshots, transcripts, or API/service summaries as appropriate.
+- Evaluation pass/fail result.
+
+## Process
+
+- Use `assets/templates/evaluate.md.template` for evidence.
+- Select the evaluation route: `sdlc-gui-test`, `sdlc-tui-test`, API/service checks, or manual review.
+- Compare observed behavior against acceptance and negative criteria.
+- Record control, observation, and evaluation evidence.
+
+## Idempotency
+
+- Rerunning evaluation refreshes evidence.
+- If product behavior is unchanged, outcome should be stable.
+- Failed evaluation routes back to the correct phase.
+
+## Failure Handling
+
+- Real behavior mismatch maps to `EVALUATION_DEFECT`.
+- Automation failure maps to `ENVIRONMENT_DEFECT` or `EVALUATION_DEFECT` based on cause.
+- Acceptance issue maps to `SPEC_GAP`.
+- Design mismatch maps to `DESIGN_DEFECT`.
+
+## Must Not
+
+- Ignore negative criteria.
+- Mark pass without observable evidence.
+- Overwrite validation or test evidence.
+
+## Completion Criteria
+
+- Evaluation evidence exists.
+- Acceptance criteria are explicitly pass or fail.
+- State moves to `evaluated` only when pass.
+
+## SDLC Invariants
+
+- Treat `docs/requirements.md` and `docs/design.md` as committed product truth.
+- Only `sdlc-create-requirements` writes `docs/requirements.md`; only `sdlc-create-design`
+  writes `docs/design.md`. Other skills route spec changes to those owners.
+- Keep run state, plans, evidence, steering, screenshots, and transcripts under `~/.codex/sdlc-runs/<project-id>/<run-id>/`.
+- When an active run exists, reload `current-state.json` and the latest
+  checkpoint before changing phase or writing evidence.
+- Work on one feature at a time unless the user explicitly asks for a different SDLC shape.
+- Classify every failure before retrying or routing backward.
+- Use MCP servers for browser, GitHub, internal docs, Slack, Confluence, Jira, and other external systems when they are available and appropriate.
+- Treat hooks as invariant guardrails only; do not make hooks orchestrate the workflow.
+
+## Learning Loop
+
+When using this skill, capture durable, reusable, public-safe learnings back
+into this skill's local source materials before completion when the current task
+contract allows source edits. Update the narrowest appropriate surface:
+`SKILL.md` for runtime rules, `references/` for detailed guidance, `assets/`
+for reusable templates, `scripts/` for deterministic helpers, and README or
+changelog entries for human-facing or release-note updates.
+
+If the current task is explicitly read-only/report-only, or source writes are
+outside this skill's task contract, do not edit skill sources; report the
+skipped source update instead.
+
+Do not capture secrets, private URLs, customer data, raw logs, one-off local
+state, or unverified/vendor-specific claims. If a useful learning is not safe,
+not evidence-backed, or outside this skill's scope, report that it was skipped.
+
+## Output Contract
+
+Return a concise result with:
+
+- Scope handled and current `REQ-*` or `FEAT-*` IDs.
+- Files or local state written.
+- Evidence created or checked.
+- Failure classification and next recommended skill when blocked.
+- Confirmation that private SDLC state was kept out of committed project files.
+
+## References
+
+- Use `assets/templates/evaluate.md.template` when creating the corresponding artifact.

--- a/skills/sdlc-evaluate/agents/openai.yaml
+++ b/skills/sdlc-evaluate/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "SDLC Evaluate"
+  short_description: "Evaluate acceptance behavior"
+  default_prompt: "Use $sdlc-evaluate to evaluate observed Agentic SDLC product behavior against real-world acceptance criteria."

--- a/skills/sdlc-evaluate/assets/templates/evaluate.md.template
+++ b/skills/sdlc-evaluate/assets/templates/evaluate.md.template
@@ -1,0 +1,23 @@
+# FEAT-<id> Evaluation Evidence
+
+## Route
+
+<sdlc-gui-test | sdlc-tui-test | api | service | manual-review>
+
+## Control
+
+<How the product was controlled.>
+
+## Observation
+
+<What was observed.>
+
+## Acceptance Result
+
+| Criterion | Result | Evidence |
+| --- | --- | --- |
+| REQ-<id> AC-<id> | <pass|fail> | <path-or-summary> |
+
+## Failure Classification
+
+<classification or none>

--- a/skills/sdlc-gather-context/README.md
+++ b/skills/sdlc-gather-context/README.md
@@ -1,0 +1,28 @@
+# Gather Context
+
+`sdlc-gather-context` is an Agentic SDLC skill. It is authored in this repository and is
+installed into a Codex runtime only when `install-skills.sh` is run.
+
+## What It Does
+
+Gather only the context needed for one feature and produce a compact context pack for design and planning.
+
+## Main Boundaries
+
+- Implement code.
+- Create design decisions without evidence.
+- Store secrets or private tokens in context packs.
+- Use unofficial sources when official docs are available.
+
+## Primary Inputs
+
+- One `REQ-*` or `FEAT-*`.
+- Relevant requirement or feature block.
+- User-provided links or references.
+- Existing design block when present.
+
+## Output
+
+- Context pack exists.
+- Important facts have source traceability.
+- Design implications and open blockers are explicit.

--- a/skills/sdlc-gather-context/SKILL.md
+++ b/skills/sdlc-gather-context/SKILL.md
@@ -1,0 +1,118 @@
+---
+name: sdlc-gather-context
+description: "Use only as part of the Agentic SDLC workflow; use when an Agentic SDLC feature needs technical, product, vendor, internal, codebase, or test context before design or implementation. Produces a compact feature-specific context pack."
+---
+
+# Gather Context
+
+## Purpose
+
+Gather only the context needed for one feature and produce a compact context pack for design and planning.
+
+## When To Use
+
+- A `REQ-*` or `FEAT-*` needs technical context before design.
+- Vendor, internal, codebase, or test facts may affect implementation.
+- A design or plan is blocked by missing context.
+
+## When Not To Use
+
+- Do not use to make design decisions without evidence.
+- Do not use to implement code.
+- Do not use to dump raw webpages, Slack threads, or logs.
+
+## Inputs
+
+- One `REQ-*` or `FEAT-*`.
+- Relevant requirement or feature block.
+- User-provided links or references.
+- Existing design block when present.
+
+## Required Reads
+
+- `docs/requirements.md`.
+- `docs/design.md` if present.
+- Relevant source files, tests, README, and architecture docs.
+- Official vendor docs first.
+- Internal Confluence, Slack, Jira, GitHub, or MCP resources when available.
+
+## Writes
+
+- `context/FEAT-*.context.md`.
+- Context fingerprint, source list, and open context questions.
+
+## Process
+
+- Use `assets/templates/context-pack.md.template` when creating a context pack.
+- Identify technologies and vendors used by the feature.
+- Gather official vendor facts first, internal docs second, code and tests third.
+- Summarize only facts that affect design or implementation.
+- Record exact versions, APIs, constraints, unresolved risks, and design implications.
+
+## Idempotency
+
+- If context sources and feature requirements are unchanged, reuse the context pack.
+- If sources changed, update the context pack and mark affected design blocks stale.
+
+## Failure Handling
+
+- If official docs are unavailable, state that the behavior could not be verified.
+- If internal docs conflict with vendor docs, record the conflict and prefer official docs unless internal platform behavior overrides it.
+- If context is insufficient, mark `CONTEXT_GAP`.
+
+## Must Not
+
+- Implement code.
+- Create design decisions without evidence.
+- Store secrets or private tokens in context packs.
+- Use unofficial sources when official docs are available.
+
+## Completion Criteria
+
+- Context pack exists.
+- Important facts have source traceability.
+- Design implications and open blockers are explicit.
+
+## SDLC Invariants
+
+- Treat `docs/requirements.md` and `docs/design.md` as committed product truth.
+- Only `sdlc-create-requirements` writes `docs/requirements.md`; only `sdlc-create-design`
+  writes `docs/design.md`. Other skills route spec changes to those owners.
+- Keep run state, plans, evidence, steering, screenshots, and transcripts under `~/.codex/sdlc-runs/<project-id>/<run-id>/`.
+- When an active run exists, reload `current-state.json` and the latest
+  checkpoint before changing phase or writing evidence.
+- Work on one feature at a time unless the user explicitly asks for a different SDLC shape.
+- Classify every failure before retrying or routing backward.
+- Use MCP servers for browser, GitHub, internal docs, Slack, Confluence, Jira, and other external systems when they are available and appropriate.
+- Treat hooks as invariant guardrails only; do not make hooks orchestrate the workflow.
+
+## Learning Loop
+
+When using this skill, capture durable, reusable, public-safe learnings back
+into this skill's local source materials before completion when the current task
+contract allows source edits. Update the narrowest appropriate surface:
+`SKILL.md` for runtime rules, `references/` for detailed guidance, `assets/`
+for reusable templates, `scripts/` for deterministic helpers, and README or
+changelog entries for human-facing or release-note updates.
+
+If the current task is explicitly read-only/report-only, or source writes are
+outside this skill's task contract, do not edit skill sources; report the
+skipped source update instead.
+
+Do not capture secrets, private URLs, customer data, raw logs, one-off local
+state, or unverified/vendor-specific claims. If a useful learning is not safe,
+not evidence-backed, or outside this skill's scope, report that it was skipped.
+
+## Output Contract
+
+Return a concise result with:
+
+- Scope handled and current `REQ-*` or `FEAT-*` IDs.
+- Files or local state written.
+- Evidence created or checked.
+- Failure classification and next recommended skill when blocked.
+- Confirmation that private SDLC state was kept out of committed project files.
+
+## References
+
+- Use `assets/templates/context-pack.md.template` when creating the corresponding artifact.

--- a/skills/sdlc-gather-context/agents/openai.yaml
+++ b/skills/sdlc-gather-context/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "SDLC Gather Context"
+  short_description: "Build feature context packs"
+  default_prompt: "Use $sdlc-gather-context to gather only the Agentic SDLC context needed for one feature and produce a compact context pack for design and planning."

--- a/skills/sdlc-gather-context/assets/templates/context-pack.md.template
+++ b/skills/sdlc-gather-context/assets/templates/context-pack.md.template
@@ -1,0 +1,29 @@
+# FEAT-<id> Context Pack
+
+## Scope
+
+- Feature: FEAT-<id>
+- Requirements: REQ-<id>
+
+## Sources
+
+| Source | Type | Date Checked | Finding |
+| --- | --- | --- | --- |
+| <source> | <official-docs|internal-docs|code|tests> | <YYYY-MM-DD> | <summary> |
+
+## Facts That Affect Design Or Implementation
+
+- <fact>: <source>
+
+## Design Implications
+
+- <implication>
+
+## Open Context Questions
+
+- <question>
+
+## Fingerprint Inputs
+
+- Requirements fingerprint: <hash-or-summary>
+- Source fingerprint: <hash-or-summary>

--- a/skills/sdlc-gui-test/README.md
+++ b/skills/sdlc-gui-test/README.md
@@ -1,0 +1,28 @@
+# GUI Test
+
+`sdlc-gui-test` is an Agentic SDLC skill. It is authored in this repository and is
+installed into a Codex runtime only when `install-skills.sh` is run.
+
+## What It Does
+
+Control, observe, and evaluate browser UI behavior with durable local evidence.
+
+## Main Boundaries
+
+- Use screenshots as the only interaction source when DOM or accessibility snapshots are available.
+- Store secrets in screenshots or reports.
+- Use production data without explicit permission.
+
+## Primary Inputs
+
+- GUI acceptance criteria.
+- App URL or startup method.
+- Test data or account instructions.
+- Feature design.
+
+## Output
+
+- Browser flow was executed.
+- Evidence exists.
+- Acceptance criteria are pass/fail.
+- Screenshots or snapshots are stored locally.

--- a/skills/sdlc-gui-test/SKILL.md
+++ b/skills/sdlc-gui-test/SKILL.md
@@ -1,0 +1,123 @@
+---
+name: sdlc-gui-test
+description: "Use only as part of the Agentic SDLC workflow; use when browser-based GUI behavior must be controlled, observed, screenshotted, and evaluated against Agentic SDLC acceptance criteria, preferably through Playwright MCP when available."
+---
+
+# GUI Test
+
+## Purpose
+
+Control, observe, and evaluate browser UI behavior with durable local evidence.
+
+## When To Use
+
+- A feature or UAT evaluation requires browser UI interaction.
+- Screenshots, accessibility snapshots, console notes, or network notes are needed.
+- The design evaluation route says `sdlc-gui-test`.
+
+## When Not To Use
+
+- Do not use for non-browser TUI or CLI flows; use `sdlc-tui-test`.
+- Do not use production data unless explicitly allowed.
+- Do not mark pass without observable evidence.
+
+## Inputs
+
+- GUI acceptance criteria.
+- App URL or startup method.
+- Test data or account instructions.
+- Feature design.
+
+## Required Reads
+
+- Evaluation plan.
+- Acceptance criteria.
+- Existing Playwright config if any.
+- UI routes and startup docs.
+
+## Writes
+
+- GUI evaluation report.
+- Screenshots or accessibility snapshots.
+- Console or network notes when available.
+- Pass/fail result.
+
+## Process
+
+- Use Browser or Playwright MCP when available.
+- Start or access the app environment.
+- Navigate to the target flow and use accessibility snapshots for interaction when available.
+- Perform the user journey.
+- Capture screenshots at meaningful checkpoints.
+- Compare result to acceptance criteria and record reproduction steps for failures.
+
+## Idempotency
+
+- Use disposable test data where possible.
+- Clean up created records when safe.
+- Use unique test names when cleanup is not possible.
+- Avoid relying on previous browser state.
+
+## Failure Handling
+
+- Missing app server maps to `ENVIRONMENT_DEFECT`.
+- UI mismatch maps to `EVALUATION_DEFECT`.
+- Broken selector with correct UI behavior maps to `TEST_DEFECT`.
+- Missing acceptance criteria maps to `SPEC_GAP`.
+
+## Must Not
+
+- Use screenshots as the only interaction source when DOM or accessibility snapshots are available.
+- Store secrets in screenshots or reports.
+- Use production data without explicit permission.
+
+## Completion Criteria
+
+- Browser flow was executed.
+- Evidence exists.
+- Acceptance criteria are pass/fail.
+- Screenshots or snapshots are stored locally.
+
+## SDLC Invariants
+
+- Treat `docs/requirements.md` and `docs/design.md` as committed product truth.
+- Only `sdlc-create-requirements` writes `docs/requirements.md`; only `sdlc-create-design`
+  writes `docs/design.md`. Other skills route spec changes to those owners.
+- Keep run state, plans, evidence, steering, screenshots, and transcripts under `~/.codex/sdlc-runs/<project-id>/<run-id>/`.
+- When an active run exists, reload `current-state.json` and the latest
+  checkpoint before changing phase or writing evidence.
+- Work on one feature at a time unless the user explicitly asks for a different SDLC shape.
+- Classify every failure before retrying or routing backward.
+- Use MCP servers for browser, GitHub, internal docs, Slack, Confluence, Jira, and other external systems when they are available and appropriate.
+- Treat hooks as invariant guardrails only; do not make hooks orchestrate the workflow.
+
+## Learning Loop
+
+When using this skill, capture durable, reusable, public-safe learnings back
+into this skill's local source materials before completion when the current task
+contract allows source edits. Update the narrowest appropriate surface:
+`SKILL.md` for runtime rules, `references/` for detailed guidance, `assets/`
+for reusable templates, `scripts/` for deterministic helpers, and README or
+changelog entries for human-facing or release-note updates.
+
+If the current task is explicitly read-only/report-only, or source writes are
+outside this skill's task contract, do not edit skill sources; report the
+skipped source update instead.
+
+Do not capture secrets, private URLs, customer data, raw logs, one-off local
+state, or unverified/vendor-specific claims. If a useful learning is not safe,
+not evidence-backed, or outside this skill's scope, report that it was skipped.
+
+## Output Contract
+
+Return a concise result with:
+
+- Scope handled and current `REQ-*` or `FEAT-*` IDs.
+- Files or local state written.
+- Evidence created or checked.
+- Failure classification and next recommended skill when blocked.
+- Confirmation that private SDLC state was kept out of committed project files.
+
+## References
+
+- No skill-local references are required by default; use project files and current official documentation as needed.

--- a/skills/sdlc-gui-test/agents/openai.yaml
+++ b/skills/sdlc-gui-test/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "SDLC GUI Test"
+  short_description: "Evaluate browser UI flows"
+  default_prompt: "Use $sdlc-gui-test to control, observe, and evaluate browser UI behavior during Agentic SDLC work with durable local evidence."

--- a/skills/sdlc-implement-plan/README.md
+++ b/skills/sdlc-implement-plan/README.md
@@ -1,0 +1,30 @@
+# Implement Plan
+
+`sdlc-implement-plan` is an Agentic SDLC skill. It is authored in this repository and is
+installed into a Codex runtime only when `install-skills.sh` is run.
+
+## What It Does
+
+Implement production code for one feature while staying inside the locked plan.
+
+## Main Boundaries
+
+- Change unrelated features.
+- Modify locked plans.
+- Hide failures.
+- Remove tests to pass.
+
+## Primary Inputs
+
+- Locked plan.
+- Red or ready tests.
+- Feature design.
+- Context pack.
+- Existing codebase.
+
+## Output
+
+- Planned code changes are implemented.
+- Focused tests are runnable or blocker is recorded.
+- Changed files match implementation boundaries.
+- State moves to `implemented`.

--- a/skills/sdlc-implement-plan/SKILL.md
+++ b/skills/sdlc-implement-plan/SKILL.md
@@ -1,0 +1,123 @@
+---
+name: sdlc-implement-plan
+description: "Use only as part of the Agentic SDLC workflow; use after `sdlc-tdd` when a locked Agentic SDLC feature plan needs production implementation. Implements only the current feature plan and stays inside its boundaries."
+---
+
+# Implement Plan
+
+## Purpose
+
+Implement production code for one feature while staying inside the locked plan.
+
+## When To Use
+
+- A feature has a locked plan and tests are red, ready, or already green.
+- The SDLC loop reaches implementation for the current feature.
+- A classified implementation defect needs repair within the same plan.
+
+## When Not To Use
+
+- Do not use to edit requirements, design, or locked plans.
+- Do not use to broaden scope.
+- Do not use to remove tests to pass.
+
+## Inputs
+
+- Locked plan.
+- Red or ready tests.
+- Feature design.
+- Context pack.
+- Existing codebase.
+
+## Required Reads
+
+- Locked plan.
+- Feature design and context pack.
+- Relevant source files, tests, and project conventions.
+
+## Writes
+
+- Production code.
+- Required configuration changes from the plan.
+- Test fixture updates only when required.
+- Local implementation evidence.
+
+## Process
+
+- Re-read the locked plan and inspect current code before editing.
+- Make the smallest coherent implementation.
+- Preserve public behavior unrelated to the feature.
+- Keep style consistent with nearby code.
+- Run focused tests when useful and record changed files plus rationale.
+
+## Idempotency
+
+- Reruns converge instead of duplicating code.
+- If implementation already exists, verify it against the plan instead of rewriting.
+- If source drift invalidates the plan, stop and route to `sdlc-create-plan`.
+
+## Failure Handling
+
+- If tests cannot pass due to code, fix implementation.
+- If tests are wrong, route to `sdlc-tdd`.
+- If design is wrong, route to `sdlc-create-design`.
+- If environment is blocked, mark `ENVIRONMENT_DEFECT`.
+
+## Must Not
+
+- Change unrelated features.
+- Modify locked plans.
+- Hide failures.
+- Remove tests to pass.
+- Expand scope without design update.
+
+## Completion Criteria
+
+- Planned code changes are implemented.
+- Focused tests are runnable or blocker is recorded.
+- Changed files match implementation boundaries.
+- State moves to `implemented`.
+
+## SDLC Invariants
+
+- Treat `docs/requirements.md` and `docs/design.md` as committed product truth.
+- Only `sdlc-create-requirements` writes `docs/requirements.md`; only `sdlc-create-design`
+  writes `docs/design.md`. Other skills route spec changes to those owners.
+- Keep run state, plans, evidence, steering, screenshots, and transcripts under `~/.codex/sdlc-runs/<project-id>/<run-id>/`.
+- When an active run exists, reload `current-state.json` and the latest
+  checkpoint before changing phase or writing evidence.
+- Work on one feature at a time unless the user explicitly asks for a different SDLC shape.
+- Classify every failure before retrying or routing backward.
+- Use MCP servers for browser, GitHub, internal docs, Slack, Confluence, Jira, and other external systems when they are available and appropriate.
+- Treat hooks as invariant guardrails only; do not make hooks orchestrate the workflow.
+
+## Learning Loop
+
+When using this skill, capture durable, reusable, public-safe learnings back
+into this skill's local source materials before completion when the current task
+contract allows source edits. Update the narrowest appropriate surface:
+`SKILL.md` for runtime rules, `references/` for detailed guidance, `assets/`
+for reusable templates, `scripts/` for deterministic helpers, and README or
+changelog entries for human-facing or release-note updates.
+
+If the current task is explicitly read-only/report-only, or source writes are
+outside this skill's task contract, do not edit skill sources; report the
+skipped source update instead.
+
+Do not capture secrets, private URLs, customer data, raw logs, one-off local
+state, or unverified/vendor-specific claims. If a useful learning is not safe,
+not evidence-backed, or outside this skill's scope, report that it was skipped.
+
+## Output Contract
+
+Return a concise result with:
+
+- Scope handled and current `REQ-*` or `FEAT-*` IDs.
+- Files or local state written.
+- Evidence created or checked.
+- Failure classification and next recommended skill when blocked.
+- Confirmation that private SDLC state was kept out of committed project files.
+
+## References
+
+- No skill-local references are required by default; use project files and current official documentation as needed.

--- a/skills/sdlc-implement-plan/agents/openai.yaml
+++ b/skills/sdlc-implement-plan/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "SDLC Implement Plan"
+  short_description: "Implement locked feature plan"
+  default_prompt: "Use $sdlc-implement-plan to implement Agentic SDLC production code for one feature while staying inside the locked plan."

--- a/skills/sdlc-merge-pr/README.md
+++ b/skills/sdlc-merge-pr/README.md
@@ -1,0 +1,27 @@
+# Merge PR
+
+`sdlc-merge-pr` is an Agentic SDLC skill. It is authored in this repository and is
+installed into a Codex runtime only when `install-skills.sh` is run.
+
+## What It Does
+
+Merge only after explicit human instruction and final readiness verification.
+
+## Main Boundaries
+
+- Merge without explicit user request.
+- Override branch protection.
+- Force merge.
+- Merge failed UAT.
+
+## Primary Inputs
+
+- Explicit user merge request.
+- PR URL or number.
+- Desired merge method if specified.
+
+## Output
+
+- PR is merged or blocker is reported.
+- Merge evidence is stored.
+- SDLC run is marked complete when applicable.

--- a/skills/sdlc-merge-pr/SKILL.md
+++ b/skills/sdlc-merge-pr/SKILL.md
@@ -1,0 +1,130 @@
+---
+name: sdlc-merge-pr
+description: "Use only as part of the Agentic SDLC workflow; use only when the user explicitly asks to merge a specific pull request in the Agentic SDLC workflow. Verifies readiness and merges only when policy, checks, reviews, branch state, and UAT allow it."
+---
+
+# Merge PR
+
+## Purpose
+
+Merge only after explicit human instruction and final readiness verification.
+
+## When To Use
+
+- The user explicitly asks to merge a specific PR.
+- Review, checks, branch state, and UAT evidence must be verified before merging.
+- The SDLC run needs final merge evidence after PR readiness.
+
+## When Not To Use
+
+- Do not use for PR review; use `review-pr`.
+- Do not use for PR creation; use `create-pr`.
+- Do not use without explicit merge instruction.
+
+## Inputs
+
+- Explicit user merge request.
+- PR URL or number.
+- Desired merge method if specified.
+
+## Required Reads
+
+- PR status, checks, reviews, branch protection, and unresolved conversations when available.
+- Latest UAT and review evidence.
+- Current repository state.
+
+## Writes
+
+- Merge result.
+- Local evidence entry.
+- `permissions/merge-authorization.json`, immediately before the merge, with a
+  short expiry and specific PR scope.
+- Final run status when this completes the SDLC run.
+
+## Process
+
+- Confirm the user explicitly requested merge for the specific PR.
+- Read PR status and verify checks pass.
+- Verify required reviews pass and unresolved conversations do not block policy.
+- Verify branch is up to date when required.
+- Verify UAT passed.
+- Write `permissions/merge-authorization.json` in the active run directory
+  immediately before merge execution. Include `allowed: true`,
+  `phase: "sdlc-merge-pr"`, the specific PR URL or number,
+  `explicit_user_request: true`, checks status, review status, and
+  `expires_at`.
+- Merge using the allowed method and record result.
+- Remove or expire `permissions/merge-authorization.json` after the merge
+  attempt.
+
+## Idempotency
+
+- If PR is already merged, report merged state.
+- Do not attempt repeated merge operations.
+- Do not reopen or recreate PR.
+
+## Failure Handling
+
+- Missing explicit approval maps to `POLICY_BLOCK`.
+- Missing or expired `merge-authorization.json` maps to `POLICY_BLOCK`.
+- Failing checks map to blocker.
+- Required review missing maps to blocker.
+- Conflict maps to blocker.
+
+## Must Not
+
+- Merge without explicit user request.
+- Override branch protection.
+- Force merge.
+- Merge failed UAT.
+- Merge unreviewed PRs when review is required.
+
+## Completion Criteria
+
+- PR is merged or blocker is reported.
+- Merge evidence is stored.
+- SDLC run is marked complete when applicable.
+
+## SDLC Invariants
+
+- Treat `docs/requirements.md` and `docs/design.md` as committed product truth.
+- Only `sdlc-create-requirements` writes `docs/requirements.md`; only `sdlc-create-design`
+  writes `docs/design.md`. Other skills route spec changes to those owners.
+- Keep run state, plans, evidence, steering, screenshots, and transcripts under `~/.codex/sdlc-runs/<project-id>/<run-id>/`.
+- When an active run exists, reload `current-state.json` and the latest
+  checkpoint before changing phase or writing evidence.
+- Work on one feature at a time unless the user explicitly asks for a different SDLC shape.
+- Classify every failure before retrying or routing backward.
+- Use MCP servers for browser, GitHub, internal docs, Slack, Confluence, Jira, and other external systems when they are available and appropriate.
+- Treat hooks as invariant guardrails only; do not make hooks orchestrate the workflow.
+
+## Learning Loop
+
+When using this skill, capture durable, reusable, public-safe learnings back
+into this skill's local source materials before completion when the current task
+contract allows source edits. Update the narrowest appropriate surface:
+`SKILL.md` for runtime rules, `references/` for detailed guidance, `assets/`
+for reusable templates, `scripts/` for deterministic helpers, and README or
+changelog entries for human-facing or release-note updates.
+
+If the current task is explicitly read-only/report-only, or source writes are
+outside this skill's task contract, do not edit skill sources; report the
+skipped source update instead.
+
+Do not capture secrets, private URLs, customer data, raw logs, one-off local
+state, or unverified/vendor-specific claims. If a useful learning is not safe,
+not evidence-backed, or outside this skill's scope, report that it was skipped.
+
+## Output Contract
+
+Return a concise result with:
+
+- Scope handled and current `REQ-*` or `FEAT-*` IDs.
+- Files or local state written.
+- Evidence created or checked.
+- Failure classification and next recommended skill when blocked.
+- Confirmation that private SDLC state was kept out of committed project files.
+
+## References
+
+- No skill-local references are required by default; use project files and current official documentation as needed.

--- a/skills/sdlc-merge-pr/agents/openai.yaml
+++ b/skills/sdlc-merge-pr/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "SDLC Merge PR"
+  short_description: "Explicit final PR merge"
+  default_prompt: "Use $sdlc-merge-pr to merge an Agentic SDLC pull request only after explicit human instruction and final readiness verification."

--- a/skills/sdlc-start/README.md
+++ b/skills/sdlc-start/README.md
@@ -1,0 +1,31 @@
+# Start SDLC
+
+`sdlc-start` is an Agentic SDLC skill. It is authored in this repository and is
+installed into a Codex runtime only when `install-skills.sh` is run.
+
+## What It Does
+
+Coordinate the SDLC loop by reading specs, checkpoints, and local state,
+selecting the next feature, and choosing exactly one next skill.
+
+## Main Boundaries
+
+- Free-edit requirements or design.
+- Implement code directly.
+- Commit, push, create PRs, review PRs, or merge.
+- Bypass validation, tests, or evaluation.
+
+## Primary Inputs
+
+- `docs/requirements.md`.
+- `docs/design.md` when present.
+- Existing local run state when present.
+- User instruction or continuation prompt.
+
+## Output
+
+- Active run state is accurate and backed by a checkpoint.
+- Current feature and next skill are explicit.
+- Each state transition writes a checkpoint and history entry.
+- Repeated resumes without state changes do not duplicate history.
+- The loop can resume after context loss.

--- a/skills/sdlc-start/README.md
+++ b/skills/sdlc-start/README.md
@@ -10,10 +10,10 @@ selecting the next feature, and choosing exactly one next skill.
 
 ## Main Boundaries
 
-- Free-edit requirements or design.
-- Implement code directly.
-- Commit, push, create PRs, review PRs, or merge.
-- Bypass validation, tests, or evaluation.
+- Do not free-edit requirements or design.
+- Do not implement code directly.
+- Do not commit, push, create PRs, review PRs, or merge.
+- Do not bypass validation, tests, or evaluation.
 
 ## Primary Inputs
 
@@ -29,3 +29,39 @@ selecting the next feature, and choosing exactly one next skill.
 - Each state transition writes a checkpoint and history entry.
 - Repeated resumes without state changes do not duplicate history.
 - The loop can resume after context loss.
+
+## Optional Hook Bundle
+
+`sdlc-start/assets/hooks/` is the source bundle for optional Agentic SDLC
+runtime hooks:
+
+- `pre_tool_use_sdlc_policy.py`
+- `stop_sdlc_continue.py`
+- `lib/sdlc_policy.py`
+- `lib/sdlc_state.py`
+- `tests/test_sdlc_hooks.py`
+
+Patch these source files before touching installed runtime copies under
+`$CODEX_HOME/hooks`. The Stop hook must emit `sdlc-start` and canonical
+`sdlc-*` skill names, while still accepting short phase aliases as input. The
+PreToolUse hook should continue blocking out-of-scope edits, including
+unscoped edits to runtime hook files from unrelated project workspaces.
+
+Validate the source bundle from the `skills/` directory:
+
+```bash
+python3 sdlc-start/assets/hooks/tests/test_sdlc_hooks.py
+```
+
+To intentionally sync the source bundle into a local Codex runtime:
+
+```bash
+./install-skills.sh --install-all-hooks
+./install-skills.sh --install-hooks sdlc-start/assets/hooks
+```
+
+The all-hooks form syncs every reviewed hook-only bundle under the source skills
+folder. The single-source form copies only SDLC hook files into
+`${CODEX_HOME:-$HOME/.codex}/hooks`. Neither form updates `hooks.json` or
+trusts hooks. Restart Codex and review the PreToolUse and Stop entries in
+`/hooks` after syncing.

--- a/skills/sdlc-start/SKILL.md
+++ b/skills/sdlc-start/SKILL.md
@@ -1,0 +1,166 @@
+---
+name: sdlc-start
+description: "Use only as part of the Agentic SDLC workflow; use when the user asks to start, resume, continue, or run the Agentic SDLC workflow for a project using `docs/requirements.md` and `docs/design.md`. This is the main SDLC coordinator and state-machine skill."
+---
+
+# Start SDLC
+
+## Purpose
+
+Coordinate the SDLC loop by reading specs, checkpoints, and local state,
+selecting the next feature, and choosing exactly one next skill.
+
+## When To Use
+
+- The user asks to start, resume, continue, or run the Agentic SDLC workflow.
+- A Stop-hook continuation prompt says to continue an active SDLC run.
+- An active run needs the next phase selected after a skill completes.
+
+## When Not To Use
+
+- Do not use to implement code directly.
+- Do not use to free-edit requirements or design.
+- Do not use to commit, push, create PRs, review PRs, or merge directly.
+
+## Inputs
+
+- `docs/requirements.md`.
+- `docs/design.md` when present.
+- Existing local run state when present.
+- User instruction or continuation prompt.
+
+## Required Reads
+
+- `docs/requirements.md`.
+- `docs/design.md`.
+- `~/.codex/sdlc-runs/<project-id>/active-run.json` when present.
+- Active run state under `~/.codex/sdlc-runs/<project-id>/<run-id>/`.
+- `current-state.json`, `feature-queue.json`, `fingerprints.json`,
+  `checkpoints/latest.json`, and the latest checkpoint file.
+- `STEERING.md`.
+- Latest feature evidence and failure logs.
+- `references/state-schema.md` for state fields and transitions.
+
+## Writes
+
+- `active-run.json` only when starting or switching the active run.
+- `run.json`, `current-state.json`, `feature-queue.json`, and
+  `fingerprints.json`.
+- `checkpoints/checkpoint-*.json` and `checkpoints/latest.json`.
+- `history/iteration-*.md` for state transitions.
+- Local blocker summaries.
+
+## Process
+
+- Read `references/state-schema.md` before initializing or repairing local state.
+- Resolve the project ID from the repository identity and read
+  `active-run.json` before choosing a run.
+- Acquire or honor the active run lock. If the lock appears stale, report the
+  lock owner and timestamp and recover only when the local evidence clearly
+  shows no active writer.
+- Resume from `checkpoints/latest.json` first. Do not rely on conversation
+  memory for current feature, phase, blocker, retry counts, or next skill.
+- Reconcile `current-state.json`, the latest checkpoint, feature queue,
+  fingerprints, and evidence. If they disagree, prefer the newest complete
+  checkpoint that matches existing evidence, then repair `current-state.json`.
+- Initialize local run state only when no active run or checkpoint exists.
+- If requirements are missing, route to `sdlc-create-requirements`.
+- If design is missing or stale and required context is missing, route only to
+  `sdlc-gather-context`.
+- If design is missing or stale and required context is present, route only to
+  `sdlc-create-design`.
+- Build or refresh the feature queue from `docs/design.md`.
+- Check `STEERING.md` before every iteration.
+- Select the highest-priority incomplete feature whose dependencies are complete.
+- Set one `next_recommended_skill` based on the current phase.
+- Before returning a next skill, write a checkpoint containing current feature,
+  phase, status, blocker, retry counts, last successful phase, fingerprints,
+  evidence pointers, and next recommended skill.
+- Update `checkpoints/latest.json`, then `current-state.json`, after the
+  checkpoint is written.
+- Write a history entry only when state changes. A repeated resume with no
+  state change returns the existing checkpoint and does not duplicate history.
+- Stop when complete, blocked, retry budget is exceeded, or human input is
+  required.
+
+## Idempotency
+
+- Every invocation starts by reading the latest checkpoint and current state.
+- Repeating the same invocation with unchanged specs, fingerprints, evidence,
+  and steering returns the same current feature and `next_recommended_skill`.
+- Completed features with unchanged fingerprints are skipped.
+- Changed requirements or design invalidate only affected features and
+  supersede stale plans; locked plan files are never edited in place.
+- History entries, checkpoints, and blocker summaries are append-only except
+  for `checkpoints/latest.json` and `current-state.json` pointers.
+- Partial writes are repaired by selecting the newest complete checkpoint and
+  regenerating derived pointers.
+
+## Failure Handling
+
+- If state is corrupt, reconstruct from the newest complete checkpoint, specs,
+  commits, and evidence when possible.
+- If plan lock conflicts exist, stop and report.
+- If a feature loops repeatedly, classify the blocker and stop after retry budget.
+- If no checkpoint can be trusted, stop with `HUMAN_INPUT_REQUIRED` instead of
+  guessing the phase.
+
+## Must Not
+
+- Free-edit requirements or design.
+- Implement code directly.
+- Commit, push, create PRs, review PRs, or merge.
+- Bypass validation, tests, or evaluation.
+- Create a workflow CLI.
+
+## Completion Criteria
+
+- Active run state is accurate and backed by a checkpoint.
+- Current feature and next skill are explicit.
+- Each state transition writes a checkpoint and history entry.
+- Repeated resumes without state changes do not duplicate history.
+- The loop can resume after context loss.
+
+## SDLC Invariants
+
+- Treat `docs/requirements.md` and `docs/design.md` as committed product truth.
+- Only `sdlc-create-requirements` writes `docs/requirements.md`; only `sdlc-create-design`
+  writes `docs/design.md`. Other skills route spec changes to those owners.
+- Keep run state, plans, evidence, steering, screenshots, and transcripts under `~/.codex/sdlc-runs/<project-id>/<run-id>/`.
+- When an active run exists, reload `current-state.json` and the latest
+  checkpoint before changing phase or writing evidence.
+- Work on one feature at a time unless the user explicitly asks for a different SDLC shape.
+- Classify every failure before retrying or routing backward.
+- Use MCP servers for browser, GitHub, internal docs, Slack, Confluence, Jira, and other external systems when they are available and appropriate.
+- Treat hooks as invariant guardrails only; do not make hooks orchestrate the workflow.
+
+## Learning Loop
+
+When using this skill, capture durable, reusable, public-safe learnings back
+into this skill's local source materials before completion when the current task
+contract allows source edits. Update the narrowest appropriate surface:
+`SKILL.md` for runtime rules, `references/` for detailed guidance, `assets/`
+for reusable templates, `scripts/` for deterministic helpers, and README or
+changelog entries for human-facing or release-note updates.
+
+If the current task is explicitly read-only/report-only, or source writes are
+outside this skill's task contract, do not edit skill sources; report the
+skipped source update instead.
+
+Do not capture secrets, private URLs, customer data, raw logs, one-off local
+state, or unverified/vendor-specific claims. If a useful learning is not safe,
+not evidence-backed, or outside this skill's scope, report that it was skipped.
+
+## Output Contract
+
+Return a concise result with:
+
+- Scope handled and current `REQ-*` or `FEAT-*` IDs.
+- Files or local state written.
+- Evidence created or checked.
+- Failure classification and next recommended skill when blocked.
+- Confirmation that private SDLC state was kept out of committed project files.
+
+## References
+
+- Read `references/state-schema.md` when this skill needs that local policy or schema.

--- a/skills/sdlc-start/SKILL.md
+++ b/skills/sdlc-start/SKILL.md
@@ -40,6 +40,8 @@ selecting the next feature, and choosing exactly one next skill.
 - `STEERING.md`.
 - Latest feature evidence and failure logs.
 - `references/state-schema.md` for state fields and transitions.
+- `assets/hooks/README.md` when maintaining optional SDLC PreToolUse or Stop
+  hooks.
 
 ## Writes
 
@@ -133,6 +135,11 @@ selecting the next feature, and choosing exactly one next skill.
 - Classify every failure before retrying or routing backward.
 - Use MCP servers for browser, GitHub, internal docs, Slack, Confluence, Jira, and other external systems when they are available and appropriate.
 - Treat hooks as invariant guardrails only; do not make hooks orchestrate the workflow.
+- Keep optional SDLC hook source under `assets/hooks/`. Patch that source first,
+  validate it with its local tests, then intentionally sync it to `$CODEX_HOME/hooks`
+  with `install-skills.sh --install-all-hooks`, or with
+  `install-skills.sh --install-hooks sdlc-start/assets/hooks` for an SDLC-only
+  hook sync.
 
 ## Learning Loop
 
@@ -164,3 +171,4 @@ Return a concise result with:
 ## References
 
 - Read `references/state-schema.md` when this skill needs that local policy or schema.
+- Read `assets/hooks/README.md` when maintaining or installing optional SDLC hooks.

--- a/skills/sdlc-start/agents/openai.yaml
+++ b/skills/sdlc-start/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "SDLC Start"
+  short_description: "Coordinate SDLC run state"
+  default_prompt: "Use $sdlc-start to coordinate the Agentic SDLC loop by reading specs and local state, selecting the next feature, and choosing exactly one next skill."

--- a/skills/sdlc-start/assets/hooks/README.md
+++ b/skills/sdlc-start/assets/hooks/README.md
@@ -1,0 +1,61 @@
+# Agentic SDLC Hook Bundle
+
+This directory is the source bundle for the optional Agentic SDLC runtime
+hooks. Keep hook fixes here first, then deliberately sync the bundle into a
+local Codex home.
+
+## Files
+
+- `pre_tool_use_sdlc_policy.py`: PreToolUse guardrail for active SDLC runs.
+- `stop_sdlc_continue.py`: Stop hook continuation guard for active SDLC runs.
+- `lib/sdlc_policy.py`: shared policy helpers.
+- `lib/sdlc_state.py`: shared state and Git helpers.
+- `tests/test_sdlc_hooks.py`: local unit tests for the hook bundle.
+
+## Maintenance Contract
+
+- Hooks are runtime guardrails, not skills. They must not make workflow phase
+  decisions that belong to `sdlc-start`.
+- The Stop hook must route continuation through `sdlc-start` and use canonical
+  `sdlc-*` skill names in prompts. Short phase aliases may be accepted as
+  input, but they must not be emitted as the next recommended skill.
+- `STEERING.md` pause and PR-control text, including `Pause after the current
+  feature. Do not create a PR.`, must trigger a continuation through
+  `sdlc-start` so the coordinator can persist the paused or no-PR decision.
+- The PreToolUse hook should keep out-of-scope writes blocked. Do not weaken
+  it to allow arbitrary edits to `$CODEX_HOME/hooks` from unrelated project
+  workspaces.
+- The PreToolUse hook must allow writes under `$CODEX_HOME/task-state` so the
+  global-context-management task-state file can be created and updated by the
+  parent agent. This global continuity state is separate from private SDLC run
+  state and from protected runtime hook files.
+
+## Validate
+
+From the `skills/` directory:
+
+```bash
+python3 sdlc-start/assets/hooks/tests/test_sdlc_hooks.py
+python3 -m py_compile \
+  sdlc-start/assets/hooks/pre_tool_use_sdlc_policy.py \
+  sdlc-start/assets/hooks/stop_sdlc_continue.py \
+  sdlc-start/assets/hooks/lib/sdlc_policy.py \
+  sdlc-start/assets/hooks/lib/sdlc_state.py
+```
+
+## Install To Local Runtime
+
+Use the explicit installer option so hook updates are not hidden inside the
+normal skill installation path:
+
+```bash
+./install-skills.sh --install-all-hooks
+./install-skills.sh --install-hooks sdlc-start/assets/hooks
+```
+
+Set `CODEX_HOME` first to target a non-default Codex home. The all-hooks form
+syncs every reviewed hook-only bundle under the source skills folder. The
+single-source form copies only the SDLC hook scripts and tests into
+`${CODEX_HOME:-$HOME/.codex}/hooks`. Neither form modifies `hooks.json`, trusts
+hooks, or installs skills. After syncing, restart Codex and review the
+PreToolUse and Stop hook entries in `/hooks`.

--- a/skills/sdlc-start/assets/hooks/lib/sdlc_policy.py
+++ b/skills/sdlc-start/assets/hooks/lib/sdlc_policy.py
@@ -1,0 +1,408 @@
+#!/usr/bin/env python3
+"""Policy helpers for Agentic SDLC Codex hooks."""
+
+from __future__ import annotations
+
+import json
+import re
+import shlex
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from sdlc_state import (
+    ActiveRun,
+    SDLC_RUNS,
+    CODEX_TASK_STATE,
+    detect_current_branch,
+    detect_default_branch,
+    is_inside,
+    resolve_path,
+    staged_diff,
+    staged_files,
+)
+
+
+DEFAULT_BRANCHES = {"main", "master", "trunk", "develop", "default"}
+WRITE_TOOL_KEYWORDS = ("write", "create", "update", "delete", "remove", "move", "rename", "patch", "edit")
+READ_TOOL_KEYWORDS = ("read", "get", "list", "search", "status", "view", "inspect")
+PRIVATE_STATE_PARTS = {
+    ".agent-state",
+    "evidence",
+    "history",
+    "screenshots",
+    "transcripts",
+}
+PRIVATE_STATE_FILES = {
+    "continuation-state.json",
+    "hook-events.jsonl",
+}
+CREDENTIAL_DIRS = {
+    ".ssh",
+    ".aws",
+    ".config",
+    ".kube",
+    ".gnupg",
+    ".gpg",
+    ".docker",
+    ".azure",
+}
+
+
+def allow() -> dict[str, Any]:
+    return {}
+
+
+def deny(reason: str) -> dict[str, Any]:
+    return {
+        "hookSpecificOutput": {
+            "hookEventName": "PreToolUse",
+            "permissionDecision": "deny",
+            "permissionDecisionReason": reason,
+        }
+    }
+
+
+def warn_context(message: str) -> dict[str, Any]:
+    return {
+        "hookSpecificOutput": {
+            "hookEventName": "PreToolUse",
+            "additionalContext": message,
+        }
+    }
+
+
+def stop(reason: str) -> dict[str, Any]:
+    return {"continue": False, "stopReason": reason}
+
+
+def continue_with(reason: str) -> dict[str, Any]:
+    return {"decision": "block", "reason": reason}
+
+
+def _json_text(value: Any) -> str:
+    try:
+        return json.dumps(value, sort_keys=True)
+    except TypeError:
+        return str(value)
+
+
+def contains_secret(text: str) -> bool:
+    if not text:
+        return False
+    placeholder_markers = (
+        "example",
+        "dummy",
+        "placeholder",
+        "redacted",
+        "<token>",
+        "<secret>",
+        "<password>",
+        "changeme",
+        "not-a-secret",
+    )
+    secret_patterns = [
+        r"-----BEGIN [A-Z ]*PRIVATE KEY-----",
+        r"\bAWS_ACCESS_KEY_ID\b\s*[:=]\s*[A-Z0-9]{16,}",
+        r"\bAWS_SECRET_ACCESS_KEY\b\s*[:=]\s*[A-Za-z0-9/+=]{30,}",
+        r"\bGITHUB_TOKEN\b\s*[:=]\s*[A-Za-z0-9_ghopsu-]{20,}",
+        r"\bOPENAI_API_KEY\b\s*[:=]\s*sk-[A-Za-z0-9_-]{16,}",
+        r"\bNEBIUS_[A-Z0-9_]*\b\s*[:=]\s*[A-Za-z0-9_./+=:-]{12,}",
+        r"\bYC_TOKEN\b\s*[:=]\s*[A-Za-z0-9_./+=:-]{12,}",
+        r"\bKUBECONFIG\b.*(certificate-authority-data|client-key-data|token:)",
+        r"(?i)\b(password|secret|token)\b\s*[:=]\s*[\"']?[A-Za-z0-9_./+=:-]{12,}",
+    ]
+    for line in text.splitlines() or [text]:
+        lowered = line.lower()
+        if any(marker in lowered for marker in placeholder_markers):
+            continue
+        if any(re.search(pattern, line) for pattern in secret_patterns):
+            return True
+    return False
+
+
+def dangerous_shell_reason(command: str) -> str | None:
+    normalized = re.sub(r"\s+", " ", command.strip())
+    patterns = [
+        (r"\b(curl|wget)\b.+\|\s*(sh|bash|zsh)\b", "Blocked: piping downloaded content into a shell."),
+        (r"(^|[;&|]\s*)sudo\b", "Blocked: sudo is outside the SDLC hook policy."),
+        (r"\bchmod\s+-R\s+777\b", "Blocked: recursive chmod 777 is unsafe."),
+        (r"\bchown\s+-R\b", "Blocked: recursive chown is unsafe."),
+        (r"\brm\s+-[^\n;]*r[^\n;]*f[^\n;]*(?:/\s*$|/\s|~(?:/|\s|$)|\.\.(?:/|\s|$))", "Blocked: destructive recursive removal outside a known temp path."),
+        (r"\bfind\s+/\s+.*-delete\b", "Blocked: deleting from filesystem root is unsafe."),
+        (r"\bdd\s+if=", "Blocked: dd is outside the SDLC hook policy."),
+        (r"\bmkfs(\.|\s|$)", "Blocked: filesystem formatting is unsafe."),
+        (r"\bdiskutil\s+erase", "Blocked: disk erase is unsafe."),
+        (r"\bkillall\b", "Blocked: killall is outside the SDLC hook policy."),
+        (r"\bpkill\s+-9\b", "Blocked: pkill -9 is outside the SDLC hook policy."),
+    ]
+    for pattern, reason in patterns:
+        if re.search(pattern, normalized, re.IGNORECASE):
+            return reason
+    return None
+
+
+def extract_apply_patch_targets(command: str, cwd: Path) -> list[Path]:
+    targets: list[Path] = []
+    for line in command.splitlines():
+        match = re.match(r"\*\*\* (?:Add|Update|Delete) File: (.+)$", line.strip())
+        if match:
+            targets.append(resolve_path(match.group(1).strip(), cwd))
+        move_match = re.match(r"\*\*\* Move to: (.+)$", line.strip())
+        if move_match:
+            targets.append(resolve_path(move_match.group(1).strip(), cwd))
+    return targets
+
+
+def extract_obvious_command_paths(command: str, cwd: Path) -> list[Path]:
+    paths: list[Path] = []
+    try:
+        tokens = shlex.split(command)
+    except ValueError:
+        tokens = command.split()
+    skip_next = False
+    for token in tokens:
+        if skip_next:
+            skip_next = False
+            continue
+        if token in {"-m", "--message", "-c", "--config"}:
+            skip_next = True
+            continue
+        if token.startswith("-"):
+            continue
+        if token.startswith(("~", "/", "./", "../")) or "/" in token:
+            paths.append(resolve_path(token, cwd))
+    return paths
+
+
+def extract_mcp_paths(args: Any, cwd: Path) -> list[Path]:
+    paths: list[Path] = []
+
+    def walk(value: Any) -> None:
+        if isinstance(value, dict):
+            for key, item in value.items():
+                if key.lower() in {"path", "file", "filepath", "filename", "dest", "destination", "target"} and isinstance(item, str):
+                    paths.append(resolve_path(item, cwd))
+                else:
+                    walk(item)
+        elif isinstance(value, list):
+            for item in value:
+                walk(item)
+
+    walk(args)
+    return paths
+
+
+def is_temp_path(path: Path) -> bool:
+    resolved = resolve_path(path)
+    temp_roots = [Path("/tmp"), Path("/private/tmp"), Path("/var/tmp")]
+    return any(is_inside(resolved, root) for root in temp_roots)
+
+
+def is_credential_path(path: Path) -> bool:
+    resolved = resolve_path(path)
+    home = resolve_path(Path.home())
+    if not is_inside(resolved, home):
+        return False
+    rel_parts = resolved.relative_to(home).parts
+    return bool(rel_parts and rel_parts[0] in CREDENTIAL_DIRS)
+
+
+def is_sdlc_private_path(path: Path, active: ActiveRun | None = None) -> bool:
+    resolved = resolve_path(path)
+    home_sdlc = resolve_path(Path.home() / ".codex" / "sdlc-runs")
+    if is_inside(resolved, home_sdlc):
+        return True
+    if active and is_inside(resolved, active.run_dir):
+        return True
+    parts = set(resolved.parts)
+    if ".agent-state" in parts:
+        return True
+    if any(part in PRIVATE_STATE_PARTS for part in resolved.parts):
+        return True
+    if resolved.name in PRIVATE_STATE_FILES or resolved.name.endswith(".lock"):
+        return True
+    return False
+
+
+def is_plan_locked(path: Path, active: ActiveRun | None = None) -> bool:
+    resolved = resolve_path(path)
+    if resolved.name.endswith(".lock"):
+        return True
+    if not re.match(r"FEAT-\d+\.plan\.v\d+\.md$", resolved.name):
+        return False
+    lock = resolved.with_suffix(resolved.suffix + ".lock")
+    if lock.exists():
+        return True
+    if active:
+        active_lock = active.plans_dir / (resolved.name + ".lock")
+        if active_lock.exists():
+            return True
+    return False
+
+
+def validate_write_targets(paths: list[Path], project_root: Path, active: ActiveRun | None) -> str | None:
+    for path in paths:
+        if is_credential_path(path):
+            return f"Blocked: writing credential path {path}."
+        if is_plan_locked(path, active):
+            return f"Blocked: locked SDLC plan cannot be edited or deleted: {path}."
+        allowed = (
+            is_inside(path, project_root)
+            or is_inside(path, SDLC_RUNS)
+            or is_inside(path, CODEX_TASK_STATE)
+            or is_temp_path(path)
+        )
+        if active:
+            allowed = allowed or is_inside(path, active.run_dir) or is_inside(path, active.project_dir)
+        if not allowed:
+            return f"Blocked: write target is outside the project root, SDLC state, global task state, or temp directory: {path}."
+    return None
+
+
+def command_has_private_state_leak(command: str) -> bool:
+    patterns = [
+        r"\bgit\s+add\b.*(\.codex/sdlc-runs|~/.codex/sdlc-runs|\.agent-state|evidence|screenshots|transcripts)",
+        r"\bcp\s+(-[A-Za-z]*R[A-Za-z]*\s+|\s+).*(\.codex/sdlc-runs|~/.codex/sdlc-runs|\.agent-state).*\s+\.",
+        r"\brsync\b.*(\.codex/sdlc-runs|~/.codex/sdlc-runs|\.agent-state).*\s+\.",
+    ]
+    return any(re.search(pattern, command) for pattern in patterns)
+
+
+def staged_private_paths(project_root: Path, active: ActiveRun | None = None) -> list[str]:
+    bad: list[str] = []
+    for name in staged_files(project_root):
+        path = resolve_path(project_root / name)
+        if is_sdlc_private_path(path, active):
+            bad.append(name)
+    return bad
+
+
+def auth_valid(active: ActiveRun | None, filename: str, expected_branch: str | None = None) -> tuple[bool, str]:
+    if not active:
+        return False, "no active SDLC run"
+    auth_path = active.permissions_dir / filename
+    try:
+        with auth_path.open("r", encoding="utf-8") as handle:
+            auth = json.load(handle)
+    except FileNotFoundError:
+        return False, f"missing {filename}"
+    except json.JSONDecodeError:
+        return False, f"corrupt {filename}"
+    if not auth.get("allowed"):
+        return False, f"{filename} does not allow this action"
+    expires_at = auth.get("expires_at")
+    if expires_at:
+        try:
+            parsed = datetime.fromisoformat(str(expires_at).replace("Z", "+00:00"))
+            if parsed < datetime.now(timezone.utc):
+                return False, f"{filename} expired"
+        except ValueError:
+            return False, f"{filename} has invalid expires_at"
+    if expected_branch and auth.get("branch") and auth.get("branch") != expected_branch:
+        return False, f"{filename} is for branch {auth.get('branch')}, not {expected_branch}"
+    return True, "authorized"
+
+
+def command_words(command: str) -> list[str]:
+    try:
+        return shlex.split(command)
+    except ValueError:
+        return command.split()
+
+
+def is_git_command(words: list[str], subcommand: str) -> bool:
+    return len(words) >= 2 and words[0] == "git" and words[1] == subcommand
+
+
+def is_gh_pr_merge(words: list[str]) -> bool:
+    return len(words) >= 3 and words[0] == "gh" and words[1] == "pr" and words[2] == "merge"
+
+
+def git_policy_reason(command: str, project_root: Path, active: ActiveRun | None) -> str | None:
+    words = command_words(command)
+    if not words:
+        return None
+    branch = detect_current_branch(project_root)
+    default_branch = detect_default_branch(project_root)
+    protected = DEFAULT_BRANCHES | {default_branch}
+    if is_git_command(words, "commit"):
+        if branch in protected:
+            return f"Blocked: git commit on protected branch {branch or '<detached>'}."
+        if active:
+            ok, reason = auth_valid(active, "commit-authorization.json", branch)
+            if not ok:
+                return f"Blocked: git commit requires valid SDLC commit authorization: {reason}."
+            private = staged_private_paths(project_root, active)
+            if private:
+                return "Blocked: staged files include private SDLC state: " + ", ".join(private[:5])
+            diff = staged_diff(project_root)
+            if contains_secret(diff):
+                return "Blocked: staged diff appears to contain a secret."
+        return None
+    if is_git_command(words, "push"):
+        if any(word in {"-f", "--force", "--force-with-lease"} or word.startswith("--force") for word in words):
+            return "Blocked: force push is outside the SDLC hook policy."
+        if branch in protected:
+            return f"Blocked: git push from protected branch {branch or '<detached>'}."
+        if active:
+            ok, reason = auth_valid(active, "pr-authorization.json", branch)
+            if not ok:
+                return f"Blocked: git push requires valid SDLC PR authorization: {reason}."
+        return None
+    if is_git_command(words, "reset") and "--hard" in words:
+        return "Blocked: git reset --hard is destructive."
+    if is_git_command(words, "clean") and any(re.fullmatch(r"-[A-Za-z]*f[A-Za-z]*d[A-Za-z]*x[A-Za-z]*", word) for word in words[2:]):
+        return "Blocked: git clean -fdx is destructive."
+    if is_git_command(words, "rebase") and branch in protected:
+        return f"Blocked: rebase on protected branch {branch}."
+    if is_git_command(words, "merge") and branch in protected:
+        return f"Blocked: merge into protected branch {branch}."
+    if is_git_command(words, "branch") and any(word in {"-D", "--delete", "-d"} for word in words):
+        return "Blocked: branch deletion is outside the SDLC hook policy."
+    if is_git_command(words, "push") and "--tags" in words:
+        return "Blocked: pushing tags requires explicit authorization."
+    if is_gh_pr_merge(words):
+        ok, reason = auth_valid(active, "merge-authorization.json", branch)
+        if not ok:
+            return f"Blocked: PR merge requires valid SDLC merge authorization: {reason}."
+    return None
+
+
+def mcp_policy_reason(tool_name: str, tool_input: Any, cwd: Path, project_root: Path, active: ActiveRun | None) -> str | None:
+    lower = tool_name.lower()
+    payload = _json_text(tool_input)
+    if contains_secret(payload):
+        return "Blocked: MCP arguments appear to contain a secret."
+    if "github" in lower and "merge" in lower:
+        ok, reason = auth_valid(active, "merge-authorization.json", detect_current_branch(project_root))
+        if not ok:
+            return f"Blocked: GitHub merge requires valid SDLC merge authorization: {reason}."
+    if "github" in lower and ("create_pull_request" in lower or "create_pr" in lower or "pull_request" in lower):
+        ok, reason = auth_valid(active, "pr-authorization.json", detect_current_branch(project_root))
+        if active and not ok:
+            return f"Blocked: GitHub PR creation requires valid SDLC PR authorization: {reason}."
+    if ("slack" in lower or "confluence" in lower) and any(word in lower for word in WRITE_TOOL_KEYWORDS):
+        if not active:
+            return "Blocked: external write MCP call requires active SDLC authorization."
+    if any(word in lower for word in WRITE_TOOL_KEYWORDS):
+        paths = extract_mcp_paths(tool_input, cwd)
+        target_reason = validate_write_targets(paths, project_root, active)
+        if target_reason:
+            return target_reason
+    return None
+
+
+def spec_warning_or_denial(command: str, paths: list[Path], project_root: Path, current_state: dict[str, Any]) -> dict[str, Any] | None:
+    spec_paths = {project_root / "docs" / "requirements.md": "requirements_update", project_root / "docs" / "design.md": "design_update"}
+    touched = [path for path in paths if any(resolve_path(path) == resolve_path(spec) for spec in spec_paths)]
+    if not touched:
+        return None
+    if re.search(r"^-.*\b(REQ|FEAT)-\d+\b", command, re.MULTILINE) and "CHANGELOG" not in command and "Change Log" not in command:
+        return deny("Blocked: spec edit appears to delete REQ/FEAT IDs without a changelog entry.")
+    phase = str(current_state.get("current_phase") or "")
+    for path in touched:
+        expected = spec_paths[resolve_path(path)]
+        if phase and phase != expected:
+            return warn_context(f"SDLC warning: {path.name} is normally updated only during {expected}; current phase is {phase}.")
+    return None

--- a/skills/sdlc-start/assets/hooks/lib/sdlc_state.py
+++ b/skills/sdlc-start/assets/hooks/lib/sdlc_state.py
@@ -1,0 +1,290 @@
+#!/usr/bin/env python3
+"""Shared state helpers for local Agentic SDLC Codex hooks."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import subprocess
+import tempfile
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+CODEX_HOME = Path(os.environ.get("CODEX_HOME", Path.home() / ".codex")).expanduser()
+SDLC_RUNS = CODEX_HOME / "sdlc-runs"
+CODEX_TASK_STATE = CODEX_HOME / "task-state"
+
+
+@dataclass(frozen=True)
+class ActiveRun:
+    project_id: str
+    project_root: Path
+    run_id: str
+    project_dir: Path
+    run_dir: Path
+    lock_path: Path
+
+    @property
+    def run_json_path(self) -> Path:
+        return self.run_dir / "run.json"
+
+    @property
+    def current_state_path(self) -> Path:
+        return self.run_dir / "current-state.json"
+
+    @property
+    def feature_queue_path(self) -> Path:
+        return self.run_dir / "feature-queue.json"
+
+    @property
+    def fingerprints_path(self) -> Path:
+        return self.run_dir / "fingerprints.json"
+
+    @property
+    def steering_path(self) -> Path:
+        return self.run_dir / "STEERING.md"
+
+    @property
+    def permissions_dir(self) -> Path:
+        return self.run_dir / "permissions"
+
+    @property
+    def plans_dir(self) -> Path:
+        return self.run_dir / "plans"
+
+    @property
+    def evidence_dir(self) -> Path:
+        return self.run_dir / "evidence"
+
+    @property
+    def history_dir(self) -> Path:
+        return self.run_dir / "history"
+
+
+def now_iso() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def resolve_path(path: Path | str, cwd: Path | None = None) -> Path:
+    candidate = Path(path).expanduser()
+    if not candidate.is_absolute() and cwd is not None:
+        candidate = cwd / candidate
+    return candidate.resolve(strict=False)
+
+
+def is_inside(path: Path | str, root: Path | str) -> bool:
+    try:
+        resolve_path(path).relative_to(resolve_path(root))
+        return True
+    except ValueError:
+        return False
+
+
+def load_json(path: Path) -> dict[str, Any] | None:
+    try:
+        with path.open("r", encoding="utf-8") as handle:
+            value = json.load(handle)
+    except FileNotFoundError:
+        return None
+    except json.JSONDecodeError:
+        raise
+    if isinstance(value, dict):
+        return value
+    return {}
+
+
+def write_json_atomic(path: Path, value: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp_name = tempfile.mkstemp(prefix=f".{path.name}.", suffix=".tmp", dir=str(path.parent))
+    tmp_path = Path(tmp_name)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            json.dump(value, handle, indent=2, sort_keys=True)
+            handle.write("\n")
+        os.replace(tmp_path, path)
+        try:
+            path.chmod(0o600)
+        except OSError:
+            pass
+    finally:
+        if tmp_path.exists():
+            tmp_path.unlink()
+
+
+def append_jsonl(path: Path, value: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    payload = dict(value)
+    payload.setdefault("created_at", now_iso())
+    with path.open("a", encoding="utf-8") as handle:
+        json.dump(payload, handle, sort_keys=True)
+        handle.write("\n")
+    try:
+        path.chmod(0o600)
+    except OSError:
+        pass
+
+
+def run_git(cwd: Path, args: list[str]) -> str:
+    try:
+        result = subprocess.run(
+            ["git", *args],
+            cwd=str(cwd),
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            check=False,
+            timeout=5,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return ""
+    if result.returncode != 0:
+        return ""
+    return result.stdout.strip()
+
+
+def resolve_project_root(cwd: Path | str) -> Path:
+    resolved = resolve_path(cwd)
+    git_root = run_git(resolved, ["rev-parse", "--show-toplevel"])
+    if git_root:
+        return resolve_path(git_root)
+    return resolved
+
+
+def detect_current_branch(project_root: Path) -> str:
+    return run_git(project_root, ["branch", "--show-current"])
+
+
+def detect_default_branch(project_root: Path) -> str:
+    origin_head = run_git(project_root, ["symbolic-ref", "--short", "refs/remotes/origin/HEAD"])
+    if origin_head.startswith("origin/"):
+        return origin_head.removeprefix("origin/")
+    for candidate in ("main", "master", "trunk", "develop"):
+        ref = run_git(project_root, ["rev-parse", "--verify", "--quiet", candidate])
+        if ref:
+            return candidate
+    return "main"
+
+
+def git_head(project_root: Path) -> str:
+    return run_git(project_root, ["rev-parse", "HEAD"])
+
+
+def staged_files(project_root: Path) -> list[str]:
+    output = run_git(project_root, ["diff", "--cached", "--name-only", "-z"])
+    if not output:
+        return []
+    return [part for part in output.split("\x00") if part]
+
+
+def staged_diff(project_root: Path) -> str:
+    try:
+        result = subprocess.run(
+            ["git", "diff", "--cached", "--no-ext-diff"],
+            cwd=str(project_root),
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            check=False,
+            timeout=15,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return ""
+    if result.returncode != 0:
+        return ""
+    return result.stdout
+
+
+def _run_dir_from_lock(project_dir: Path, lock: dict[str, Any]) -> Path | None:
+    run_id = str(lock.get("run_id") or "")
+    if run_id:
+        run_dir = project_dir / run_id
+        if run_dir.exists():
+            return run_dir
+    active_run = load_json(project_dir / "active-run.json")
+    active_id = str((active_run or {}).get("run_id") or "")
+    if active_id and (project_dir / active_id).exists():
+        return project_dir / active_id
+    active_dir = project_dir / "active"
+    if active_dir.exists():
+        return active_dir
+    if run_id:
+        return project_dir / run_id
+    return None
+
+
+def load_active_run(cwd: Path | str, codex_home: Path = CODEX_HOME) -> ActiveRun | None:
+    cwd_path = resolve_path(cwd)
+    runs_root = codex_home.expanduser() / "sdlc-runs"
+    if not runs_root.exists():
+        return None
+    for lock_path in sorted(runs_root.glob("*/active.lock")):
+        try:
+            lock = load_json(lock_path)
+        except json.JSONDecodeError:
+            continue
+        if not lock:
+            continue
+        project_root_raw = lock.get("project_root")
+        if not project_root_raw:
+            continue
+        project_root = resolve_path(str(project_root_raw))
+        if not is_inside(cwd_path, project_root):
+            continue
+        project_dir = lock_path.parent
+        run_dir = _run_dir_from_lock(project_dir, lock)
+        if run_dir is None:
+            continue
+        project_id = str(lock.get("project_id") or project_dir.name)
+        run_id = str(lock.get("run_id") or run_dir.name)
+        return ActiveRun(
+            project_id=project_id,
+            project_root=project_root,
+            run_id=run_id,
+            project_dir=project_dir,
+            run_dir=run_dir,
+            lock_path=lock_path,
+        )
+    return None
+
+
+def load_active_state(cwd: Path | str) -> tuple[ActiveRun | None, dict[str, Any], dict[str, Any], dict[str, Any]]:
+    active = load_active_run(cwd)
+    if active is None:
+        return None, {}, {}, {}
+    run_state = load_json(active.run_json_path) or {}
+    current_state = load_json(active.current_state_path) or {}
+    feature_queue = load_json(active.feature_queue_path) or {}
+    return active, run_state, current_state, feature_queue
+
+
+def hash_state(paths: list[Path], extra: list[str] | None = None) -> str:
+    digest = hashlib.sha256()
+    for path in paths:
+        digest.update(str(path).encode("utf-8", errors="replace"))
+        digest.update(b"\0")
+        if path.is_file():
+            try:
+                digest.update(path.read_bytes())
+            except OSError:
+                digest.update(b"<unreadable>")
+        elif path.is_dir():
+            for child in sorted(p for p in path.rglob("*") if p.is_file()):
+                try:
+                    stat = child.stat()
+                    rel = str(child.relative_to(path))
+                    digest.update(rel.encode("utf-8", errors="replace"))
+                    digest.update(str(stat.st_mtime_ns).encode("ascii"))
+                    digest.update(str(stat.st_size).encode("ascii"))
+                except OSError:
+                    continue
+        else:
+            digest.update(b"<missing>")
+        digest.update(b"\0")
+    for item in extra or []:
+        digest.update(item.encode("utf-8", errors="replace"))
+        digest.update(b"\0")
+    return "sha256:" + digest.hexdigest()

--- a/skills/sdlc-start/assets/hooks/pre_tool_use_sdlc_policy.py
+++ b/skills/sdlc-start/assets/hooks/pre_tool_use_sdlc_policy.py
@@ -1,0 +1,176 @@
+#!/usr/bin/env python3
+"""PreToolUse safety hook for Agentic SDLC runs."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+HOOK_DIR = Path(__file__).resolve().parent
+LIB_DIR = HOOK_DIR / "lib"
+if str(LIB_DIR) not in sys.path:
+    sys.path.insert(0, str(LIB_DIR))
+
+from sdlc_policy import (  # noqa: E402
+    allow,
+    command_has_private_state_leak,
+    contains_secret,
+    dangerous_shell_reason,
+    deny,
+    extract_apply_patch_targets,
+    extract_obvious_command_paths,
+    git_policy_reason,
+    mcp_policy_reason,
+    spec_warning_or_denial,
+    validate_write_targets,
+)
+from sdlc_state import (  # noqa: E402
+    append_jsonl,
+    load_active_state,
+    now_iso,
+    resolve_path,
+    resolve_project_root,
+)
+
+
+WRITE_COMMANDS = {"rm", "mv", "cp", "rsync", "chmod", "chown", "mkdir", "touch", "tee"}
+
+
+def _tool_text(tool_input: Any) -> str:
+    if isinstance(tool_input, dict):
+        command = tool_input.get("command")
+        if isinstance(command, str):
+            return command
+    try:
+        return json.dumps(tool_input, sort_keys=True)
+    except TypeError:
+        return str(tool_input)
+
+
+def _command_starts_with_write(command: str) -> bool:
+    first = command.strip().split(maxsplit=1)[0] if command.strip() else ""
+    return first in WRITE_COMMANDS or ">" in command or ">>" in command
+
+
+def _log_event(payload: dict[str, Any], decision: dict[str, Any], reason: str | None) -> None:
+    cwd = payload.get("cwd") or "."
+    try:
+        active, _, _, _ = load_active_state(cwd)
+    except json.JSONDecodeError:
+        active = None
+    if active is None:
+        return
+    event = {
+        "event": "PreToolUse",
+        "tool_name": payload.get("tool_name"),
+        "tool_use_id": payload.get("tool_use_id"),
+        "turn_id": payload.get("turn_id"),
+        "cwd": cwd,
+        "decision": "deny" if reason else ("context" if decision else "allow"),
+        "reason": reason,
+        "project_id": active.project_id,
+        "run_id": active.run_id,
+        "created_at": now_iso(),
+    }
+    append_jsonl(active.history_dir / "hook-events.jsonl", event)
+
+
+def _deny(payload: dict[str, Any], reason: str) -> dict[str, Any]:
+    decision = deny(reason)
+    _log_event(payload, decision, reason)
+    return decision
+
+
+def _allow(payload: dict[str, Any], decision: dict[str, Any] | None = None) -> dict[str, Any]:
+    result = decision if decision is not None else allow()
+    _log_event(payload, result, None)
+    return result
+
+
+def evaluate(payload: dict[str, Any]) -> dict[str, Any]:
+    if payload.get("hook_event_name") != "PreToolUse":
+        return allow()
+
+    cwd = resolve_path(payload.get("cwd") or ".")
+    tool_name = str(payload.get("tool_name") or "")
+    tool_input = payload.get("tool_input") or {}
+    command = _tool_text(tool_input)
+
+    try:
+        active, _, current_state, _ = load_active_state(cwd)
+    except json.JSONDecodeError:
+        return _deny(payload, "Blocked: active SDLC state is corrupt and must be repaired before mutating actions.")
+
+    project_root = active.project_root if active else resolve_project_root(cwd)
+
+    danger = dangerous_shell_reason(command)
+    if danger:
+        return _deny(payload, danger)
+
+    if command_has_private_state_leak(command):
+        return _deny(payload, "Blocked: command appears to move, stage, or copy private SDLC state into the repository.")
+
+    if tool_name == "Bash":
+        git_reason = git_policy_reason(command, project_root, active)
+        if git_reason:
+            return _deny(payload, git_reason)
+        if _command_starts_with_write(command):
+            targets = extract_obvious_command_paths(command, cwd)
+            target_reason = validate_write_targets(targets, project_root, active)
+            if target_reason:
+                return _deny(payload, target_reason)
+        if contains_secret(command):
+            return _deny(payload, "Blocked: shell command appears to contain a secret.")
+        return _allow(payload)
+
+    if tool_name == "apply_patch":
+        targets = extract_apply_patch_targets(command, cwd)
+        target_reason = validate_write_targets(targets, project_root, active)
+        if target_reason:
+            return _deny(payload, target_reason)
+        if contains_secret(command):
+            return _deny(payload, "Blocked: patch appears to contain a secret.")
+        spec_decision = spec_warning_or_denial(command, targets, project_root, current_state)
+        if spec_decision:
+            if spec_decision.get("hookSpecificOutput", {}).get("permissionDecision") == "deny":
+                return _deny(payload, spec_decision["hookSpecificOutput"]["permissionDecisionReason"])
+            return _allow(payload, spec_decision)
+        return _allow(payload)
+
+    if tool_name.startswith("mcp__"):
+        reason = mcp_policy_reason(tool_name, tool_input, cwd, project_root, active)
+        if reason:
+            return _deny(payload, reason)
+        return _allow(payload)
+
+    return _allow(payload)
+
+
+def main() -> int:
+    try:
+        raw = sys.stdin.read()
+        payload = json.loads(raw) if raw.strip() else {}
+        result = evaluate(payload)
+        if result:
+            print(json.dumps(result, sort_keys=True))
+        return 0
+    except Exception as exc:  # pragma: no cover - fail closed for hook runtime
+        print(
+            json.dumps(
+                {
+                    "hookSpecificOutput": {
+                        "hookEventName": "PreToolUse",
+                        "permissionDecision": "deny",
+                        "permissionDecisionReason": f"Blocked: SDLC PreToolUse hook failed closed: {exc}",
+                    }
+                },
+                sort_keys=True,
+            )
+        )
+        return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/sdlc-start/assets/hooks/stop_sdlc_continue.py
+++ b/skills/sdlc-start/assets/hooks/stop_sdlc_continue.py
@@ -1,0 +1,300 @@
+#!/usr/bin/env python3
+"""Stop hook that safely continues active Agentic SDLC runs."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+HOOK_DIR = Path(__file__).resolve().parent
+LIB_DIR = HOOK_DIR / "lib"
+if str(LIB_DIR) not in sys.path:
+    sys.path.insert(0, str(LIB_DIR))
+
+from sdlc_policy import continue_with, stop  # noqa: E402
+from sdlc_state import (  # noqa: E402
+    append_jsonl,
+    git_head,
+    hash_state,
+    is_inside,
+    load_active_run,
+    load_json,
+    now_iso,
+    resolve_path,
+    write_json_atomic,
+)
+
+
+TERMINAL_STATUSES = {"complete", "completed", "paused", "blocked"}
+RETRY_DEFAULT = 3
+COORDINATOR_SKILL = "sdlc-start"
+
+
+def _normalize_skill_name(value: str) -> str:
+    aliases = {
+        "align-specs": "sdlc-align-specs",
+        "classify-failure": "sdlc-classify-failure",
+        "commit": "sdlc-commit",
+        "create-design": "sdlc-create-design",
+        "create-plan": "sdlc-create-plan",
+        "create-requirements": "sdlc-create-requirements",
+        "evaluate": "sdlc-evaluate",
+        "gather-context": "sdlc-gather-context",
+        "gui-test": "sdlc-gui-test",
+        "implement-plan": "sdlc-implement-plan",
+        "merge-pr": "sdlc-merge-pr",
+        "tdd": "sdlc-tdd",
+        "tui-test": "sdlc-tui-test",
+        "uat-tests": "sdlc-uat-tests",
+        "unit-tests": "sdlc-unit-tests",
+        "validate-codes": "sdlc-validate-codes",
+    }
+    stripped = value.strip()
+    return aliases.get(stripped, stripped)
+
+
+def _continue_normally() -> dict[str, Any]:
+    return {"continue": True}
+
+
+def _feature_items(feature_queue: dict[str, Any]) -> list[dict[str, Any]]:
+    for key in ("features", "queue", "items"):
+        value = feature_queue.get(key)
+        if isinstance(value, list):
+            return [item for item in value if isinstance(item, dict)]
+    return []
+
+
+def _all_features_committed(feature_queue: dict[str, Any]) -> bool:
+    features = _feature_items(feature_queue)
+    if not features:
+        return False
+    committed_states = {"committed", "uat", "pr-ready", "pr", "review", "merged", "complete", "completed"}
+    for feature in features:
+        status = str(feature.get("status") or feature.get("phase") or "").lower()
+        if not feature.get("committed") and status not in committed_states:
+            return False
+    return True
+
+
+def _uat_passed(feature_queue: dict[str, Any], current_state: dict[str, Any]) -> bool:
+    for source in (feature_queue.get("uat"), current_state.get("uat"), current_state.get("evidence")):
+        if isinstance(source, dict):
+            status = str(source.get("status") or source.get("uat") or source.get("result") or "").lower()
+            if status in {"pass", "passed", "success"}:
+                return True
+    return str(current_state.get("uat_status") or "").lower() in {"pass", "passed", "success"}
+
+
+def _uat_failed_addressable(current_state: dict[str, Any]) -> bool:
+    status = str(current_state.get("uat_status") or "").lower()
+    failure = str(current_state.get("failure_classification") or current_state.get("blocked_reason") or "").lower()
+    return status in {"fail", "failed"} and any(
+        token in failure for token in ("design", "implementation", "test", "environment")
+    )
+
+
+def _retry_exceeded(current_state: dict[str, Any]) -> str | None:
+    phase = str(current_state.get("current_phase") or current_state.get("phase") or "")
+    retry_counts = current_state.get("retry_counts")
+    if not phase or not isinstance(retry_counts, dict):
+        return None
+    count = int(retry_counts.get(phase, 0) or 0)
+    max_retries = int(current_state.get("max_retries", RETRY_DEFAULT) or RETRY_DEFAULT)
+    if count >= max_retries:
+        return phase
+    return None
+
+
+def _steering_reason(active) -> str | None:
+    try:
+        text = active.steering_path.read_text(encoding="utf-8")
+    except FileNotFoundError:
+        return None
+    except OSError:
+        return "STEERING.md could not be read."
+    upper = text.upper()
+    if any(token in upper for token in ("CRITICAL", "URGENT", "PRIORITY", "BLOCKER")):
+        return "critical STEERING.md instructions are present"
+    if "PAUSE" in upper or "DO NOT CREATE A PR" in upper or "DO NOT CREATE PR" in upper or "NO PR" in upper:
+        return "STEERING.md contains pause or PR-control instructions"
+    return None
+
+
+def _current_iteration(current_state: dict[str, Any]) -> int:
+    return int(current_state.get("iteration_count", current_state.get("iteration", 0)) or 0)
+
+
+def _max_iterations(current_state: dict[str, Any]) -> int:
+    return int(current_state.get("max_iterations", 200) or 200)
+
+
+def _continuation_prompt(active, current_state: dict[str, Any], next_skill: str, reason: str) -> str:
+    return "\n".join(
+        [
+            f"Use skill {COORDINATOR_SKILL}.",
+            "Continue the active SDLC run from local state.",
+            "",
+            f"Project root: {active.project_root}",
+            f"Project ID: {active.project_id}",
+            f"Run ID: {active.run_id}",
+            f"Current feature: {current_state.get('current_feature') or '<none>'}",
+            f"Current phase: {current_state.get('current_phase') or '<unknown>'}",
+            f"Next recommended skill: {_normalize_skill_name(next_skill)}",
+            f"Reason: {reason}",
+            "",
+            "Before doing anything:",
+            "- Read active.lock.",
+            "- Read current-state.json.",
+            "- Read feature-queue.json.",
+            "- Check STEERING.md.",
+            "- Read docs/requirements.md and docs/design.md only as needed.",
+            "- Do not modify locked plans.",
+            "- Do not edit requirements.md or design.md directly.",
+            "- Persist evidence before stopping.",
+            "- If blocked, classify the failure and update current-state.json.",
+        ]
+    )
+
+
+def _load_continuation(active) -> dict[str, Any]:
+    try:
+        return load_json(active.history_dir / "continuation-state.json") or {}
+    except json.JSONDecodeError:
+        return {}
+
+
+def _state_digest(active, current_state: dict[str, Any]) -> str:
+    return hash_state(
+        [
+            active.current_state_path,
+            active.feature_queue_path,
+            active.fingerprints_path,
+            active.evidence_dir,
+        ],
+        extra=[git_head(active.project_root), str(current_state.get("next_recommended_skill") or "")],
+    )
+
+
+def _record_continuation(active, payload: dict[str, Any], digest: str, no_progress_count: int, reason: str) -> None:
+    value = {
+        "last_state_digest": digest,
+        "last_continuation_turn_id": payload.get("turn_id"),
+        "no_progress_count": no_progress_count,
+        "last_reason": reason,
+        "last_updated_at": now_iso(),
+    }
+    write_json_atomic(active.history_dir / "continuation-state.json", value)
+    append_jsonl(
+        active.history_dir / "hook-events.jsonl",
+        {
+            "event": "Stop",
+            "turn_id": payload.get("turn_id"),
+            "decision": "continue" if reason != "NO_PROGRESS" else "stop",
+            "reason": reason,
+            "project_id": active.project_id,
+            "run_id": active.run_id,
+        },
+    )
+
+
+def _no_progress_count(active, payload: dict[str, Any], digest: str) -> int:
+    previous = _load_continuation(active)
+    if payload.get("stop_hook_active") and previous.get("last_state_digest") == digest:
+        return int(previous.get("no_progress_count", 0) or 0) + 1
+    return 0
+
+
+def evaluate(payload: dict[str, Any]) -> dict[str, Any]:
+    if payload.get("hook_event_name") != "Stop":
+        return _continue_normally()
+
+    cwd = resolve_path(payload.get("cwd") or ".")
+    active = load_active_run(cwd)
+    if active is None:
+        return _continue_normally()
+    if not is_inside(cwd, active.project_root):
+        return _continue_normally()
+
+    try:
+        run_state = load_json(active.run_json_path) or {}
+        current_state = load_json(active.current_state_path) or {}
+        feature_queue = load_json(active.feature_queue_path) or {}
+    except json.JSONDecodeError:
+        return stop("SDLC state is corrupt and needs repair.")
+
+    current_status = str(current_state.get("status") or "").lower()
+    run_status = str(run_state.get("status") or "").lower()
+    status = current_status or run_status
+    if run_status in TERMINAL_STATUSES:
+        status = run_status
+    blocked_reason = current_state.get("blocked_reason") or run_state.get("blocked_reason")
+    if status in TERMINAL_STATUSES:
+        if status in {"complete", "completed"}:
+            return stop("SDLC run complete.")
+        if status == "paused":
+            return stop("SDLC run paused.")
+        return stop(f"SDLC run is blocked: {blocked_reason or 'no blocker reason recorded'}")
+
+    if current_state.get("needs_human") or run_state.get("needs_human"):
+        return stop(f"Human input required: {blocked_reason or 'state requested human input'}")
+
+    if _current_iteration(current_state) >= _max_iterations(current_state):
+        return stop("Max SDLC iterations reached.")
+
+    retry_phase = _retry_exceeded(current_state)
+    if retry_phase:
+        return stop(f"Retry budget exceeded for {retry_phase}.")
+
+    digest = _state_digest(active, current_state)
+    no_progress = _no_progress_count(active, payload, digest)
+    if no_progress >= 2:
+        _record_continuation(active, payload, digest, no_progress, "NO_PROGRESS")
+        return stop("No progress after Stop continuation.")
+
+    steering_reason = _steering_reason(active)
+    if steering_reason:
+        prompt = _continuation_prompt(active, current_state, COORDINATOR_SKILL, steering_reason)
+        _record_continuation(active, payload, digest, no_progress, steering_reason)
+        return continue_with(prompt)
+
+    if _all_features_committed(feature_queue) and not _uat_passed(feature_queue, current_state):
+        reason = "all features are committed and UAT has not passed"
+        prompt = _continuation_prompt(active, current_state, "sdlc-uat-tests", reason)
+        _record_continuation(active, payload, digest, no_progress, reason)
+        return continue_with(prompt)
+
+    if _uat_failed_addressable(current_state):
+        reason = "UAT failed with an addressable classification"
+        prompt = _continuation_prompt(active, current_state, COORDINATOR_SKILL, reason)
+        _record_continuation(active, payload, digest, no_progress, reason)
+        return continue_with(prompt)
+
+    next_skill = str(current_state.get("next_recommended_skill") or "").strip()
+    next_skill = _normalize_skill_name(next_skill)
+    if next_skill == "sdlc-merge-pr":
+        return stop("Merge requires an explicit user request and will not be continued automatically.")
+    if next_skill:
+        reason = f"state recommends {next_skill}"
+        prompt = _continuation_prompt(active, current_state, next_skill, reason)
+        _record_continuation(active, payload, digest, no_progress, reason)
+        return continue_with(prompt)
+
+    return _continue_normally()
+
+
+def main() -> int:
+    try:
+        raw = sys.stdin.read()
+        payload = json.loads(raw) if raw.strip() else {}
+        print(json.dumps(evaluate(payload), sort_keys=True))
+        return 0
+    except Exception as exc:  # pragma: no cover - stop hooks must output JSON
+        print(json.dumps(stop(f"SDLC Stop hook failed closed: {exc}"), sort_keys=True))
+        return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/sdlc-start/assets/hooks/tests/test_sdlc_hooks.py
+++ b/skills/sdlc-start/assets/hooks/tests/test_sdlc_hooks.py
@@ -1,0 +1,324 @@
+#!/usr/bin/env python3
+"""Unit tests for local Agentic SDLC Codex hooks."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import tempfile
+import unittest
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+
+HOOK_DIR = Path(__file__).resolve().parents[1]
+PRE_TOOL = HOOK_DIR / "pre_tool_use_sdlc_policy.py"
+STOP = HOOK_DIR / "stop_sdlc_continue.py"
+
+
+def run_hook(script: Path, payload: dict, codex_home: Path) -> dict:
+    env = os.environ.copy()
+    env["CODEX_HOME"] = str(codex_home)
+    result = subprocess.run(
+        ["python3", str(script)],
+        input=json.dumps(payload),
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        env=env,
+        check=False,
+        timeout=10,
+    )
+    if result.returncode != 0:
+        raise AssertionError(result.stderr)
+    if not result.stdout.strip():
+        return {}
+    return json.loads(result.stdout)
+
+
+def write_json(path: Path, value: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(value, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def git(project: Path, *args: str) -> str:
+    result = subprocess.run(
+        ["git", *args],
+        cwd=str(project),
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=True,
+    )
+    return result.stdout.strip()
+
+
+class HookTestCase(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tmp = tempfile.TemporaryDirectory()
+        self.root = Path(self.tmp.name)
+        self.codex_home = self.root / "codex"
+        self.project = self.root / "project"
+        self.project.mkdir()
+        try:
+            git(self.project, "init", "-b", "main")
+        except subprocess.CalledProcessError:
+            git(self.project, "init")
+            git(self.project, "branch", "-m", "main")
+        git(self.project, "config", "user.email", "test@example.com")
+        git(self.project, "config", "user.name", "Test User")
+        (self.project / "src").mkdir()
+        (self.project / "src" / "module.py").write_text("print('hello')\n", encoding="utf-8")
+        (self.project / "docs").mkdir()
+        (self.project / "docs" / "design.md").write_text("# Design\n\nFEAT-001\n", encoding="utf-8")
+        git(self.project, "add", ".")
+        git(self.project, "commit", "-m", "initial")
+
+    def tearDown(self) -> None:
+        self.tmp.cleanup()
+
+    def switch_feature(self) -> None:
+        git(self.project, "switch", "-c", "agent/test")
+
+    def active_run(self, *, status: str = "running", phase: str = "implementation", next_skill: str = "sdlc-validate-codes") -> Path:
+        run_dir = self.codex_home / "sdlc-runs" / "test-project" / "run-1"
+        lock = {
+            "project_id": "test-project",
+            "project_root": str(self.project),
+            "run_id": "run-1",
+            "status": status,
+            "created_at": "2026-06-16T00:00:00Z",
+        }
+        write_json(run_dir.parent / "active.lock", lock)
+        write_json(run_dir.parent / "active-run.json", {"run_id": "run-1"})
+        write_json(run_dir / "run.json", {"status": status})
+        write_json(
+            run_dir / "current-state.json",
+            {
+                "project_id": "test-project",
+                "run_id": "run-1",
+                "status": status,
+                "current_feature": "FEAT-001",
+                "current_phase": phase,
+                "next_recommended_skill": next_skill,
+                "retry_counts": {phase: 0},
+                "iteration_count": 1,
+                "max_iterations": 200,
+                "needs_human": False,
+            },
+        )
+        write_json(run_dir / "feature-queue.json", {"features": [{"id": "FEAT-001", "status": phase}]})
+        write_json(run_dir / "fingerprints.json", {})
+        (run_dir / "history").mkdir(parents=True, exist_ok=True)
+        (run_dir / "evidence" / "FEAT-001").mkdir(parents=True, exist_ok=True)
+        return run_dir
+
+    def authorize(self, run_dir: Path, name: str) -> None:
+        expires = datetime.now(timezone.utc) + timedelta(hours=1)
+        write_json(
+            run_dir / "permissions" / name,
+            {
+                "allowed": True,
+                "branch": "agent/test",
+                "phase": name.removesuffix("-authorization.json"),
+                "expires_at": expires.isoformat().replace("+00:00", "Z"),
+            },
+        )
+
+    def pre_payload(self, tool_name: str, command: str | None = None, tool_input: dict | None = None) -> dict:
+        return {
+            "hook_event_name": "PreToolUse",
+            "cwd": str(self.project),
+            "turn_id": "turn-test",
+            "tool_name": tool_name,
+            "tool_use_id": "tool-test",
+            "tool_input": tool_input if tool_input is not None else {"command": command or ""},
+        }
+
+    def stop_payload(self, *, active: bool = False) -> dict:
+        return {
+            "hook_event_name": "Stop",
+            "cwd": str(self.project),
+            "turn_id": "turn-test",
+            "stop_hook_active": active,
+            "last_assistant_message": "done",
+        }
+
+    def assert_denied(self, result: dict, text: str) -> None:
+        output = result.get("hookSpecificOutput", {})
+        self.assertEqual(output.get("permissionDecision"), "deny")
+        self.assertIn(text, output.get("permissionDecisionReason", ""))
+
+    def test_pretool_allows_git_status(self) -> None:
+        result = run_hook(PRE_TOOL, self.pre_payload("Bash", "git status --short"), self.codex_home)
+        self.assertEqual(result, {})
+
+    def test_pretool_allows_project_patch(self) -> None:
+        patch = "*** Begin Patch\n*** Add File: src/new.py\n+print('ok')\n*** End Patch\n"
+        result = run_hook(PRE_TOOL, self.pre_payload("apply_patch", patch), self.codex_home)
+        self.assertEqual(result, {})
+
+    def test_pretool_allows_initial_sdlc_state_patch(self) -> None:
+        state_path = self.codex_home / "sdlc-runs" / "test-project" / "run-1" / "current-state.json"
+        patch = f"*** Begin Patch\n*** Add File: {state_path}\n+{{}}\n*** End Patch\n"
+        result = run_hook(PRE_TOOL, self.pre_payload("apply_patch", patch), self.codex_home)
+        self.assertEqual(result, {})
+
+    def test_pretool_allows_global_task_state_patch(self) -> None:
+        state_path = self.codex_home / "task-state" / "workspace-abc" / "session-1" / "current.md"
+        patch = f"*** Begin Patch\n*** Add File: {state_path}\n+# Current Codex task state\n*** End Patch\n"
+        result = run_hook(PRE_TOOL, self.pre_payload("apply_patch", patch), self.codex_home)
+        self.assertEqual(result, {})
+
+    def test_pretool_allows_mcp_read(self) -> None:
+        result = run_hook(
+            PRE_TOOL,
+            self.pre_payload("mcp__filesystem__read_file", tool_input={"path": str(self.project / "src" / "module.py")}),
+            self.codex_home,
+        )
+        self.assertEqual(result, {})
+
+    def test_pretool_denies_credential_patch(self) -> None:
+        patch = "*** Begin Patch\n*** Add File: ~/.ssh/config\n+Host example\n*** End Patch\n"
+        result = run_hook(PRE_TOOL, self.pre_payload("apply_patch", patch), self.codex_home)
+        self.assert_denied(result, "credential path")
+
+    def test_pretool_denies_locked_plan_patch(self) -> None:
+        run_dir = self.active_run()
+        plan = run_dir / "plans" / "FEAT-001.plan.v1.md"
+        plan.parent.mkdir(parents=True, exist_ok=True)
+        plan.write_text("# Plan\n", encoding="utf-8")
+        plan.with_suffix(plan.suffix + ".lock").write_text("locked\n", encoding="utf-8")
+        patch = f"*** Begin Patch\n*** Update File: {plan}\n@@\n-# Plan\n+# Changed\n*** End Patch\n"
+        result = run_hook(PRE_TOOL, self.pre_payload("apply_patch", patch), self.codex_home)
+        self.assert_denied(result, "locked SDLC plan")
+
+    def test_pretool_denies_commit_on_main(self) -> None:
+        (self.project / "src" / "main_change.py").write_text("print('x')\n", encoding="utf-8")
+        git(self.project, "add", ".")
+        result = run_hook(PRE_TOOL, self.pre_payload("Bash", "git commit -m test"), self.codex_home)
+        self.assert_denied(result, "protected branch")
+
+    def test_pretool_denies_commit_without_authorization(self) -> None:
+        self.switch_feature()
+        self.active_run()
+        (self.project / "src" / "feature.py").write_text("print('feature')\n", encoding="utf-8")
+        git(self.project, "add", ".")
+        result = run_hook(PRE_TOOL, self.pre_payload("Bash", "git commit -m feature"), self.codex_home)
+        self.assert_denied(result, "commit authorization")
+
+    def test_pretool_denies_staged_private_evidence(self) -> None:
+        self.switch_feature()
+        run_dir = self.active_run()
+        self.authorize(run_dir, "commit-authorization.json")
+        (self.project / "evidence").mkdir()
+        (self.project / "evidence" / "note.md").write_text("private\n", encoding="utf-8")
+        git(self.project, "add", ".")
+        result = run_hook(PRE_TOOL, self.pre_payload("Bash", "git commit -m feature"), self.codex_home)
+        self.assert_denied(result, "private SDLC state")
+
+    def test_pretool_denies_staged_private_key(self) -> None:
+        self.switch_feature()
+        run_dir = self.active_run()
+        self.authorize(run_dir, "commit-authorization.json")
+        (self.project / "src" / "secret.txt").write_text(
+            "-----BEGIN PRIVATE KEY-----\nabc\n-----END PRIVATE KEY-----\n",
+            encoding="utf-8",
+        )
+        git(self.project, "add", ".")
+        result = run_hook(PRE_TOOL, self.pre_payload("Bash", "git commit -m feature"), self.codex_home)
+        self.assert_denied(result, "secret")
+
+    def test_pretool_denies_real_secret_even_with_example_line(self) -> None:
+        patch = (
+            "*** Begin Patch\n"
+            "*** Add File: src/secret.txt\n"
+            "+example placeholder line\n"
+            "+-----BEGIN PRIVATE KEY-----\n"
+            "+abc\n"
+            "+-----END PRIVATE KEY-----\n"
+            "*** End Patch\n"
+        )
+        result = run_hook(PRE_TOOL, self.pre_payload("apply_patch", patch), self.codex_home)
+        self.assert_denied(result, "secret")
+
+    def test_pretool_denies_push_without_pr_authorization(self) -> None:
+        self.switch_feature()
+        self.active_run()
+        result = run_hook(PRE_TOOL, self.pre_payload("Bash", "git push origin HEAD"), self.codex_home)
+        self.assert_denied(result, "PR authorization")
+
+    def test_pretool_denies_force_push(self) -> None:
+        self.switch_feature()
+        self.active_run()
+        result = run_hook(PRE_TOOL, self.pre_payload("Bash", "git push --force origin HEAD"), self.codex_home)
+        self.assert_denied(result, "force push")
+
+    def test_pretool_denies_dangerous_rm(self) -> None:
+        result = run_hook(PRE_TOOL, self.pre_payload("Bash", "rm -rf /"), self.codex_home)
+        self.assert_denied(result, "recursive removal")
+
+    def test_pretool_warns_design_edit_outside_design_phase(self) -> None:
+        self.active_run(phase="implementation")
+        patch = "*** Begin Patch\n*** Update File: docs/design.md\n@@\n # Design\n+More\n*** End Patch\n"
+        result = run_hook(PRE_TOOL, self.pre_payload("apply_patch", patch), self.codex_home)
+        self.assertIn("additionalContext", result.get("hookSpecificOutput", {}))
+
+    def test_pretool_allows_design_edit_in_design_phase(self) -> None:
+        self.active_run(phase="design_update")
+        patch = "*** Begin Patch\n*** Update File: docs/design.md\n@@\n # Design\n+More\n*** End Patch\n"
+        result = run_hook(PRE_TOOL, self.pre_payload("apply_patch", patch), self.codex_home)
+        self.assertEqual(result, {})
+
+    def test_stop_allows_no_active_run(self) -> None:
+        result = run_hook(STOP, self.stop_payload(), self.codex_home)
+        self.assertEqual(result, {"continue": True})
+
+    def test_stop_stops_complete_run(self) -> None:
+        self.active_run(status="complete")
+        result = run_hook(STOP, self.stop_payload(), self.codex_home)
+        self.assertFalse(result["continue"])
+        self.assertIn("complete", result["stopReason"])
+
+    def test_stop_continues_running_next_skill(self) -> None:
+        self.active_run(next_skill="sdlc-validate-codes")
+        result = run_hook(STOP, self.stop_payload(), self.codex_home)
+        self.assertEqual(result.get("decision"), "block")
+        self.assertIn("Use skill sdlc-start", result.get("reason", ""))
+        self.assertIn("sdlc-validate-codes", result.get("reason", ""))
+
+    def test_stop_normalizes_short_next_skill_alias(self) -> None:
+        self.active_run(next_skill="validate-codes")
+        result = run_hook(STOP, self.stop_payload(), self.codex_home)
+        self.assertEqual(result.get("decision"), "block")
+        self.assertIn("Use skill sdlc-start", result.get("reason", ""))
+        self.assertIn("sdlc-validate-codes", result.get("reason", ""))
+        self.assertNotIn("Next recommended skill: validate-codes", result.get("reason", ""))
+
+    def test_stop_continues_for_pause_steering(self) -> None:
+        run_dir = self.active_run(next_skill="sdlc-validate-codes")
+        (run_dir / "STEERING.md").write_text("Pause after the current feature. Do not create a PR.\n", encoding="utf-8")
+        result = run_hook(STOP, self.stop_payload(), self.codex_home)
+        self.assertEqual(result.get("decision"), "block")
+        self.assertIn("Use skill sdlc-start", result.get("reason", ""))
+        self.assertIn("STEERING.md", result.get("reason", ""))
+        self.assertIn("pause or PR-control", result.get("reason", ""))
+
+    def test_stop_no_progress_guard(self) -> None:
+        self.active_run(next_skill="sdlc-validate-codes")
+        run_hook(STOP, self.stop_payload(active=True), self.codex_home)
+        run_hook(STOP, self.stop_payload(active=True), self.codex_home)
+        result = run_hook(STOP, self.stop_payload(active=True), self.codex_home)
+        self.assertFalse(result["continue"])
+        self.assertIn("No progress", result["stopReason"])
+
+    def test_stop_does_not_continue_merge_pr(self) -> None:
+        self.active_run(next_skill="sdlc-merge-pr")
+        result = run_hook(STOP, self.stop_payload(), self.codex_home)
+        self.assertFalse(result["continue"])
+        self.assertIn("explicit user request", result["stopReason"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/skills/sdlc-start/references/state-schema.md
+++ b/skills/sdlc-start/references/state-schema.md
@@ -229,3 +229,23 @@ instructions, or UAT rerun requests. Convert durable product changes through
 A Stop hook may continue a run by injecting a continuation prompt. A PreToolUse
 hook may deny unsafe actions. Hooks enforce invariants only; `sdlc-start` owns
 workflow decisions.
+
+Optional Agentic SDLC hook source lives under
+`sdlc-start/assets/hooks/`. Installed copies under `$CODEX_HOME/hooks` are
+runtime artifacts and can drift, so maintainers should patch the source bundle
+first, run its hook tests, and then sync it intentionally with
+`install-skills.sh --install-all-hooks`, or with
+`install-skills.sh --install-hooks sdlc-start/assets/hooks` when only the SDLC
+hook bundle should be refreshed.
+
+The Stop hook continuation prompt must route through `sdlc-start` and emit
+canonical `sdlc-*` skill names. It may normalize short phase values when
+reading local state, but those aliases must not appear as emitted next-skill
+names. Steering text that pauses work or controls PR creation, including
+`Pause after the current feature. Do not create a PR.`, must be treated as
+coordinator input rather than ignored.
+
+The PreToolUse hook must continue blocking out-of-scope writes such as direct
+runtime hook edits from an unrelated project workspace. Use the explicit hook
+installer option for deliberate runtime sync instead of broadening the write
+allowlist.

--- a/skills/sdlc-start/references/state-schema.md
+++ b/skills/sdlc-start/references/state-schema.md
@@ -1,0 +1,231 @@
+# Agentic SDLC State Schema
+
+Use this reference when creating, repairing, or reading local SDLC run state.
+All run artifacts are private local state under
+`~/.codex/sdlc-runs/<project-id>/<run-id>/` and must not be committed.
+
+## Layout
+
+```text
+~/.codex/sdlc-runs/
+  <project-id>/
+    active-run.json
+    active.lock
+    <run-id>/
+      run.json
+      current-state.json
+      feature-queue.json
+      fingerprints.json
+      STEERING.md
+      permissions/
+        commit-authorization.json
+        pr-authorization.json
+        merge-authorization.json
+      checkpoints/
+        checkpoint-0001.json
+        latest.json
+      context/
+        FEAT-001.context.md
+      plans/
+        FEAT-001.plan.v1.md
+        FEAT-001.plan.v1.lock
+      evidence/
+        FEAT-001/
+          validate.md
+          tests.md
+          evaluate.md
+          screenshots/
+          transcripts/
+          failure-log.md
+          commit.md
+        uat/
+          uat-report.md
+        pr.md
+        review.md
+        merge.md
+      history/
+        iteration-0001.md
+```
+
+`active-run.json` is a small project-level pointer to the active run ID. It is
+the only project-level file that should change when switching active runs.
+
+## Minimum current-state.json
+
+```json
+{
+  "state_version": 1,
+  "project_id": "<project-id>",
+  "run_id": "<run-id>",
+  "iteration": 7,
+  "checkpoint_id": "checkpoint-0007",
+  "current_feature": "FEAT-001",
+  "current_phase": "plan_locked",
+  "status": "running",
+  "blocked_reason": null,
+  "needs_human": false,
+  "iteration_count": 7,
+  "max_iterations": 200,
+  "retry_counts": {
+    "requirements": 0,
+    "context": 0,
+    "design": 0,
+    "plan": 0,
+    "sdlc-tdd": 0,
+    "implementation": 0,
+    "validation": 0,
+    "test": 0,
+    "evaluation": 0,
+    "sdlc-align-specs": 0,
+    "sdlc-commit": 0,
+    "uat": 0,
+    "create-pr": 0,
+    "review-pr": 0,
+    "sdlc-merge-pr": 0
+  },
+  "last_successful_phase": "sdlc-create-plan",
+  "next_recommended_skill": "sdlc-tdd",
+  "updated_at": "2026-06-16T00:00:00Z"
+}
+```
+
+## Minimum checkpoint
+
+Each checkpoint is an append-only JSON snapshot that lets `sdlc-start` resume
+without conversation history.
+
+```json
+{
+  "state_version": 1,
+  "checkpoint_id": "checkpoint-0007",
+  "project_id": "<project-id>",
+  "run_id": "<run-id>",
+  "iteration": 7,
+  "created_at": "2026-06-16T00:00:00Z",
+  "current_feature": "FEAT-001",
+  "current_phase": "plan_locked",
+  "status": "running",
+  "blocked_reason": null,
+  "retry_counts": {
+    "requirements": 0,
+    "context": 0,
+    "design": 0,
+    "plan": 0,
+    "sdlc-tdd": 0,
+    "implementation": 0,
+    "validation": 0,
+    "test": 0,
+    "evaluation": 0,
+    "sdlc-align-specs": 0,
+    "sdlc-commit": 0,
+    "uat": 0,
+    "create-pr": 0,
+    "review-pr": 0,
+    "sdlc-merge-pr": 0
+  },
+  "last_successful_phase": "sdlc-create-plan",
+  "next_recommended_skill": "sdlc-tdd",
+  "fingerprint_ids": [
+    "requirements:sha256:<digest>",
+    "design:sha256:<digest>"
+  ],
+  "evidence": {
+    "context": "context/FEAT-001.context.md",
+    "plan": "plans/FEAT-001.plan.v1.md",
+    "validation": null,
+    "tests": null,
+    "evaluation": null,
+    "uat": null,
+    "pr": null,
+    "review": null,
+    "merge": null
+  }
+}
+```
+
+`checkpoints/latest.json` points to the newest complete checkpoint:
+
+```json
+{
+  "checkpoint_id": "checkpoint-0007",
+  "path": "checkpoints/checkpoint-0007.json",
+  "created_at": "2026-06-16T00:00:00Z"
+}
+```
+
+## Resume Rules
+
+1. Read `active-run.json`, `current-state.json`, `checkpoints/latest.json`, and
+   the latest checkpoint before selecting a phase.
+2. Treat the latest complete checkpoint as authoritative when it matches
+   available evidence.
+3. If `current-state.json` points past the latest complete checkpoint, repair it
+   from the checkpoint.
+4. If a checkpoint exists but `checkpoints/latest.json` is stale, update only
+   the pointer.
+5. If the latest checkpoint and evidence disagree, use the newest earlier
+   checkpoint that still matches evidence. If none can be trusted, stop with
+   `HUMAN_INPUT_REQUIRED`.
+6. Repeated runs with no state, steering, fingerprint, or evidence change must
+   return the same `next_recommended_skill` without appending duplicate history.
+
+## Hook Authorization Files
+
+Short-lived authorization files live under `permissions/` in the active run
+directory. They are local runtime state only and must not be committed.
+
+- `commit-authorization.json`: written immediately before `sdlc-commit` runs
+  `git commit`, after validation, tests, and evaluation evidence passes.
+- `pr-authorization.json`: written immediately before `create-pr` publishes a
+  branch or opens/reuses a PR, after UAT evidence passes unless the user
+  explicitly requested an early draft PR.
+- `merge-authorization.json`: written immediately before `sdlc-merge-pr` merges a
+  specific PR, after the explicit user merge request and final readiness checks.
+
+Each file must include `allowed: true`, an `expires_at` timestamp, and the
+branch or PR scope it authorizes. Sensitive actions should remove or expire the
+file after use. The PreToolUse hook treats missing, expired, corrupt, or
+wrong-scope authorization as a policy block.
+
+## Checkpoint Write Order
+
+1. Build the next state in memory from specs, state, evidence, steering, and
+   fingerprints.
+2. Write the new `checkpoints/checkpoint-*.json` file completely.
+3. Update `checkpoints/latest.json`.
+4. Update `current-state.json`.
+5. Append `history/iteration-*.md` only when the state changed.
+
+Use atomic replace semantics where the local environment supports them. If a
+write is interrupted, resume by selecting the newest complete checkpoint.
+
+## Phase Order
+
+1. requirements
+2. context
+3. design
+4. plan
+5. sdlc-tdd
+6. implementation
+7. validation
+8. test
+9. evaluation
+10. sdlc-align-specs
+11. sdlc-commit
+12. uat
+13. create-pr
+14. review-pr
+15. sdlc-merge-pr, only after explicit user request
+
+## Steering
+
+`STEERING.md` is temporary runtime steering, not a second requirements file.
+Use it for urgent corrections, priority overrides, blocker answers, pause
+instructions, or UAT rerun requests. Convert durable product changes through
+`sdlc-create-requirements` and `sdlc-create-design`.
+
+## Hook Boundary
+
+A Stop hook may continue a run by injecting a continuation prompt. A PreToolUse
+hook may deny unsafe actions. Hooks enforce invariants only; `sdlc-start` owns
+workflow decisions.

--- a/skills/sdlc-tdd/README.md
+++ b/skills/sdlc-tdd/README.md
@@ -1,0 +1,27 @@
+# SDLC TDD
+
+`sdlc-tdd` is an Agentic SDLC skill. It is authored in this repository and is
+installed into a Codex runtime only when `install-skills.sh` is run.
+
+## What It Does
+
+Define success before implementation by creating tests that prove the current feature behavior.
+
+## Main Boundaries
+
+- Implement production code except minimal test-only fixtures.
+- Delete or weaken tests to pass.
+- Skip test execution unless environment is blocked.
+
+## Primary Inputs
+
+- Locked feature plan.
+- Feature design.
+- Requirement acceptance criteria.
+- Existing test conventions.
+
+## Output
+
+- Tests exist and map to acceptance criteria.
+- Test run evidence exists.
+- Expected red or already-green state is recorded.

--- a/skills/sdlc-tdd/SKILL.md
+++ b/skills/sdlc-tdd/SKILL.md
@@ -1,0 +1,117 @@
+---
+name: sdlc-tdd
+description: "Use only as part of the Agentic SDLC workflow; use after `sdlc-create-plan` when an Agentic SDLC feature needs tests written before implementation. Converts acceptance criteria and design success criteria into failing or already-green tests."
+---
+
+# SDLC TDD
+
+## Purpose
+
+Define success before implementation by creating tests that prove the current feature behavior.
+
+## When To Use
+
+- A locked feature plan exists and tests must be written before implementation.
+- Acceptance criteria need unit, integration, component, contract, or regression coverage.
+- Existing tests must be mapped to SDLC acceptance criteria.
+
+## When Not To Use
+
+- Do not use to implement production behavior.
+- Do not use to weaken acceptance criteria.
+- Do not use when no locked plan exists.
+
+## Inputs
+
+- Locked feature plan.
+- Feature design.
+- Requirement acceptance criteria.
+- Existing test conventions.
+
+## Required Reads
+
+- Locked plan.
+- Feature and requirement blocks.
+- Existing tests and test framework configuration.
+
+## Writes
+
+- Tests, fixtures, or mocks required by the plan.
+- Test evidence showing expected red or already-green state.
+- Local state transition to `tests_red` or `tests_ready`.
+
+## Process
+
+- Identify acceptance criteria that can be tested.
+- Choose the smallest useful test level first.
+- Write tests that fail for missing behavior when implementation is absent.
+- Avoid over-mocking real behavior.
+- Run focused tests and record evidence.
+
+## Idempotency
+
+- Do not duplicate tests.
+- Reuse existing tests that already match criteria.
+- If implementation already exists and tests pass, record `tests_already_green`.
+
+## Failure Handling
+
+- If test framework is missing, route to project scaffolding or design update.
+- If criteria are not testable, route to `sdlc-create-requirements`.
+- If design lacks test seams, route to `sdlc-create-design`.
+
+## Must Not
+
+- Implement production code except minimal test-only fixtures.
+- Delete or weaken tests to pass.
+- Skip test execution unless environment is blocked.
+
+## Completion Criteria
+
+- Tests exist and map to acceptance criteria.
+- Test run evidence exists.
+- Expected red or already-green state is recorded.
+
+## SDLC Invariants
+
+- Treat `docs/requirements.md` and `docs/design.md` as committed product truth.
+- Only `sdlc-create-requirements` writes `docs/requirements.md`; only `sdlc-create-design`
+  writes `docs/design.md`. Other skills route spec changes to those owners.
+- Keep run state, plans, evidence, steering, screenshots, and transcripts under `~/.codex/sdlc-runs/<project-id>/<run-id>/`.
+- When an active run exists, reload `current-state.json` and the latest
+  checkpoint before changing phase or writing evidence.
+- Work on one feature at a time unless the user explicitly asks for a different SDLC shape.
+- Classify every failure before retrying or routing backward.
+- Use MCP servers for browser, GitHub, internal docs, Slack, Confluence, Jira, and other external systems when they are available and appropriate.
+- Treat hooks as invariant guardrails only; do not make hooks orchestrate the workflow.
+
+## Learning Loop
+
+When using this skill, capture durable, reusable, public-safe learnings back
+into this skill's local source materials before completion when the current task
+contract allows source edits. Update the narrowest appropriate surface:
+`SKILL.md` for runtime rules, `references/` for detailed guidance, `assets/`
+for reusable templates, `scripts/` for deterministic helpers, and README or
+changelog entries for human-facing or release-note updates.
+
+If the current task is explicitly read-only/report-only, or source writes are
+outside this skill's task contract, do not edit skill sources; report the
+skipped source update instead.
+
+Do not capture secrets, private URLs, customer data, raw logs, one-off local
+state, or unverified/vendor-specific claims. If a useful learning is not safe,
+not evidence-backed, or outside this skill's scope, report that it was skipped.
+
+## Output Contract
+
+Return a concise result with:
+
+- Scope handled and current `REQ-*` or `FEAT-*` IDs.
+- Files or local state written.
+- Evidence created or checked.
+- Failure classification and next recommended skill when blocked.
+- Confirmation that private SDLC state was kept out of committed project files.
+
+## References
+
+- No skill-local references are required by default; use project files and current official documentation as needed.

--- a/skills/sdlc-tdd/agents/openai.yaml
+++ b/skills/sdlc-tdd/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "SDLC TDD"
+  short_description: "Write SDLC tests first"
+  default_prompt: "Use $sdlc-tdd to define Agentic SDLC success before implementation by creating tests that prove the current feature behavior."

--- a/skills/sdlc-tui-test/README.md
+++ b/skills/sdlc-tui-test/README.md
@@ -1,0 +1,28 @@
+# TUI Test
+
+`sdlc-tui-test` is an Agentic SDLC skill. It is authored in this repository and is
+installed into a Codex runtime only when `install-skills.sh` is run.
+
+## What It Does
+
+Control terminal applications like a user and capture prompts, inputs, outputs, exit codes, and side effects.
+
+## Main Boundaries
+
+- Hide interactive failures.
+- Treat a zero exit code as sufficient when criteria require specific behavior.
+- Persist credentials in transcripts.
+
+## Primary Inputs
+
+- TUI or CLI acceptance criteria.
+- Startup command from docs or design.
+- Test data.
+- Expected prompts and outputs.
+
+## Output
+
+- Transcript exists.
+- Exit code is recorded.
+- Outputs and side effects are evaluated.
+- Acceptance criteria are pass/fail.

--- a/skills/sdlc-tui-test/SKILL.md
+++ b/skills/sdlc-tui-test/SKILL.md
@@ -1,0 +1,121 @@
+---
+name: sdlc-tui-test
+description: "Use only as part of the Agentic SDLC workflow; use when terminal, CLI wizard, or TUI behavior must be controlled, observed, transcripted, and evaluated against Agentic SDLC acceptance criteria using Pexpect-style interaction."
+---
+
+# TUI Test
+
+## Purpose
+
+Control terminal applications like a user and capture prompts, inputs, outputs, exit codes, and side effects.
+
+## When To Use
+
+- A feature or UAT evaluation requires terminal, CLI wizard, or TUI interaction.
+- Transcripts and exit-code evidence are required.
+- The design evaluation route says `sdlc-tui-test`.
+
+## When Not To Use
+
+- Do not use for browser GUI flows; use `sdlc-gui-test`.
+- Do not run destructive commands.
+- Do not use real credentials in transcripts.
+
+## Inputs
+
+- TUI or CLI acceptance criteria.
+- Startup command from docs or design.
+- Test data.
+- Expected prompts and outputs.
+
+## Required Reads
+
+- Evaluation plan.
+- CLI or TUI docs.
+- Existing command definitions.
+- Build artifacts or package config.
+
+## Writes
+
+- Terminal transcript.
+- Exit-code summary.
+- Output assertions.
+- Pass/fail result.
+
+## Process
+
+- Launch the CLI or TUI in a controlled environment.
+- Wait for expected prompts and send inputs.
+- Capture output and exit code.
+- Validate generated files or side effects.
+- Compare transcript against acceptance criteria.
+
+## Idempotency
+
+- Use temp directories for generated files.
+- Reset test environment where possible.
+- Use unique names for created resources.
+- Avoid persistent external side effects unless explicitly required.
+
+## Failure Handling
+
+- Prompt mismatch maps to `EVALUATION_DEFECT` or `IMPLEMENTATION_DEFECT`.
+- Harness timeout maps to `ENVIRONMENT_DEFECT` unless output proves application fault.
+- Incorrect expected transcript maps to `TEST_DEFECT`.
+
+## Must Not
+
+- Hide interactive failures.
+- Treat a zero exit code as sufficient when criteria require specific behavior.
+- Persist credentials in transcripts.
+
+## Completion Criteria
+
+- Transcript exists.
+- Exit code is recorded.
+- Outputs and side effects are evaluated.
+- Acceptance criteria are pass/fail.
+
+## SDLC Invariants
+
+- Treat `docs/requirements.md` and `docs/design.md` as committed product truth.
+- Only `sdlc-create-requirements` writes `docs/requirements.md`; only `sdlc-create-design`
+  writes `docs/design.md`. Other skills route spec changes to those owners.
+- Keep run state, plans, evidence, steering, screenshots, and transcripts under `~/.codex/sdlc-runs/<project-id>/<run-id>/`.
+- When an active run exists, reload `current-state.json` and the latest
+  checkpoint before changing phase or writing evidence.
+- Work on one feature at a time unless the user explicitly asks for a different SDLC shape.
+- Classify every failure before retrying or routing backward.
+- Use MCP servers for browser, GitHub, internal docs, Slack, Confluence, Jira, and other external systems when they are available and appropriate.
+- Treat hooks as invariant guardrails only; do not make hooks orchestrate the workflow.
+
+## Learning Loop
+
+When using this skill, capture durable, reusable, public-safe learnings back
+into this skill's local source materials before completion when the current task
+contract allows source edits. Update the narrowest appropriate surface:
+`SKILL.md` for runtime rules, `references/` for detailed guidance, `assets/`
+for reusable templates, `scripts/` for deterministic helpers, and README or
+changelog entries for human-facing or release-note updates.
+
+If the current task is explicitly read-only/report-only, or source writes are
+outside this skill's task contract, do not edit skill sources; report the
+skipped source update instead.
+
+Do not capture secrets, private URLs, customer data, raw logs, one-off local
+state, or unverified/vendor-specific claims. If a useful learning is not safe,
+not evidence-backed, or outside this skill's scope, report that it was skipped.
+
+## Output Contract
+
+Return a concise result with:
+
+- Scope handled and current `REQ-*` or `FEAT-*` IDs.
+- Files or local state written.
+- Evidence created or checked.
+- Failure classification and next recommended skill when blocked.
+- Confirmation that private SDLC state was kept out of committed project files.
+
+## References
+
+- No skill-local references are required by default; use project files and current official documentation as needed.

--- a/skills/sdlc-tui-test/agents/openai.yaml
+++ b/skills/sdlc-tui-test/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "SDLC TUI Test"
+  short_description: "Evaluate terminal flows"
+  default_prompt: "Use $sdlc-tui-test to control terminal applications like a user during Agentic SDLC testing and capture prompts, inputs, outputs, exit codes, and side effects."

--- a/skills/sdlc-uat-tests/README.md
+++ b/skills/sdlc-uat-tests/README.md
@@ -1,0 +1,30 @@
+# UAT Tests
+
+`sdlc-uat-tests` is an Agentic SDLC skill. It is authored in this repository and is
+installed into a Codex runtime only when `install-skills.sh` is run.
+
+## What It Does
+
+Validate the full product, not just individual features, before PR creation.
+
+## Main Boundaries
+
+- Create PRs.
+- Merge.
+- Ignore failed negative criteria.
+- Modify requirements or design directly.
+
+## Primary Inputs
+
+- All requirements.
+- All feature designs.
+- All feature evidence.
+- Current branch.
+- Product startup instructions.
+
+## Output
+
+- Full UAT report exists.
+- All P0 acceptance criteria pass or blockers are classified.
+- Cross-feature flows pass.
+- Product is ready for `create-pr` only on pass.

--- a/skills/sdlc-uat-tests/SKILL.md
+++ b/skills/sdlc-uat-tests/SKILL.md
@@ -1,0 +1,126 @@
+---
+name: sdlc-uat-tests
+description: "Use only as part of the Agentic SDLC workflow; use after all Agentic SDLC feature commits are complete to run product-level user acceptance testing across the whole system before pull request creation."
+---
+
+# UAT Tests
+
+## Purpose
+
+Validate the full product, not just individual features, before PR creation.
+
+## When To Use
+
+- All feature commits are complete.
+- Cross-feature user journeys need acceptance evidence.
+- The SDLC loop reaches UAT before PR creation.
+
+## When Not To Use
+
+- Do not use for a single feature evaluation; use `sdlc-evaluate`.
+- Do not create PRs or merge.
+- Do not approve UAT without evidence.
+
+## Inputs
+
+- All requirements.
+- All feature designs.
+- All feature evidence.
+- Current branch.
+- Product startup instructions.
+
+## Required Reads
+
+- `docs/requirements.md`.
+- `docs/design.md`.
+- Feature evidence.
+- Current source tree.
+- Existing UAT or E2E tests.
+- Environment instructions.
+
+## Writes
+
+- `evidence/uat/uat-report.md`.
+- GUI screenshots, TUI transcripts, or API/service logs.
+- Final pass/fail result.
+
+## Process
+
+- Use `assets/templates/uat-report.md.template` for the report.
+- Build a UAT matrix from acceptance criteria.
+- Select GUI, TUI, API, service, or mixed harness.
+- Run end-to-end user journeys and negative criteria.
+- Validate cross-feature interactions.
+- Record evidence and classify failures.
+
+## Idempotency
+
+- Rerunning UAT refreshes the report.
+- Use clean or isolated test data.
+- Do not duplicate external resources.
+- Preserve previous UAT evidence in history when useful.
+
+## Failure Handling
+
+- Product behavior failure maps to `EVALUATION_DEFECT`.
+- Cross-feature design issue maps to `DESIGN_DEFECT`.
+- Missing acceptance coverage maps to `SPEC_GAP`.
+- Environment problem maps to `ENVIRONMENT_DEFECT`.
+
+## Must Not
+
+- Create PRs.
+- Merge.
+- Ignore failed negative criteria.
+- Modify requirements or design directly.
+
+## Completion Criteria
+
+- Full UAT report exists.
+- All P0 acceptance criteria pass or blockers are classified.
+- Cross-feature flows pass.
+- Product is ready for `create-pr` only on pass.
+
+## SDLC Invariants
+
+- Treat `docs/requirements.md` and `docs/design.md` as committed product truth.
+- Only `sdlc-create-requirements` writes `docs/requirements.md`; only `sdlc-create-design`
+  writes `docs/design.md`. Other skills route spec changes to those owners.
+- Keep run state, plans, evidence, steering, screenshots, and transcripts under `~/.codex/sdlc-runs/<project-id>/<run-id>/`.
+- When an active run exists, reload `current-state.json` and the latest
+  checkpoint before changing phase or writing evidence.
+- Work on one feature at a time unless the user explicitly asks for a different SDLC shape.
+- Classify every failure before retrying or routing backward.
+- Use MCP servers for browser, GitHub, internal docs, Slack, Confluence, Jira, and other external systems when they are available and appropriate.
+- Treat hooks as invariant guardrails only; do not make hooks orchestrate the workflow.
+
+## Learning Loop
+
+When using this skill, capture durable, reusable, public-safe learnings back
+into this skill's local source materials before completion when the current task
+contract allows source edits. Update the narrowest appropriate surface:
+`SKILL.md` for runtime rules, `references/` for detailed guidance, `assets/`
+for reusable templates, `scripts/` for deterministic helpers, and README or
+changelog entries for human-facing or release-note updates.
+
+If the current task is explicitly read-only/report-only, or source writes are
+outside this skill's task contract, do not edit skill sources; report the
+skipped source update instead.
+
+Do not capture secrets, private URLs, customer data, raw logs, one-off local
+state, or unverified/vendor-specific claims. If a useful learning is not safe,
+not evidence-backed, or outside this skill's scope, report that it was skipped.
+
+## Output Contract
+
+Return a concise result with:
+
+- Scope handled and current `REQ-*` or `FEAT-*` IDs.
+- Files or local state written.
+- Evidence created or checked.
+- Failure classification and next recommended skill when blocked.
+- Confirmation that private SDLC state was kept out of committed project files.
+
+## References
+
+- Use `assets/templates/uat-report.md.template` when creating the corresponding artifact.

--- a/skills/sdlc-uat-tests/agents/openai.yaml
+++ b/skills/sdlc-uat-tests/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "SDLC UAT Tests"
+  short_description: "Run product-level UAT"
+  default_prompt: "Use $sdlc-uat-tests to validate the full Agentic SDLC product, not just individual features, before PR creation."

--- a/skills/sdlc-uat-tests/assets/templates/uat-report.md.template
+++ b/skills/sdlc-uat-tests/assets/templates/uat-report.md.template
@@ -1,0 +1,25 @@
+# UAT Report
+
+## Scope
+
+- Branch: <branch>
+- Requirements: <REQ IDs>
+- Features: <FEAT IDs>
+
+## Matrix
+
+| Requirement | Flow | Harness | Result | Evidence |
+| --- | --- | --- | --- | --- |
+| REQ-<id> | <journey> | <gui|tui|api|service> | <pass|fail> | <path> |
+
+## Cross-Feature Findings
+
+- <finding>
+
+## Negative Criteria
+
+- <criterion>: <pass|fail>
+
+## Final Result
+
+<ready-for-pr | blocked>

--- a/skills/sdlc-unit-tests/README.md
+++ b/skills/sdlc-unit-tests/README.md
@@ -1,0 +1,28 @@
+# Unit Tests
+
+`sdlc-unit-tests` is an Agentic SDLC skill. It is authored in this repository and is
+installed into a Codex runtime only when `install-skills.sh` is run.
+
+## What It Does
+
+Answer whether the code behaves correctly against the feature tests and acceptance criteria.
+
+## Main Boundaries
+
+- Delete or weaken tests to pass.
+- Treat flaky tests as pass without evidence.
+- Overwrite evaluation results.
+
+## Primary Inputs
+
+- Current feature ID.
+- Test files created or selected by `sdlc-tdd`.
+- Locked plan.
+- Project test tooling.
+
+## Output
+
+- Required tests pass.
+- Evidence file exists.
+- Failures are classified if not passing.
+- State moves to `tested`.

--- a/skills/sdlc-unit-tests/SKILL.md
+++ b/skills/sdlc-unit-tests/SKILL.md
@@ -1,0 +1,122 @@
+---
+name: sdlc-unit-tests
+description: "Use only as part of the Agentic SDLC workflow; use after validation in the Agentic SDLC loop to run behavior tests for the current feature, including unit, integration, component, contract, regression, and mock-based tests when applicable."
+---
+
+# Unit Tests
+
+## Purpose
+
+Answer whether the code behaves correctly against the feature tests and acceptance criteria.
+
+## When To Use
+
+- Validation has passed and feature tests need to run.
+- Regression or integration tests are required by design.
+- A test failure needs classification and evidence.
+
+## When Not To Use
+
+- Do not use to approve real-world behavior; use `sdlc-evaluate` after tests.
+- Do not use to delete or weaken tests.
+- Do not use to modify requirements or design.
+
+## Inputs
+
+- Current feature ID.
+- Test files created or selected by `sdlc-tdd`.
+- Locked plan.
+- Project test tooling.
+
+## Required Reads
+
+- Test configuration.
+- Test files.
+- Feature design.
+- Acceptance criteria.
+- Existing test conventions.
+
+## Writes
+
+- `evidence/FEAT-*/tests.md`.
+- Coverage notes if available.
+- Failure classification.
+
+## Process
+
+- Use `assets/templates/tests.md.template` for evidence.
+- Run focused feature tests first.
+- Run nearby regression tests.
+- Run integration or component tests required by design.
+- Run broader suite only when feasible.
+- Record commands and outcomes.
+
+## Idempotency
+
+- Rerunning tests updates evidence.
+- Do not duplicate tests.
+- Do not skip failed tests without classification.
+
+## Failure Handling
+
+- Production behavior failure maps to `IMPLEMENTATION_DEFECT`.
+- Incorrect test expectation maps to `TEST_DEFECT`.
+- Missing service or dependency maps to `ENVIRONMENT_DEFECT`.
+- Design mismatch maps to `DESIGN_DEFECT`.
+
+## Must Not
+
+- Delete or weaken tests to pass.
+- Treat flaky tests as pass without evidence.
+- Overwrite evaluation results.
+
+## Completion Criteria
+
+- Required tests pass.
+- Evidence file exists.
+- Failures are classified if not passing.
+- State moves to `tested`.
+
+## SDLC Invariants
+
+- Treat `docs/requirements.md` and `docs/design.md` as committed product truth.
+- Only `sdlc-create-requirements` writes `docs/requirements.md`; only `sdlc-create-design`
+  writes `docs/design.md`. Other skills route spec changes to those owners.
+- Keep run state, plans, evidence, steering, screenshots, and transcripts under `~/.codex/sdlc-runs/<project-id>/<run-id>/`.
+- When an active run exists, reload `current-state.json` and the latest
+  checkpoint before changing phase or writing evidence.
+- Work on one feature at a time unless the user explicitly asks for a different SDLC shape.
+- Classify every failure before retrying or routing backward.
+- Use MCP servers for browser, GitHub, internal docs, Slack, Confluence, Jira, and other external systems when they are available and appropriate.
+- Treat hooks as invariant guardrails only; do not make hooks orchestrate the workflow.
+
+## Learning Loop
+
+When using this skill, capture durable, reusable, public-safe learnings back
+into this skill's local source materials before completion when the current task
+contract allows source edits. Update the narrowest appropriate surface:
+`SKILL.md` for runtime rules, `references/` for detailed guidance, `assets/`
+for reusable templates, `scripts/` for deterministic helpers, and README or
+changelog entries for human-facing or release-note updates.
+
+If the current task is explicitly read-only/report-only, or source writes are
+outside this skill's task contract, do not edit skill sources; report the
+skipped source update instead.
+
+Do not capture secrets, private URLs, customer data, raw logs, one-off local
+state, or unverified/vendor-specific claims. If a useful learning is not safe,
+not evidence-backed, or outside this skill's scope, report that it was skipped.
+
+## Output Contract
+
+Return a concise result with:
+
+- Scope handled and current `REQ-*` or `FEAT-*` IDs.
+- Files or local state written.
+- Evidence created or checked.
+- Failure classification and next recommended skill when blocked.
+- Confirmation that private SDLC state was kept out of committed project files.
+
+## References
+
+- Use `assets/templates/tests.md.template` when creating the corresponding artifact.

--- a/skills/sdlc-unit-tests/agents/openai.yaml
+++ b/skills/sdlc-unit-tests/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "SDLC Unit Tests"
+  short_description: "Run SDLC behavior tests"
+  default_prompt: "Use $sdlc-unit-tests to answer whether Agentic SDLC code behaves correctly against the feature tests and acceptance criteria."

--- a/skills/sdlc-unit-tests/assets/templates/tests.md.template
+++ b/skills/sdlc-unit-tests/assets/templates/tests.md.template
@@ -1,0 +1,15 @@
+# FEAT-<id> Test Evidence
+
+## Commands
+
+| Command | Scope | Result |
+| --- | --- | --- |
+| `<command>` | <unit|integration|component|regression> | <pass|fail|blocked> |
+
+## Acceptance Criteria Covered
+
+- REQ-<id> AC-<id>: <test path or command>
+
+## Failure Classification
+
+<classification or none>

--- a/skills/sdlc-validate-codes/README.md
+++ b/skills/sdlc-validate-codes/README.md
@@ -1,0 +1,28 @@
+# Validate Codes
+
+`sdlc-validate-codes` is an Agentic SDLC skill. It is authored in this repository and is
+installed into a Codex runtime only when `install-skills.sh` is run.
+
+## What It Does
+
+Answer whether the implemented feature can be built or run correctly before deeper behavior tests.
+
+## Main Boundaries
+
+- Change requirements or design.
+- Skip configured validation.
+- Treat missing tooling as success.
+- Overwrite test or evaluation evidence.
+
+## Primary Inputs
+
+- Current feature ID.
+- Locked plan.
+- Changed files.
+- Project tooling.
+
+## Output
+
+- Validation evidence exists.
+- Required checks pass or blocker is classified.
+- State moves to `validated` only on pass.

--- a/skills/sdlc-validate-codes/SKILL.md
+++ b/skills/sdlc-validate-codes/SKILL.md
@@ -1,0 +1,117 @@
+---
+name: sdlc-validate-codes
+description: "Use only as part of the Agentic SDLC workflow; use after implementation or before `sdlc-commit` in the Agentic SDLC loop to check whether the project can build, parse, lint, type-check, import, and validate configuration correctly."
+---
+
+# Validate Codes
+
+## Purpose
+
+Answer whether the implemented feature can be built or run correctly before deeper behavior tests.
+
+## When To Use
+
+- Implementation completed and syntax, lint, type, import, config, or build checks must run.
+- A classified validation defect needs repair evidence.
+- The SDLC loop reaches validation for the current feature.
+
+## When Not To Use
+
+- Do not use as a substitute for behavior tests or evaluation.
+- Do not use to silently fix code unless the parent task expects repair.
+- Do not treat missing configured tooling as success.
+
+## Inputs
+
+- Current feature ID.
+- Locked plan.
+- Changed files.
+- Project tooling.
+
+## Required Reads
+
+- Project config, package manager files, build files, linter and type checker config.
+- Changed source files.
+
+## Writes
+
+- `evidence/FEAT-*/validate.md`.
+- Validation status.
+- Failure classification if needed.
+
+## Process
+
+- Use `assets/templates/validate.md.template` for evidence.
+- Detect the project stack and reuse configured project commands.
+- Run the smallest reliable validation set first.
+- Include syntax, linting, type checking when configured, Python import checks when relevant, config validation, and feasible build checks.
+- Record exact commands and outcomes.
+
+## Idempotency
+
+- Rerunning validation updates evidence.
+- Passing validation with unchanged inputs should remain passing.
+- New failures replace stale evidence.
+
+## Failure Handling
+
+- Syntax, lint, type, import, build, or config failure maps to `VALIDATION_DEFECT`.
+- Missing tooling maps to `ENVIRONMENT_DEFECT` unless intentionally absent.
+- Design flaw discovered by validation routes to `sdlc-create-design`.
+
+## Must Not
+
+- Change requirements or design.
+- Skip configured validation.
+- Treat missing tooling as success.
+- Overwrite test or evaluation evidence.
+
+## Completion Criteria
+
+- Validation evidence exists.
+- Required checks pass or blocker is classified.
+- State moves to `validated` only on pass.
+
+## SDLC Invariants
+
+- Treat `docs/requirements.md` and `docs/design.md` as committed product truth.
+- Only `sdlc-create-requirements` writes `docs/requirements.md`; only `sdlc-create-design`
+  writes `docs/design.md`. Other skills route spec changes to those owners.
+- Keep run state, plans, evidence, steering, screenshots, and transcripts under `~/.codex/sdlc-runs/<project-id>/<run-id>/`.
+- When an active run exists, reload `current-state.json` and the latest
+  checkpoint before changing phase or writing evidence.
+- Work on one feature at a time unless the user explicitly asks for a different SDLC shape.
+- Classify every failure before retrying or routing backward.
+- Use MCP servers for browser, GitHub, internal docs, Slack, Confluence, Jira, and other external systems when they are available and appropriate.
+- Treat hooks as invariant guardrails only; do not make hooks orchestrate the workflow.
+
+## Learning Loop
+
+When using this skill, capture durable, reusable, public-safe learnings back
+into this skill's local source materials before completion when the current task
+contract allows source edits. Update the narrowest appropriate surface:
+`SKILL.md` for runtime rules, `references/` for detailed guidance, `assets/`
+for reusable templates, `scripts/` for deterministic helpers, and README or
+changelog entries for human-facing or release-note updates.
+
+If the current task is explicitly read-only/report-only, or source writes are
+outside this skill's task contract, do not edit skill sources; report the
+skipped source update instead.
+
+Do not capture secrets, private URLs, customer data, raw logs, one-off local
+state, or unverified/vendor-specific claims. If a useful learning is not safe,
+not evidence-backed, or outside this skill's scope, report that it was skipped.
+
+## Output Contract
+
+Return a concise result with:
+
+- Scope handled and current `REQ-*` or `FEAT-*` IDs.
+- Files or local state written.
+- Evidence created or checked.
+- Failure classification and next recommended skill when blocked.
+- Confirmation that private SDLC state was kept out of committed project files.
+
+## References
+
+- Use `assets/templates/validate.md.template` when creating the corresponding artifact.

--- a/skills/sdlc-validate-codes/agents/openai.yaml
+++ b/skills/sdlc-validate-codes/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "SDLC Validate Codes"
+  short_description: "Validate build and code health"
+  default_prompt: "Use $sdlc-validate-codes to answer whether the implemented Agentic SDLC feature can be built or run correctly before deeper behavior tests."

--- a/skills/sdlc-validate-codes/assets/templates/validate.md.template
+++ b/skills/sdlc-validate-codes/assets/templates/validate.md.template
@@ -1,0 +1,15 @@
+# FEAT-<id> Validation Evidence
+
+## Commands
+
+| Command | Purpose | Result |
+| --- | --- | --- |
+| `<command>` | <purpose> | <pass|fail|blocked> |
+
+## Summary
+
+<Validation result.>
+
+## Failure Classification
+
+<classification or none>

--- a/skills/shell-scripting/SKILL.md
+++ b/skills/shell-scripting/SKILL.md
@@ -51,6 +51,23 @@ Keep usage output readable:
 - Avoid destructive actions by default; require explicit opt-in for risky actions.
 - Keep scripts composable and testable with small functions.
 
+## Learning Loop
+
+When using this skill, capture durable, reusable, public-safe learnings back
+into this skill's local source materials before completion when the current task
+contract allows source edits. Update the narrowest appropriate surface:
+`SKILL.md` for runtime rules, `references/` for detailed guidance, `assets/`
+for reusable templates, `scripts/` for deterministic helpers, and README or
+changelog entries for human-facing or release-note updates.
+
+If the current task is explicitly read-only/report-only, or source writes are
+outside this skill's task contract, do not edit skill sources; report the
+skipped source update instead.
+
+Do not capture secrets, private URLs, customer data, raw logs, one-off local
+state, or unverified/vendor-specific claims. If a useful learning is not safe,
+not evidence-backed, or outside this skill's scope, report that it was skipped.
+
 ## Resources
 
 - `assets/script-template.sh`: baseline script template with rich usage/log output.

--- a/skills/terraform/SKILL.md
+++ b/skills/terraform/SKILL.md
@@ -223,3 +223,20 @@ If using HCP Terraform `cloud` blocks, omit per-env `backend.tf`.
 - Include minimal Terraform snippets only when they materially clarify implementation.
 - Do not guess provider behavior; if provider support cannot be confirmed from official docs, explicitly state that uncertainty.
 - Default to no legacy compatibility layers when changing module contracts unless the user explicitly asks for compatibility.
+
+## Learning Loop
+
+When using this skill, capture durable, reusable, public-safe learnings back
+into this skill's local source materials before completion when the current task
+contract allows source edits. Update the narrowest appropriate surface:
+`SKILL.md` for runtime rules, `references/` for detailed guidance, `assets/`
+for reusable templates, `scripts/` for deterministic helpers, and README or
+changelog entries for human-facing or release-note updates.
+
+If the current task is explicitly read-only/report-only, or source writes are
+outside this skill's task contract, do not edit skill sources; report the
+skipped source update instead.
+
+Do not capture secrets, private URLs, customer data, raw logs, one-off local
+state, or unverified/vendor-specific claims. If a useful learning is not safe,
+not evidence-backed, or outside this skill's scope, report that it was skipped.


### PR DESCRIPTION
## Summary

- Fix bundled cxcli Soperator production defaults: remove stale worker/Munge image overrides, raise service-role CPU defaults, make system nodes autoscale 3..5, and default controller/login/accounting to two nodes.
- Replace stale generated Soperator SFS mirror values from the active SFS infra row instead of preserving obsolete mount tags.
- Add and update cxcli tests/docs for the Soperator profile/default behavior.
- Include the current skill updates on this branch, including SDLC/global-context/config-codex alignment and local-template validation updates.

## Validation

- `git diff --check origin/main...HEAD`
- `rg -n '^(<{7}|={7}|>{7})'` returned no conflict markers
- `python3 skills/global-context-management/scripts/validate-local-templates.py`
- `cd services/nebius-cxcli && python -m ruff check src/nebius_cxcli/cli.py src/nebius_cxcli/wizard_profiles.py tests/test_cli_command_coverage.py tests/test_component_sources.py tests/test_config_model.py tests/test_mk8s_gpu.py tests/test_phase3_prompt_introspection.py tests/test_render.py`
- Earlier cxcli alignment pass: `NEBIUS_CXCLI_COMPONENT_SOURCES_PROFILE=portable make all` passed with 1999 non-integration tests plus wheel build
