### PR TITLE
Align Soperator upgrade docs and Nebius auth skill hooks

### DIFF
--- a/services/nebius-cxcli/CHANGELOG.md
+++ b/services/nebius-cxcli/CHANGELOG.md
@@ -6,6 +6,11 @@ All notable changes to this project are tracked here. This changelog follows
 
 ## [Unreleased]
 
+- Documented the Soperator cluster upgrade split in the README. Full
+  cxcli-managed cluster upgrades run the Terraform-managed MK8s layer first and
+  the Soperator chart upgrade second only when both layers change, while
+  external clusters use `ext-soperator onboard` and guarded `ext-soperator
+  migrate` for onboarding-selected MK8s/Soperator migration work.
 - Added Soperator GPU driver-jail guardrails for Nebius-image GPU workers.
   cxcli now materializes the chart-owned `gpuDriverJail` contract for managed
   and migrated GPU NodeSets, fails fast on conflicting external mounts, and

--- a/services/nebius-cxcli/README.md
+++ b/services/nebius-cxcli/README.md
@@ -38,7 +38,7 @@ Use this guide by task:
   - [Soperator Slurm Scheduling And Command Examples](#soperator-slurm-scheduling-and-command-examples)
   - [External Soperator Onboarding](#external-soperator-onboarding)
   - [External Soperator Migration](#external-soperator-migration)
-  - [CXCLI Managed Upgrade vs External Onboard and Migrate](#cxcli-managed-upgrade-vs-external-onboard-and-migrate)
+  - [Soperator Cluster Upgrade](#soperator-cluster-upgrade)
   - [Soperator Rules and Safety Checks](#soperator-rules-and-safety-checks)
 - [Upgrade](#upgrade)
   - [When To Use upgrade](#when-to-use-upgrade)
@@ -3176,10 +3176,36 @@ Phases complete only when their live prerequisites are absent or satisfied;
 otherwise cxcli writes the pending phase and reason to the checkpoint for the
 next explicit action.
 
-### CXCLI Managed Upgrade vs External Onboard and Migrate
+### Soperator Cluster Upgrade
 
-Use `soperator upgrade` when cxcli already manages the Soperator app row and
-the target is already part of the rendered bundle:
+A Soperator cluster upgrade can involve two separate layers:
+
+- the underlying MK8s cluster and node groups;
+- the Soperator Helm chart/app row.
+
+Upgrade only the layer that is changing. A full cxcli-managed Soperator cluster
+upgrade that changes both MK8s and the Soperator chart is a two-phase process:
+upgrade the Terraform-managed MK8s layer first, then upgrade the Soperator chart.
+It is not always a two-phase process for chart-only or MK8s-only changes.
+
+For cxcli-managed Soperator clusters, use `upgrade node-template` first when the
+MK8s Kubernetes minor, node OS image, or Nebius-image GPU stack must change:
+
+```bash
+nebius-cxcli upgrade node-template <config.yaml> infra:mk8s@<target> \
+  --to-version <major.minor> \
+  --to-os <os> \
+  --to-gpu-stack-preset <cuda...> \
+  --dry-run
+nebius-cxcli upgrade node-template <config.yaml> infra:mk8s@<target> \
+  --to-version <major.minor> \
+  --to-os <os> \
+  --to-gpu-stack-preset <cuda...>
+```
+
+Use `soperator upgrade` when cxcli already manages the Soperator app row and the
+target is already part of the rendered bundle. For a full two-layer upgrade, run
+it after the MK8s phase:
 
 ```bash
 nebius-cxcli soperator upgrade <config.yaml> \
@@ -3191,12 +3217,22 @@ nebius-cxcli soperator upgrade <config.yaml> \
   --to-version <chart-version>
 ```
 
-That path is a cxcli-managed chart upgrade. It validates the current generated
-bundle, runs live Soperator/Slurm smoke preflight, updates the Soperator app
-version in `config.yaml`, rerenders, validates the new bundle, applies the
-selected target Flux bundle, verifies the static Soperator chart version on
-live Kubernetes objects, reruns the required Soperator/Slurm smoke validation,
-and writes command-owned validation details plus
+`upgrade node-template` validates the live compatibility matrix, updates
+`config.yaml`, rerenders, validates, applies the staged Terraform changes, waits
+for the MK8s control plane and selected node groups, and writes
+`generated/reports/upgrade-node-template-report.md` /
+`generated/reports/upgrade-node-template-report.json`. Use `upgrade node-group`
+instead when the change is hardware platform, hardware preset, CPU/GPU kind, GPU
+cluster, or InfiniBand fabric; current `upgrade node-group --execute --approve`
+writes the approved pre-mutation checkpoint/report and then stops before live
+replacement/cutover/retirement.
+
+`soperator upgrade` is a cxcli-managed chart upgrade. It validates the current
+generated bundle, runs live Soperator/Slurm smoke preflight, updates the
+Soperator app version in `config.yaml`, rerenders, validates the new bundle,
+applies the selected target Flux bundle, verifies the static Soperator chart
+version on live Kubernetes objects, reruns the required Soperator/Slurm smoke
+validation, and writes command-owned validation details plus
 `generated/reports/soperator-upgrade-report.md` /
 `generated/reports/soperator-upgrade-report.json`.
 `upgrade helm-chart` is intentionally non-Soperator-only and fails fast for
@@ -3223,19 +3259,42 @@ The rendered Soperator output remains a static post-Flux manifest even when the
 source is OCI; this avoids the Helm release Secret size limit for the Soperator
 umbrella chart.
 
-Use `ext-soperator onboard` plus `ext-soperator migrate` when the source cluster is not
-yet under cxcli Soperator management or when onboarding found a source
-Soperator that must be upgraded while adopting or migrating layout. In that case
-the accepted migration profile can combine adoption, Soperator chart
-upgrade to the cxcli-pinned target, external MK8s control-plane and
-node-template upgrade, storage remediation, compute remediation, target GPU
-stack reconciliation when paired with migration work, and final cutover in one
-guarded workflow. That is why migration reads the source discovery report and
-accepted action plan, prints external node-template and target GPU stack
-reconciliation as their own required actions when present, and checkpoints phase
-state instead of acting like a plain Helm chart bump.
+For external Soperator clusters, start with onboarding instead of the
+Terraform-managed MK8s upgrade commands:
 
-Underlying MK8s infrastructure upgrade commands are also different:
+```bash
+nebius-cxcli ext-soperator onboard <config.yaml-or-deployments-root>
+nebius-cxcli validate <config.yaml>
+nebius-cxcli render <config.yaml>
+```
+
+If onboarding records no migration-owned actions, use the normal deploy path:
+
+```bash
+nebius-cxcli deploy <config.yaml>
+```
+
+If onboarding records migration-owned actions, run migration as the guarded
+upgrade/adoption workflow:
+
+```bash
+nebius-cxcli ext-soperator migrate <config.yaml> --target <target> --dry-run
+nebius-cxcli ext-soperator migrate <config.yaml> --target <target> --execute --approve
+```
+
+Use `ext-soperator onboard` plus `ext-soperator migrate` when the source cluster
+is not yet under cxcli Soperator management or when onboarding found a source
+Soperator that must be upgraded while adopting or migrating layout. In that case
+the accepted migration profile can combine adoption, Soperator chart upgrade to
+the cxcli-pinned target, external MK8s control-plane and node-template upgrade,
+storage remediation, compute remediation, target GPU stack reconciliation when
+paired with migration work, and final cutover in one guarded workflow. That is
+why migration reads the source discovery report and accepted action plan, prints
+external node-template and target GPU stack reconciliation as their own required
+actions when present, and checkpoints phase state instead of acting like a plain
+Helm chart bump.
+
+Underlying MK8s upgrade ownership is different for managed and external targets:
 
 - `upgrade node-template` and `upgrade node-group` operate on Terraform-managed `infra:mk8s`
   rows.

--- a/services/nebius-cxcli/tests/test_docs_alignment.py
+++ b/services/nebius-cxcli/tests/test_docs_alignment.py
@@ -445,10 +445,7 @@ def test_readme_upgrade_section_is_visible_and_consolidated() -> None:
     )
     assert "  - [External Soperator Onboarding](#external-soperator-onboarding)" in toc
     assert "  - [External Soperator Migration](#external-soperator-migration)" in toc
-    assert (
-        "  - [CXCLI Managed Upgrade vs External Onboard and Migrate](#cxcli-managed-upgrade-vs-external-onboard-and-migrate)"
-        in toc
-    )
+    assert "  - [Soperator Cluster Upgrade](#soperator-cluster-upgrade)" in toc
     assert "  - [Soperator Rules and Safety Checks](#soperator-rules-and-safety-checks)" in toc
     assert "- [Upgrade](#upgrade)" in toc
     assert "  - [When To Use upgrade](#when-to-use-upgrade)" in toc
@@ -473,7 +470,7 @@ def test_readme_upgrade_section_is_visible_and_consolidated() -> None:
     assert "### Soperator Slurm Scheduling And Command Examples" in soperator
     assert "### External Soperator Onboarding" in soperator
     assert "### External Soperator Migration" in soperator
-    assert "### CXCLI Managed Upgrade vs External Onboard and Migrate" in soperator
+    assert "### Soperator Cluster Upgrade" in soperator
     assert "### Soperator Rules and Safety Checks" in soperator
     assert "`nebius-cxcli soperator` is for Soperator app rows that cxcli already manages" in (
         soperator_flat
@@ -552,7 +549,20 @@ def test_readme_upgrade_section_is_visible_and_consolidated() -> None:
     assert "does not silently disable arbitrary live external ActiveChecks" in (soperator_flat)
     assert (
         "Use `ext-soperator onboard` plus `ext-soperator migrate` when the source cluster is not"
-        in (soperator)
+        in soperator_flat
+    )
+    assert "A full cxcli-managed Soperator cluster upgrade that changes both MK8s" in (
+        soperator_flat
+    )
+    assert "It is not always a two-phase process for chart-only or MK8s-only changes" in (
+        soperator_flat
+    )
+    assert (
+        "For external Soperator clusters, start with onboarding instead of the Terraform-managed MK8s upgrade commands"
+        in soperator_flat
+    )
+    assert "`upgrade node-group --execute --approve` writes the approved pre-mutation checkpoint" in (
+        soperator_flat
     )
     assert "Onboarded external MK8s clusters are not Terraform-managed" in soperator
     assert "best-effort high availability" in soperator_flat
@@ -710,6 +720,7 @@ def test_readme_upgrade_section_is_visible_and_consolidated() -> None:
     assert "Improved external Soperator migration completion handoff" in unreleased_flat
     assert "live post-migration discovery refresh" in unreleased_flat
     assert "pending or still-migration-owned plans blocked from normal deploy" in unreleased_flat
+    assert "Documented the Soperator cluster upgrade split" in unreleased_flat
     assert "Reorganized the README navigation" in unreleased_flat
     assert "move Soperator Slurm scheduling guidance under `Soperator Commands`" in (
         unreleased_flat

--- a/skills/CHANGELOG.md
+++ b/skills/CHANGELOG.md
@@ -109,6 +109,20 @@ All notable changes to the reusable Codex skills are tracked here.
   treated as human/admin IAM repair sessions, and fake Nebius CLI regressions
   cover profile drift on rerun, effective `NEBIUS_PROFILE` selection,
   interrupted profile creation, and concurrent setup.
+- Changed `agent-nebius-auth` so the setup script no longer writes an inline
+  Codex hook block to `$CODEX_HOME/config.toml`. The old `--install-hook` flag
+  now fails fast and points operators to the canonical
+  `install-skills.sh --install-hooks agent-nebius-auth/assets/hooks
+  --register-hooks` path for payload sync and `hooks.json` registration, while
+  setup records the selected project under `~/.nebius` for the generic hook to
+  read locally.
+- Added an installer-side `agent-nebius-auth` migration cleanup: registering
+  the hook now removes the old marked inline `config.toml` block, backs up the
+  file, and migrates the legacy project selector to
+  `~/.nebius/codex-agent-default-project-id` without printing the project ID.
+- Added a skill-local `agent-nebius-auth/README.md` with the setup-only
+  workflow, installer-managed hook registration, runtime hook behavior,
+  idempotency checks, and validation commands.
 - Clarified `publish-helm` required release inputs so callers must provide an
   explicit tag and publish destination or be asked for them, documented the
   OCI repository base versus provider registry-ID workflow split, and made

--- a/skills/README.md
+++ b/skills/README.md
@@ -169,7 +169,10 @@ Codex Agent Nebius authentication. It uses a service account, tenant group,
 project-level access permit, authorized-key credential file, CLI profile, and a
 Codex `PreToolUse` hook that injects short-lived Nebius token environment
 variables into matching Bash commands without returning token material as model
-context.
+context. Install or refresh the hook through the root installer, for example
+`./install-skills.sh --install-hooks agent-nebius-auth/assets/hooks --register-hooks`;
+the setup script does not patch `$CODEX_HOME/config.toml` and instead records
+the selected project under `~/.nebius` for the hook to read locally.
 
 ### Agentic SDLC Skills
 
@@ -591,6 +594,11 @@ CODEX_HOME=~/custom-codex ./install-skills.sh --install-all-hooks --register-hoo
   create or preserve multiple registrations for the same hook event and Python
   hook filename, such as two `Stop` entries pointing at
   `stop_sdlc_continue.py`.
+- When registering `agent-nebius-auth`, the installer also removes the old
+  marked inline `agent-nebius-auth` block from
+  `${CODEX_HOME:-$HOME/.codex}/config.toml`, backs that file up, and migrates
+  the legacy project selector to `~/.nebius/codex-agent-default-project-id`
+  without printing the project ID.
 - `--replace-hooks-json` can be combined with `--register-hooks` to replace
   `${CODEX_HOME:-$HOME/.codex}/hooks.json` with a clean file built from the
   selected source manifest or manifests. This removes hand-written and stale

--- a/skills/agent-nebius-auth/README.md
+++ b/skills/agent-nebius-auth/README.md
@@ -1,0 +1,181 @@
+# Agent Nebius Auth
+
+`agent-nebius-auth` bootstraps and repairs local Codex Agent authentication for
+Nebius projects. It creates or verifies a project-scoped service-account
+credential, a Nebius CLI profile, and a local default project selector that the
+runtime hook can read.
+
+The skill is setup-only. Runtime token injection is handled by the installed
+Codex `PreToolUse` hook in `assets/hooks/pre_tool_use_nebius_auth.py`.
+
+## What It Does
+
+- Creates or repairs `~/.nebius/codex-agent-authkey.<project_id>.json`.
+- Creates or updates the `codex-agent-<project_id>` Nebius CLI profile.
+- Records `~/.nebius/codex-agent-default-project-id` for the hook.
+- Installs the hook only through the root `install-skills.sh` hook workflow.
+- Rewrites Nebius-sensitive Bash commands so the shell mints a short-lived
+  token at execution time.
+- Avoids returning token values through hook output, model context, task state,
+  docs, or final responses.
+
+## Design
+
+The workflow has two separate owners:
+
+```text
+operator request
+  |
+  +--> scripts/agent-nebius-auth.sh
+  |     - create or repair service-account auth
+  |     - configure codex-agent-<project_id> CLI profile
+  |     - write ~/.nebius/codex-agent-default-project-id
+  |
+  `--> install-skills.sh --install-hooks agent-nebius-auth/assets/hooks --register-hooks
+        - copy hook payload into $CODEX_HOME/hooks
+        - merge hook registration into $CODEX_HOME/hooks.json
+        - migrate the old marked inline config.toml block when present
+```
+
+The setup script must not patch `$CODEX_HOME/config.toml` or duplicate hook
+registration logic. The installer owns hook files and `hooks.json`.
+
+## Setup
+
+Run setup only when the operator explicitly asks to bootstrap or repair local
+Nebius auth:
+
+```bash
+bash scripts/agent-nebius-auth.sh ensure \
+  --tenant-id <tenant_id> \
+  --project-id <project_id> \
+  --project-name <project_name>
+```
+
+Useful optional flags:
+
+- `--service-account-name <name>`: default `codex-agent-sa`
+- `--role <role>`: default `editor`
+- `--repair`: allow replacement of a broken credential after backup
+- `--dry-run`: show the planned setup actions without changing IAM or local auth
+
+The setup path may create or repair Nebius IAM resources. Do not run it against
+production or customer environments unless the operator explicitly asked for
+that target and understands the credential and IAM changes.
+
+## Hook Install
+
+Install or refresh the runtime hook from the skills repo root:
+
+```bash
+./install-skills.sh --install-hooks agent-nebius-auth/assets/hooks --register-hooks
+```
+
+This is idempotent. Re-running the command should leave matching payload and
+registration state unchanged.
+
+When the installer sees an old marked inline `agent-nebius-auth` block in
+`${CODEX_HOME:-$HOME/.codex}/config.toml`, it:
+
+1. Preflights that the old project selector does not conflict with
+   `~/.nebius/codex-agent-default-project-id`.
+2. Migrates the old selector into
+   `~/.nebius/codex-agent-default-project-id` when needed.
+3. Backs up `config.toml`.
+4. Removes only the marked managed block.
+5. Keeps the project ID out of installer stdout and stderr.
+
+If the selector conflicts, the installer fails before copying the hook payload
+or writing `hooks.json`, so it does not create a duplicate active hook path.
+
+## Runtime Behavior
+
+On `PreToolUse` for `Bash`, the hook detects Nebius-sensitive commands such as
+Nebius API calls, Nebius-related Terraform contexts, Nebius-related tests, and
+direct Nebius CLI usage.
+
+Project selection order is:
+
+1. `CODEX_NEBIUS_PROJECT_ID`
+2. `~/.nebius/codex-agent-default-project-id`
+3. exactly one `~/.nebius/codex-agent-authkey.<project_id>.json` file
+
+For API-style commands, the hook returns an `updatedInput.command` that runs:
+
+```bash
+nebius iam get-access-token --profile "$PROFILE"
+```
+
+inside the shell command and exports `TOKEN`, `NEBIUS_IAM_TOKEN`,
+`NEBIUS_PROFILE`, and `NEBIUS_PROJECT_ID` for that process. The hook output
+contains the command substitution, not the token value.
+
+For direct `nebius` CLI commands without an explicit profile, the hook rewrites
+the command to use `--profile codex-agent-<project_id>`.
+
+The hook fails closed for direct token-minting commands unless they are plain
+manual verification commands that redirect stdout away from model-visible logs.
+It also fails closed for nested token-minting commands, shell tracing, and
+obvious environment-printing commands when token injection would be active.
+
+## Verification
+
+Run these local checks from the skill folder after changing the skill:
+
+```bash
+PYTHONDONTWRITEBYTECODE=1 python3 -B scripts/test_pre_tool_use_nebius_auth.py
+PYTHONDONTWRITEBYTECODE=1 python3 -B scripts/test_agent_nebius_auth_setup.py
+PYTHONDONTWRITEBYTECODE=1 python3 -B scripts/test_install_hook_migration.py
+```
+
+Run these checks from the skills repo root:
+
+```bash
+shellcheck install-skills.sh agent-nebius-auth/scripts/agent-nebius-auth.sh
+bash -n install-skills.sh agent-nebius-auth/scripts/agent-nebius-auth.sh
+python3 -m json.tool agent-nebius-auth/assets/hooks.json.template >/dev/null
+python3 -B align-skill/scripts/validate-skill-structure.py agent-nebius-auth
+markdownlint agent-nebius-auth/SKILL.md agent-nebius-auth/README.md README.md CHANGELOG.md
+git diff --check
+```
+
+Manual token verification, when explicitly needed, must redirect token output
+away from model-visible logs:
+
+```bash
+nebius iam get-access-token --profile codex-agent-<project_id> >/dev/null
+```
+
+## Troubleshooting
+
+- `--install-hook` is no longer supported by the setup script. Use the root
+  installer command in the Hook Install section.
+- Multiple credential files require either `CODEX_NEBIUS_PROJECT_ID` or
+  `~/.nebius/codex-agent-default-project-id`.
+- A stale inline hook block should be removed by the root installer only when
+  it is wrapped in the managed `agent-nebius-auth` markers.
+- After hook changes, restart Codex and review or trust the hook with `/hooks`
+  before relying on it.
+
+## Files
+
+- `SKILL.md`: agent-facing setup, hook behavior, guardrails, and validation.
+- `assets/hooks/pre_tool_use_nebius_auth.py`: runtime `PreToolUse` hook.
+- `assets/hooks.json.template`: installer-managed hook registration template.
+- `scripts/agent-nebius-auth.sh`: setup and repair entry point.
+- `scripts/test_agent_nebius_auth_setup.py`: fake Nebius CLI setup tests.
+- `scripts/test_pre_tool_use_nebius_auth.py`: hook unit tests.
+- `scripts/test_install_hook_migration.py`: installer migration and idempotency
+  tests.
+- `agents/openai.yaml`: UI metadata.
+
+## Vendor Evidence
+
+- OpenAI Codex Skills: <https://developers.openai.com/codex/skills>
+- OpenAI Codex Hooks: <https://developers.openai.com/codex/hooks>
+- Nebius access tokens:
+  <https://docs.nebius.com/iam/authorization/access-tokens>
+- Nebius `get-access-token` CLI reference:
+  <https://docs.nebius.com/cli/reference/iam/get-access-token>
+- Nebius authorized-key CLI reference:
+  <https://docs.nebius.com/cli/reference/iam/auth-public-key>

--- a/skills/agent-nebius-auth/SKILL.md
+++ b/skills/agent-nebius-auth/SKILL.md
@@ -24,6 +24,7 @@ Defaults:
 
 - service account: `codex-agent-sa`
 - credential file: `~/.nebius/codex-agent-authkey.<project_id>.json`
+- default project selector: `~/.nebius/codex-agent-default-project-id`
 - CLI profile: `codex-agent-<project_id>`
 - group: `codex-agent-<project-name-slug>`
 - role: `editor`
@@ -31,16 +32,15 @@ Defaults:
 
 ## Run
 
-Run the setup script only when the operator explicitly asks to bootstrap,
-repair, or install the local auth hook. If the prompt is not explicit, report
-the command instead of running it.
+Run the setup script only when the operator explicitly asks to bootstrap or
+repair the local Nebius auth state. If the prompt is not explicit, report the
+command instead of running it.
 
 ```bash
 bash scripts/agent-nebius-auth.sh ensure \
   --tenant-id <tenant_id> \
   --project-id <project_id> \
-  --project-name <project_name> \
-  --install-hook
+  --project-name <project_name>
 ```
 
 Optional flags:
@@ -48,29 +48,39 @@ Optional flags:
 - `--service-account-name <name>`: default `codex-agent-sa`
 - `--role <role>`: default `editor`
 - `--repair`: allow replacement of a broken credential file after backing it up
-- `--install-hook`: add or update the Codex `PreToolUse` hook block
 - `--dry-run`: print the planned actions without modifying IAM or local files
 
-If the skill and hook payload are installed separately with the root installer,
-register the runtime hook with:
+When the operator explicitly asks to install or refresh the runtime hook, run
+the root installer from the skills repo root:
 
 ```bash
 ./install-skills.sh --install-hooks agent-nebius-auth/assets/hooks --register-hooks
 ```
 
-Use either this installer-managed `hooks.json` registration or the setup
-script's `--install-hook` inline `config.toml` block for a given machine, not
-both. Codex runs matching hooks from all active sources, so duplicate
-registrations can make the Nebius auth hook run more than once.
+The root installer owns hook payload sync and `hooks.json` registration. The
+setup script must not edit `$CODEX_HOME/config.toml`, shell out to the
+installer, or duplicate installer merge logic; the skill workflow may run the
+installer as a separate explicit hook-install step. The old `--install-hook`
+flag fails fast with the installer command to use. Codex runs matching hooks
+from all active sources, so do not keep a stale inline `config.toml`
+registration next to the installer-managed `hooks.json` entry. When the root
+installer registers this hook, it removes the old marked inline
+`agent-nebius-auth` block from `$CODEX_HOME/config.toml`, backs that file up,
+and migrates the legacy project selector to
+`~/.nebius/codex-agent-default-project-id` without printing the project ID.
 
 ## Setup Behavior
 
 Use `scripts/agent-nebius-auth.sh` as the single setup entry point. It is
-idempotent and owns bootstrap, verification, repair, and its inline
-`config.toml` hook registration mode. The root `install-skills.sh
---install-hooks agent-nebius-auth/assets/hooks --register-hooks` path is a separate
-payload/`hooks.json` registration mode for operators who already installed the
-skill and do not want the setup script to manage inline hook config.
+idempotent and owns bootstrap, verification, and repair of the Nebius service
+account credential and CLI profile. It intentionally does not install or
+register Codex hooks. The root `install-skills.sh --install-hooks
+agent-nebius-auth/assets/hooks --register-hooks` path is the canonical
+payload/`hooks.json` registration mode for this hook.
+After a successful setup, the script records the selected project ID in
+`~/.nebius/codex-agent-default-project-id` so the generic installer-managed
+hook can select the correct project-specific agent profile without an inline
+`config.toml` environment assignment.
 
 The script serializes setup with both a project-specific lock and a global
 Nebius profile lock because `nebius profile create/update/activate` changes
@@ -91,6 +101,8 @@ When the credential file exists, the script:
    drift for the service account, group, access permit, and membership.
 7. If token minting fails, replaces the credential file only when `--repair`
    is set and the current human/admin session can regenerate it.
+8. Records the project ID in `~/.nebius/codex-agent-default-project-id` for the
+   installer-managed runtime hook.
 
 When the credential file does not exist, the script:
 
@@ -104,7 +116,8 @@ When the credential file does not exist, the script:
 8. Restores the previous active or effective human/admin Nebius CLI profile if
    profile creation changed it.
 9. Verifies service-account token minting and basic project access.
-10. Installs or updates the `PreToolUse` hook when `--install-hook` is set.
+10. Records the project ID in `~/.nebius/codex-agent-default-project-id` for
+    the installer-managed runtime hook.
 
 If the credential file exists but is broken, the script must not delete or
 overwrite it unless `--repair` is set and the human/admin Nebius session is
@@ -127,8 +140,9 @@ On `PreToolUse` for `Bash`, the hook:
 2. Detects Nebius-sensitive commands such as Nebius API calls,
    Nebius-related Terraform contexts, Nebius-related tests, or direct Nebius
    CLI usage.
-3. Resolves the project ID from `CODEX_NEBIUS_PROJECT_ID`, or from exactly one
-   local `~/.nebius/codex-agent-authkey.<project_id>.json` file.
+3. Resolves the project ID from `CODEX_NEBIUS_PROJECT_ID`,
+   `~/.nebius/codex-agent-default-project-id`, or exactly one local
+   `~/.nebius/codex-agent-authkey.<project_id>.json` file.
 4. Derives the profile as `codex-agent-<project_id>`.
 5. Rewrites the pending command so the shell process mints a short-lived token
    with `nebius iam get-access-token --profile "$PROFILE"` and exports
@@ -178,6 +192,7 @@ Run local regression checks after hook changes:
 ```bash
 PYTHONDONTWRITEBYTECODE=1 python3 -B scripts/test_pre_tool_use_nebius_auth.py
 PYTHONDONTWRITEBYTECODE=1 python3 -B scripts/test_agent_nebius_auth_setup.py
+PYTHONDONTWRITEBYTECODE=1 python3 -B scripts/test_install_hook_migration.py
 ```
 
 ## Learning Loop

--- a/skills/agent-nebius-auth/assets/hooks/pre_tool_use_nebius_auth.py
+++ b/skills/agent-nebius-auth/assets/hooks/pre_tool_use_nebius_auth.py
@@ -145,8 +145,19 @@ def infer_project_id_from_single_credential() -> str:
     return name[len(prefix) : -len(suffix)]
 
 
+def infer_project_id_from_default_file() -> str:
+    default_file = Path.home() / ".nebius" / "codex-agent-default-project-id"
+    try:
+        return default_file.read_text(encoding="utf-8").strip().splitlines()[0]
+    except (IndexError, OSError):
+        return ""
+
+
 def resolve_project_id() -> str:
     project_id = os.environ.get("CODEX_NEBIUS_PROJECT_ID", "").strip()
+    if project_id:
+        return project_id
+    project_id = infer_project_id_from_default_file()
     if project_id:
         return project_id
     return infer_project_id_from_single_credential()
@@ -221,11 +232,11 @@ def evaluate(payload: dict[str, Any]) -> dict[str, Any]:
     project_id = resolve_project_id()
     if not project_id:
         return deny(
-            "Nebius auth required, but CODEX_NEBIUS_PROJECT_ID is not set and no single local agent credential file can be inferred."
+            "Nebius auth required, but no project selector is available. Set CODEX_NEBIUS_PROJECT_ID, run $agent-nebius-auth setup to write the default selector, or keep exactly one local agent credential file."
         )
     if not validate_project_id(project_id):
         return deny(
-            "Nebius auth required, but CODEX_NEBIUS_PROJECT_ID is invalid."
+            "Nebius auth required, but the resolved Nebius project selector is invalid."
         )
     if not credential_file_exists(project_id):
         return deny(

--- a/skills/agent-nebius-auth/scripts/agent-nebius-auth.sh
+++ b/skills/agent-nebius-auth/scripts/agent-nebius-auth.sh
@@ -3,7 +3,6 @@ set -euo pipefail
 
 SA_NAME="codex-agent-sa"
 ROLE="editor"
-INSTALL_HOOK="false"
 REPAIR="false"
 DRY_RUN="false"
 ENDPOINT="api.nebius.cloud"
@@ -15,6 +14,7 @@ PROJECT_NAME=""
 COMMAND=""
 LOCK_DIRS=()
 PROFILE_RESTORE_TARGET=""
+DEFAULT_PROJECT_FILE=""
 
 die() {
   printf 'ERROR: %s\n' "$*" >&2
@@ -35,11 +35,13 @@ Usage:
     [--service-account-name <name>] \
     [--role <role>] \
     [--repair] \
-    [--install-hook] \
     [--dry-run]
 
 Creates or repairs local Codex Agent Nebius service-account auth. Runtime token
 injection is handled by the installed PreToolUse hook, not by this script.
+Install or refresh that hook from the skills repo root with:
+
+  ./install-skills.sh --install-hooks agent-nebius-auth/assets/hooks --register-hooks
 EOF
 }
 
@@ -130,6 +132,20 @@ safe_chmod_credential() {
 ensure_nebius_dir() {
   run mkdir -p "$HOME/.nebius"
   run chmod 700 "$HOME/.nebius"
+}
+
+write_default_project_id() {
+  local temp_file=""
+
+  if is_dry_run; then
+    log "Would set the default agent Nebius project to '$PROJECT_ID'."
+    return 0
+  fi
+
+  temp_file="${DEFAULT_PROJECT_FILE}.tmp.$$"
+  printf '%s\n' "$PROJECT_ID" >"$temp_file"
+  chmod 600 "$temp_file"
+  mv "$temp_file" "$DEFAULT_PROJECT_FILE"
 }
 
 active_profile() {
@@ -534,72 +550,6 @@ verify_project_access() {
     --format json >/dev/null 2>&1
 }
 
-shell_quote() {
-  printf '%q' "$1"
-}
-
-toml_literal_safe() {
-  [[ "$1" != *"'"* ]]
-}
-
-install_hook() {
-  local codex_home="${CODEX_HOME:-$HOME/.codex}"
-  local config_file="${codex_home}/config.toml"
-  local hook_file="${SKILL_DIR}/assets/hooks/pre_tool_use_nebius_auth.py"
-  local begin_marker="# agent-nebius-auth managed block begin"
-  local end_marker="# agent-nebius-auth managed block end"
-  local begin_count=""
-  local end_count=""
-  local temp_file=""
-  local hook_command=""
-  local lock_dir="${codex_home}/agent-nebius-auth.config.lock"
-
-  [[ -f "$hook_file" ]] || die "Hook file is missing: $hook_file"
-  need_cmd python3
-
-  hook_command="CODEX_NEBIUS_PROJECT_ID=$(shell_quote "$PROJECT_ID") python3 $(shell_quote "$hook_file")"
-  toml_literal_safe "$hook_command" || die "Hook command contains a single quote and cannot be written safely as a TOML literal."
-
-  if is_dry_run; then
-    log "Would add or update the agent-nebius-auth PreToolUse hook block in $config_file."
-    return 0
-  fi
-
-  mkdir -p "$codex_home"
-  acquire_lock "$lock_dir"
-  touch "$config_file"
-
-  begin_count="$(grep -cF "$begin_marker" "$config_file" || true)"
-  end_count="$(grep -cF "$end_marker" "$config_file" || true)"
-  [[ "$begin_count" == "$end_count" ]] || die "Existing agent-nebius-auth managed hook block is malformed in $config_file."
-
-  temp_file="$(mktemp)"
-  awk -v begin="$begin_marker" -v end="$end_marker" '
-    $0 == begin { skip = 1; next }
-    $0 == end { skip = 0; next }
-    !skip { print }
-  ' "$config_file" >"$temp_file"
-
-  cat >>"$temp_file" <<EOF
-
-$begin_marker
-[[hooks.PreToolUse]]
-matcher = "^Bash$"
-
-[[hooks.PreToolUse.hooks]]
-type = "command"
-command = '$hook_command'
-timeout = 30
-statusMessage = "Preparing Nebius auth"
-$end_marker
-EOF
-
-  mv "$temp_file" "$config_file"
-
-  log "Installed Codex PreToolUse hook block in $config_file"
-  log "Restart Codex and review/trust the hook with /hooks before relying on it."
-}
-
 ensure_existing_credential_flow() {
   local sa_id=""
 
@@ -684,8 +634,7 @@ parse_args() {
         shift 2
         ;;
       --install-hook)
-        INSTALL_HOOK="true"
-        shift
+        die "--install-hook is no longer supported. Install or refresh the runtime hook from the skills repo root with: ./install-skills.sh --install-hooks agent-nebius-auth/assets/hooks --register-hooks"
         ;;
       --repair)
         REPAIR="true"
@@ -730,8 +679,7 @@ main() {
   GROUP_NAME="codex-agent-${project_slug}"
   PROFILE="codex-agent-${PROJECT_ID}"
   CREDENTIAL_FILE="$HOME/.nebius/codex-agent-authkey.${PROJECT_ID}.json"
-  SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-  SKILL_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+  DEFAULT_PROJECT_FILE="$HOME/.nebius/codex-agent-default-project-id"
   auth_lock_dir="$HOME/.nebius/agent-nebius-auth.${PROJECT_ID}.lock"
   profile_lock_dir="$HOME/.nebius/agent-nebius-auth.profile.lock"
 
@@ -745,10 +693,7 @@ main() {
   else
     ensure_missing_credential_flow
   fi
-
-  if [[ "$INSTALL_HOOK" == "true" ]]; then
-    install_hook
-  fi
+  write_default_project_id
 
   log "Done."
   log "Credential file: $CREDENTIAL_FILE"

--- a/skills/agent-nebius-auth/scripts/test_agent_nebius_auth_setup.py
+++ b/skills/agent-nebius-auth/scripts/test_agent_nebius_auth_setup.py
@@ -247,6 +247,9 @@ class AgentNebiusAuthSetupTest(unittest.TestCase):
             encoding="utf-8",
         )
 
+    def default_project_file(self) -> Path:
+        return self.home / ".nebius" / "codex-agent-default-project-id"
+
     def setup_command(self, project: str = PROJECT) -> list[str]:
         return [
             "bash",
@@ -258,7 +261,6 @@ class AgentNebiusAuthSetupTest(unittest.TestCase):
             project,
             "--project-name",
             PROJECT_NAME,
-            "--install-hook",
         ]
 
     def run_setup(
@@ -332,17 +334,33 @@ class AgentNebiusAuthSetupTest(unittest.TestCase):
         self.assertEqual(after_second["profile_update_calls"], 0)
         self.assertEqual(after_second["agent_iam_attempts"], 0)
 
-        config = self.codex_home / "config.toml"
+        self.assertFalse((self.codex_home / "config.toml").exists())
         self.assertEqual(
-            config.read_text(encoding="utf-8").count(
-                "# agent-nebius-auth managed block begin"
-            ),
-            1,
+            self.default_project_file().read_text(encoding="utf-8").strip(),
+            PROJECT,
         )
-        self.assertIn(
-            f"CODEX_NEBIUS_PROJECT_ID={PROJECT}",
-            config.read_text(encoding="utf-8"),
+
+    def test_legacy_install_hook_flag_fails_fast(self) -> None:
+        self.write_state()
+        self.write_credential()
+
+        result = subprocess.run(
+            [
+                *self.setup_command(),
+                "--install-hook",
+            ],
+            cwd=str(SCRIPT.parent.parent),
+            env=self.env,
+            text=True,
+            capture_output=True,
+            check=False,
         )
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("--install-hook is no longer supported", result.stderr)
+        self.assertIn("install-skills.sh --install-hooks", result.stderr)
+        self.assertFalse((self.codex_home / "config.toml").exists())
+        self.assertFalse(self.default_project_file().exists())
 
     def test_profile_update_preserves_active_human_profile(self) -> None:
         self.write_state(

--- a/skills/agent-nebius-auth/scripts/test_install_hook_migration.py
+++ b/skills/agent-nebius-auth/scripts/test_install_hook_migration.py
@@ -1,0 +1,331 @@
+#!/usr/bin/env python3
+"""Fixture tests for installer-managed agent-nebius-auth hook migration."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+import subprocess
+import sys
+import tempfile
+import textwrap
+import unittest
+
+
+HOOK_SOURCE = "agent-nebius-auth/assets/hooks"
+PROJECT = "project-test"
+
+
+def find_repo_root() -> Path | None:
+    override = os.environ.get("AGENT_NEBIUS_AUTH_REPO_ROOT")
+    if override:
+        return Path(override).expanduser()
+
+    for parent in Path(__file__).resolve().parents:
+        if (parent / "install-skills.sh").is_file():
+            return parent
+    return None
+
+
+class AgentNebiusAuthHookInstallMigrationTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.repo_root = find_repo_root()
+        if self.repo_root is None:
+            self.skipTest("install-skills.sh is not available next to this installed skill copy")
+        self.installer = self.repo_root / "install-skills.sh"
+        self.tmp = tempfile.TemporaryDirectory()
+        self.root = Path(self.tmp.name)
+        self.home = self.root / "home"
+        self.codex_home = self.root / "codex"
+        self.home.mkdir()
+        self.codex_home.mkdir()
+        (self.home / ".nebius").mkdir()
+        self.env = os.environ.copy()
+        self.env.update(
+            {
+                "CODEX_HOME": str(self.codex_home),
+                "HOME": str(self.home),
+                "PYTHONDONTWRITEBYTECODE": "1",
+            }
+        )
+        self.env.pop("CODEX_NEBIUS_PROJECT_ID", None)
+
+    def tearDown(self) -> None:
+        self.tmp.cleanup()
+
+    def config_path(self) -> Path:
+        return self.codex_home / "config.toml"
+
+    def selector_path(self) -> Path:
+        return self.home / ".nebius" / "codex-agent-default-project-id"
+
+    def installed_hook_path(self) -> Path:
+        return self.codex_home / "hooks" / "pre_tool_use_nebius_auth.py"
+
+    def hook_registrations(self) -> list[dict[str, str]]:
+        hooks = json.loads((self.codex_home / "hooks.json").read_text(encoding="utf-8"))
+        return [
+            hook
+            for group in hooks["hooks"]["PreToolUse"]
+            for hook in group["hooks"]
+            if "pre_tool_use_nebius_auth.py" in hook["command"]
+        ]
+
+    def run_installer(self) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            [
+                "bash",
+                str(self.installer),
+                "--install-hooks",
+                HOOK_SOURCE,
+                "--register-hooks",
+            ],
+            cwd=str(self.repo_root),
+            env=self.env,
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+
+    def run_all_hooks_installer(self) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            [
+                "bash",
+                str(self.installer),
+                "--install-all-hooks",
+                "--register-hooks",
+            ],
+            cwd=str(self.repo_root),
+            env=self.env,
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+
+    def write_legacy_config_block(self) -> None:
+        self.config_path().write_text(
+            textwrap.dedent(
+                f"""\
+                model = "gpt-test"
+
+                # agent-nebius-auth managed block begin
+                [[hooks.PreToolUse]]
+                matcher = "^Bash$"
+
+                [[hooks.PreToolUse.hooks]]
+                type = "command"
+                command = 'CODEX_NEBIUS_PROJECT_ID={PROJECT} python3 /tmp/pre_tool_use_nebius_auth.py'
+                timeout = 30
+                statusMessage = "Preparing Nebius auth"
+                # agent-nebius-auth managed block end
+                """
+            ),
+            encoding="utf-8",
+        )
+
+    def test_register_hooks_removes_legacy_inline_config_block(self) -> None:
+        self.write_legacy_config_block()
+
+        result = self.run_installer()
+
+        self.assertEqual(
+            result.returncode,
+            0,
+            f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}",
+        )
+        config_text = self.config_path().read_text(encoding="utf-8")
+        self.assertIn('model = "gpt-test"', config_text)
+        self.assertNotIn("agent-nebius-auth managed block", config_text)
+        self.assertNotIn("pre_tool_use_nebius_auth.py", config_text)
+        self.assertEqual(
+            self.selector_path().read_text(encoding="utf-8").strip(),
+            PROJECT,
+        )
+        self.assertEqual(oct(self.selector_path().stat().st_mode & 0o777), "0o600")
+        backups = list(self.codex_home.glob("config.toml.bak.agent-nebius-auth.*"))
+        self.assertEqual(len(backups), 1)
+        self.assertEqual(len(self.hook_registrations()), 1)
+        self.assertIn(
+            "Removed legacy agent-nebius-auth inline config hook block(s): 1",
+            result.stdout,
+        )
+        self.assertNotIn(PROJECT, result.stdout)
+        self.assertNotIn(PROJECT, result.stderr)
+
+    def test_install_all_hooks_registers_and_migrates_legacy_inline_config(self) -> None:
+        self.write_legacy_config_block()
+
+        result = self.run_all_hooks_installer()
+
+        self.assertEqual(
+            result.returncode,
+            0,
+            f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}",
+        )
+        config_text = self.config_path().read_text(encoding="utf-8")
+        self.assertIn('model = "gpt-test"', config_text)
+        self.assertNotIn("agent-nebius-auth managed block", config_text)
+        self.assertNotIn("pre_tool_use_nebius_auth.py", config_text)
+        self.assertEqual(
+            self.selector_path().read_text(encoding="utf-8").strip(),
+            PROJECT,
+        )
+        self.assertEqual(oct(self.selector_path().stat().st_mode & 0o777), "0o600")
+        self.assertEqual(len(self.hook_registrations()), 1)
+        self.assertIn(
+            "Removed legacy agent-nebius-auth inline config hook block(s): 1",
+            result.stdout,
+        )
+        self.assertNotIn(PROJECT, result.stdout)
+        self.assertNotIn(PROJECT, result.stderr)
+
+    def test_selector_conflict_fails_before_registering_hooks(self) -> None:
+        self.write_legacy_config_block()
+        self.selector_path().write_text("project-other\n", encoding="utf-8")
+        self.selector_path().chmod(0o600)
+
+        result = self.run_installer()
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("already selects a different project", result.stderr)
+        self.assertNotIn(PROJECT, result.stdout)
+        self.assertNotIn(PROJECT, result.stderr)
+        self.assertIn(
+            "agent-nebius-auth managed block",
+            self.config_path().read_text(encoding="utf-8"),
+        )
+        self.assertEqual(
+            self.selector_path().read_text(encoding="utf-8").strip(),
+            "project-other",
+        )
+        self.assertFalse((self.codex_home / "hooks.json").exists())
+        self.assertFalse(self.installed_hook_path().exists())
+        self.assertEqual(
+            list(self.codex_home.glob("config.toml.bak.agent-nebius-auth.*")),
+            [],
+        )
+
+    def test_repeated_register_hooks_is_idempotent_and_hook_runs(self) -> None:
+        self.write_legacy_config_block()
+
+        first = self.run_installer()
+        second = self.run_installer()
+
+        for result in (first, second):
+            self.assertEqual(
+                result.returncode,
+                0,
+                f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}",
+            )
+            self.assertNotIn(PROJECT, result.stdout)
+            self.assertNotIn(PROJECT, result.stderr)
+
+        config_text = self.config_path().read_text(encoding="utf-8")
+        self.assertIn('model = "gpt-test"', config_text)
+        self.assertNotIn("agent-nebius-auth managed block", config_text)
+        self.assertNotIn("pre_tool_use_nebius_auth.py", config_text)
+        self.assertEqual(
+            self.selector_path().read_text(encoding="utf-8").strip(),
+            PROJECT,
+        )
+        self.assertEqual(oct(self.selector_path().stat().st_mode & 0o777), "0o600")
+        self.assertEqual(
+            len(list(self.codex_home.glob("config.toml.bak.agent-nebius-auth.*"))),
+            1,
+        )
+        self.assertEqual(len(self.hook_registrations()), 1)
+        self.assertTrue(self.installed_hook_path().is_file())
+        self.assertIn("Registered hook entries added: 0", second.stdout)
+        self.assertNotIn("Removed legacy agent-nebius-auth inline config hook", second.stdout)
+
+        credential = self.home / ".nebius" / f"codex-agent-authkey.{PROJECT}.json"
+        credential.write_text("{}", encoding="utf-8")
+        call_log = self.root / "nebius-calls.log"
+        bin_dir = self.root / "bin"
+        bin_dir.mkdir()
+        fake_nebius = bin_dir / "nebius"
+        fake_nebius.write_text(
+            textwrap.dedent(
+                """\
+                #!/bin/sh
+                printf '%s\n' "$*" >> "$FAKE_NEBIUS_CALL_LOG"
+                if [ "$1" = "iam" ] && [ "$2" = "get-access-token" ]; then
+                  printf '%s\n' fake-token
+                  exit 0
+                fi
+                exit 64
+                """
+            ),
+            encoding="utf-8",
+        )
+        fake_nebius.chmod(0o700)
+        exec_env = self.env.copy()
+        exec_env["PATH"] = f"{bin_dir}{os.pathsep}{exec_env['PATH']}"
+        exec_env["EXPECTED_TEST_TOKEN"] = "fake-token"
+        exec_env["FAKE_NEBIUS_CALL_LOG"] = str(call_log)
+
+        payload = {
+            "hook_event_name": "PreToolUse",
+            "tool_name": "Bash",
+            "tool_input": {
+                "command": (
+                    "python3 -c 'import os; "
+                    "expected = os.environ[\"EXPECTED_TEST_TOKEN\"]; "
+                    "assert os.environ[\"NEBIUS_IAM_TOKEN\"] == expected; "
+                    "assert os.environ[\"TOKEN\"] == expected; "
+                    f"assert os.environ[\"NEBIUS_PROFILE\"] == \"codex-agent-{PROJECT}\"; "
+                    f"assert os.environ[\"NEBIUS_PROJECT_ID\"] == \"{PROJECT}\"' "
+                    "# api.nebius.cloud"
+                ),
+            },
+        }
+        hook_result = subprocess.run(
+            [sys.executable, str(self.installed_hook_path())],
+            input=json.dumps(payload),
+            cwd=str(self.repo_root),
+            env=exec_env,
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+
+        self.assertEqual(
+            hook_result.returncode,
+            0,
+            f"stdout:\n{hook_result.stdout}\nstderr:\n{hook_result.stderr}",
+        )
+        self.assertEqual(hook_result.stderr, "")
+        hook_output = json.loads(hook_result.stdout)
+        updated_command = hook_output["hookSpecificOutput"]["updatedInput"]["command"]
+        self.assertIn("nebius iam get-access-token", updated_command)
+        self.assertNotIn("fake-token", hook_result.stdout)
+        self.assertNotIn("fake-token", hook_result.stderr)
+        self.assertNotIn("fake-token", updated_command)
+        self.assertFalse(call_log.exists())
+
+        command_result = subprocess.run(
+            ["bash", "-c", updated_command],
+            cwd=str(self.repo_root),
+            env=exec_env,
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+
+        self.assertEqual(
+            call_log.read_text(encoding="utf-8").splitlines(),
+            [f"iam get-access-token --profile codex-agent-{PROJECT}"],
+        )
+
+        self.assertEqual(
+            command_result.returncode,
+            0,
+            f"stdout:\n{command_result.stdout}\nstderr:\n{command_result.stderr}",
+        )
+        self.assertEqual(command_result.stdout, "")
+        self.assertEqual(command_result.stderr, "")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/skills/agent-nebius-auth/scripts/test_pre_tool_use_nebius_auth.py
+++ b/skills/agent-nebius-auth/scripts/test_pre_tool_use_nebius_auth.py
@@ -85,6 +85,9 @@ class PreToolUseNebiusAuthTest(unittest.TestCase):
     def evaluate_command(self, command: str) -> dict[str, object]:
         return self.hook.evaluate(self.payload(command))
 
+    def clear_project_env(self) -> None:
+        os.environ.pop(PROJECT_ENV, None)
+
     def updated_command(self, command: str) -> str:
         result = self.evaluate_command(command)
         return result["hookSpecificOutput"]["updatedInput"]["command"]
@@ -172,6 +175,32 @@ class PreToolUseNebiusAuthTest(unittest.TestCase):
 
     def test_missing_credential_denies_sensitive_command(self) -> None:
         self.credential_file.unlink()
+
+        result = self.evaluate_command(f"curl https://{service_host()}/")
+
+        self.assertEqual(
+            result["hookSpecificOutput"]["permissionDecision"],
+            "deny",
+        )
+
+    def test_default_project_file_selects_profile_with_multiple_credentials(self) -> None:
+        self.clear_project_env()
+        other = self.credential_dir / "codex-agent-authkey.project-other.json"
+        other.write_text("{}", encoding="utf-8")
+        (self.credential_dir / "codex-agent-default-project-id").write_text(
+            f"{PROJECT}\n",
+            encoding="utf-8",
+        )
+
+        command = self.updated_command(f"curl https://{service_host()}/")
+
+        self.assertIn(sensitive_command(), command)
+        self.assertIn(f"export NEBIUS_PROJECT_ID={PROJECT}", command)
+
+    def test_multiple_credentials_without_default_project_denies(self) -> None:
+        self.clear_project_env()
+        other = self.credential_dir / "codex-agent-authkey.project-other.json"
+        other.write_text("{}", encoding="utf-8")
 
         result = self.evaluate_command(f"curl https://{service_host()}/")
 

--- a/skills/install-skills.sh
+++ b/skills/install-skills.sh
@@ -761,6 +761,167 @@ print_extra_destination_hooks() {
   print_extra_hook_registrations "${codex_home}" "$@"
 }
 
+has_agent_nebius_auth_hook_source() {
+  local hook_src=""
+
+  for hook_src in "$@"; do
+    if [[ -f "${hook_src}/pre_tool_use_nebius_auth.py" ]]; then
+      return 0
+    fi
+  done
+
+  return 1
+}
+
+legacy_agent_nebius_auth_config_hook_migration() {
+  local mode="$1"
+  local codex_home="$2"
+
+  shift 2
+  has_agent_nebius_auth_hook_source "$@" || return 0
+  command -v python3 >/dev/null 2>&1 || return 0
+
+  python3 - "${mode}" "${codex_home}" <<'PY'
+from __future__ import annotations
+
+import os
+from pathlib import Path
+import re
+import shutil
+import stat
+import sys
+import tempfile
+from datetime import datetime, timezone
+
+
+def fail(message: str) -> None:
+    print(f"ERROR: {message}", file=sys.stderr)
+    raise SystemExit(1)
+
+
+mode = sys.argv[1]
+codex_home = Path(sys.argv[2]).expanduser()
+config = codex_home / "config.toml"
+begin_marker = "# agent-nebius-auth managed block begin"
+end_marker = "# agent-nebius-auth managed block end"
+selector = Path.home() / ".nebius" / "codex-agent-default-project-id"
+project_id_re = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:-]*$")
+
+if mode not in {"check", "migrate"}:
+    fail(f"unsupported legacy agent-nebius-auth migration mode: {mode}")
+
+if not config.exists():
+    raise SystemExit(0)
+
+lines = config.read_text(encoding="utf-8").splitlines(keepends=True)
+kept: list[str] = []
+current_block: list[str] = []
+blocks: list[str] = []
+skipping = False
+
+for line in lines:
+    stripped = line.rstrip("\n")
+    if stripped == begin_marker:
+        if skipping:
+            fail(f"{config} contains nested agent-nebius-auth managed blocks")
+        skipping = True
+        current_block = [line]
+        if kept and kept[-1].strip() == "":
+            kept.pop()
+        continue
+    if stripped == end_marker:
+        if not skipping:
+            fail(f"{config} contains an agent-nebius-auth block end without a begin")
+        current_block.append(line)
+        blocks.append("".join(current_block))
+        current_block = []
+        skipping = False
+        continue
+    if skipping:
+        current_block.append(line)
+    else:
+        kept.append(line)
+
+if skipping:
+    fail(f"{config} contains an agent-nebius-auth block begin without an end")
+
+if not blocks:
+    raise SystemExit(0)
+
+project_ids: set[str] = set()
+for block in blocks:
+    for match in re.finditer(r"\bCODEX_NEBIUS_PROJECT_ID=([A-Za-z0-9._:-]+)", block):
+        project_ids.add(match.group(1))
+
+if len(project_ids) > 1:
+    fail(
+        f"{config} contains multiple legacy agent-nebius-auth project selectors. "
+        "Set ~/.nebius/codex-agent-default-project-id manually and remove the "
+        "legacy block before rerunning."
+    )
+
+project_id = next(iter(project_ids), "")
+if project_id and not project_id_re.fullmatch(project_id):
+    fail(f"{config} contains an invalid legacy agent-nebius-auth project selector")
+
+selector_message = ""
+if project_id:
+    existing_selector = ""
+    if selector.exists():
+        existing_selector = selector.read_text(encoding="utf-8").strip()
+    if existing_selector and existing_selector != project_id:
+        fail(
+            f"{selector} already selects a different project. Choose the intended "
+            "project manually before removing the legacy agent-nebius-auth block."
+        )
+
+if mode == "check":
+    raise SystemExit(0)
+
+if project_id:
+    if not existing_selector:
+        selector.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
+        temp_fd, temp_name = tempfile.mkstemp(
+            prefix=f".{selector.name}.", dir=str(selector.parent)
+        )
+        with os.fdopen(temp_fd, "w", encoding="utf-8") as handle:
+            handle.write(f"{project_id}\n")
+        os.chmod(temp_name, 0o600)
+        os.replace(temp_name, selector)
+        selector_message = "Migrated legacy agent-nebius-auth project selector to ~/.nebius/codex-agent-default-project-id"
+    else:
+        selector_message = "Legacy agent-nebius-auth project selector already matched ~/.nebius/codex-agent-default-project-id"
+
+backup = config.with_name(
+    f"config.toml.bak.agent-nebius-auth.{datetime.now(timezone.utc).strftime('%Y%m%d%H%M%S%f')}"
+)
+shutil.copy2(config, backup)
+mode = stat.S_IMODE(config.stat().st_mode)
+fd, temp_name = tempfile.mkstemp(prefix=".config.toml.", dir=str(codex_home))
+try:
+    with os.fdopen(fd, "w", encoding="utf-8") as handle:
+        handle.write("".join(kept))
+    os.chmod(temp_name, mode)
+    os.replace(temp_name, config)
+finally:
+    if os.path.exists(temp_name):
+        os.unlink(temp_name)
+
+print(f"Removed legacy agent-nebius-auth inline config hook block(s): {len(blocks)} -> {config}")
+print(f"Backed up previous config.toml: {backup}")
+if selector_message:
+    print(selector_message)
+PY
+}
+
+check_legacy_agent_nebius_auth_config_hook_migration() {
+  legacy_agent_nebius_auth_config_hook_migration "check" "$@"
+}
+
+migrate_legacy_agent_nebius_auth_config_hook() {
+  legacy_agent_nebius_auth_config_hook_migration "migrate" "$@"
+}
+
 register_hooks_manifests() {
   local codex_home="$1"
   local replace_hooks_json="$2"
@@ -1103,6 +1264,7 @@ install_hooks() {
       log_note "Place the registration manifest in the hook directory or its parent directory."
       exit 1
     fi
+    check_legacy_agent_nebius_auth_config_hook_migration "${codex_home}" "${hook_src}"
   fi
 
   mkdir -p "${hook_dest}"
@@ -1134,6 +1296,7 @@ install_hooks() {
   log_note "Template suffixes were stripped for installed hook files."
   if [[ "${register_hooks}" -eq 1 ]]; then
     register_hooks_manifest "${hook_src}" "${codex_home}" "${replace_hooks_json}"
+    migrate_legacy_agent_nebius_auth_config_hook "${codex_home}" "${hook_src}"
   else
     log_note "This did not modify hooks.json. Pass --register-hooks to merge a source registration manifest."
   fi
@@ -1256,6 +1419,7 @@ install_all_hooks() {
         exit 1
       fi
     done
+    check_legacy_agent_nebius_auth_config_hook_migration "${codex_home}" "${hook_dirs[@]}"
   fi
 
   log_note "Discovered hook source directories:"
@@ -1270,6 +1434,7 @@ install_all_hooks() {
 
   if [[ "${register_hooks}" -eq 1 ]]; then
     register_hooks_manifests "${codex_home}" "${replace_hooks_json}" "${hook_dirs[@]}"
+    migrate_legacy_agent_nebius_auth_config_hook "${codex_home}" "${hook_dirs[@]}"
   else
     log_note "This did not modify hooks.json. Pass --register-hooks to merge discovered source registration manifests."
   fi


### PR DESCRIPTION
## Summary
- document the Soperator cluster upgrade flow in cxcli docs and keep docs-alignment coverage in sync
- align the agent Nebius auth skill with root hook installation and registration workflows
- add hook migration coverage and update skill installation docs/changelog entries

## Validation
- `git merge-tree --write-tree origin/main HEAD`
- `git merge --no-edit origin/main`
- `git diff --check origin/main...HEAD`
- `PYTHONDONTWRITEBYTECODE=1 python3 -B scripts/test_pre_tool_use_nebius_auth.py`
- `PYTHONDONTWRITEBYTECODE=1 python3 -B scripts/test_agent_nebius_auth_setup.py`
- `PYTHONDONTWRITEBYTECODE=1 python3 -B scripts/test_install_hook_migration.py`
- `services/nebius-cxcli/.venv/bin/python -m pytest tests/test_docs_alignment.py`
- `shellcheck install-skills.sh agent-nebius-auth/scripts/agent-nebius-auth.sh`
- `bash -n install-skills.sh agent-nebius-auth/scripts/agent-nebius-auth.sh`
- `python3 -m json.tool agent-nebius-auth/assets/hooks.json.template >/dev/null`
- `python3 -B align-skill/scripts/validate-skill-structure.py agent-nebius-auth`
- `markdownlint agent-nebius-auth/SKILL.md agent-nebius-auth/README.md README.md CHANGELOG.md`
