### PR TITLE
Prepare soperator chart 4.0.2-ps.3 release

### DIFF
--- a/helm-charts/soperator/CHANGELOG.md
+++ b/helm-charts/soperator/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this chart are tracked here.
 
 ## [Unreleased]
 
+## [soperator-chart-v4.0.2-ps.3] - 2026-06-24
+
 - Added the chart-owned `gpuDriverJail` contract for GPU NodeSets. The chart
   now injects the host driver root mount at `/run/nvidia/driver`, runs a
   `cxcli-gpu-driver-jail` init guard with the `slurmd` image to refresh real

--- a/helm-charts/soperator/Chart.yaml
+++ b/helm-charts/soperator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: soperator
 description: Self-managed Nebius Soperator deployment for MK8s clusters
 type: application
-version: 4.0.2-ps.2
+version: 4.0.2-ps.3
 appVersion: "4.0.2"
 kubeVersion: ">=1.29.0-0"
 annotations:

--- a/services/nebius-cxcli/CHANGELOG.md
+++ b/services/nebius-cxcli/CHANGELOG.md
@@ -62,7 +62,7 @@ All notable changes to this project are tracked here. This changelog follows
   ambiguous `--k8s` and `--soperator` acceptance-test selectors; operators now
   select runtime behavior through `--suite`: `k8s-cuda` or `slurm` for smoke,
   and `k8s-nccl` or `slurm-nccl` for benchmark.
-- Updated the bundled Soperator portable chart pin to `4.0.2-ps.2`, matching
+- Updated the bundled Soperator portable chart pin to `4.0.2-ps.3`, matching
   the current parent chart package release while keeping local-source
   resolution tied to `helm-charts/soperator/Chart.yaml`.
 - Changed `component add apps:soperator` so production-cluster adds fail fast on

--- a/services/nebius-cxcli/component_sources.yaml
+++ b/services/nebius-cxcli/component_sources.yaml
@@ -212,7 +212,7 @@ components:
         portable:
           repo: oci://cr.eu-north1.nebius.cloud/e00th0mgv3zddz7468/charts/soperator
           chart: soperator
-          version: 4.0.2-ps.2
+          version: 4.0.2-ps.3
         local:
           path: ../../helm-charts/soperator
       ui:


### PR DESCRIPTION
## Summary
- Bump helm-charts/soperator chart package version to 4.0.2-ps.3
- Move current Soperator chart changelog notes under soperator-chart-v4.0.2-ps.3
- Update the bundled cxcli portable Soperator chart pin to 4.0.2-ps.3

## Validation
- helm lint --strict --with-subcharts helm-charts/soperator
- helm template smoke helm-charts/soperator with publish workflow smoke args
- python chart/catalog version assertion
- .venv/bin/python -m pytest tests/test_component_sources.py::test_load_component_sources_reads_tf_modules_and_helm_entries
- NEBIUS_CXCLI_COMPONENT_SOURCES_PROFILE=local .venv/bin/nebius-cxcli validate-sources component_sources.yaml
- git diff --check