### PR TITLE
Prepare nebius-vpngw v0.5.9 release

### DIFF
--- a/.github/workflows/vpngw-ci.yml
+++ b/.github/workflows/vpngw-ci.yml
@@ -61,7 +61,9 @@ jobs:
         run: |
           set -euo pipefail
           bash -n misc/gcp-vpngw.sh
+          bash -n misc/fix-vpngw-esp4.sh
           ./misc/gcp-vpngw.sh --help >/dev/null
+          ./misc/fix-vpngw-esp4.sh --help >/dev/null
       - name: Ruff
         run: python -m ruff check src tests
 

--- a/.github/workflows/vpngw-release.yml
+++ b/.github/workflows/vpngw-release.yml
@@ -119,7 +119,9 @@ jobs:
         run: |
           set -euo pipefail
           bash -n misc/gcp-vpngw.sh
+          bash -n misc/fix-vpngw-esp4.sh
           ./misc/gcp-vpngw.sh --help >/dev/null
+          ./misc/fix-vpngw-esp4.sh --help >/dev/null
 
       - name: Lint
         if: steps.state.outputs.release_exists == 'false'

--- a/.github/workflows/vpngw-release.yml
+++ b/.github/workflows/vpngw-release.yml
@@ -144,9 +144,8 @@ jobs:
         id: asset
         run: |
           set -euo pipefail
-          shopt -s nullglob
-          assets=( ${ASSET_GLOB} )
-          shopt -u nullglob
+          assets=()
+          mapfile -t assets < <(compgen -G "${ASSET_GLOB}" | sort)
           if [[ "${#assets[@]}" -eq 0 ]]; then
             echo "::error::No release asset found with glob ${ASSET_GLOB}"
             exit 1

--- a/services/vpngw/CHANGELOG.md
+++ b/services/vpngw/CHANGELOG.md
@@ -14,6 +14,8 @@ All notable changes to this project are tracked here. This changelog follows
 
 ## [Unreleased]
 
+## [nebius-vpngw-v0.5.9] - 2026-07-07
+
 - Added an ESP4 readiness preflight for new gateway VMs and a
   `misc/fix-vpngw-esp4.sh` repair helper for existing gateways affected by
   Ubuntu Dirty Frag module-block mitigations.

--- a/services/vpngw/CHANGELOG.md
+++ b/services/vpngw/CHANGELOG.md
@@ -19,6 +19,8 @@ All notable changes to this project are tracked here. This changelog follows
   Ubuntu Dirty Frag module-block mitigations.
 - Added a project mypy check and fixed current static typing errors in the
   VPN gateway source tree.
+- Fixed local and release wheel builds by declaring the `vcs-versioning`
+  provider required for the configured `semver-pep440` version scheme.
 - Fixed route command SSH handling so `add-routes-local` BGP route discovery and
   `list-routes-remote` gateway queries honor configured SSH user and private key
   settings.

--- a/services/vpngw/CHANGELOG.md
+++ b/services/vpngw/CHANGELOG.md
@@ -23,6 +23,8 @@ All notable changes to this project are tracked here. This changelog follows
   VPN gateway source tree.
 - Fixed local and release wheel builds by declaring the `vcs-versioning`
   provider required for the configured `semver-pep440` version scheme.
+- Fixed release workflow artifact glob resolution so actionlint/shellcheck
+  validation does not depend on unsafe word splitting.
 - Fixed route command SSH handling so `add-routes-local` BGP route discovery and
   `list-routes-remote` gateway queries honor configured SSH user and private key
   settings.

--- a/services/vpngw/CHANGELOG.md
+++ b/services/vpngw/CHANGELOG.md
@@ -14,6 +14,9 @@ All notable changes to this project are tracked here. This changelog follows
 
 ## [Unreleased]
 
+- Added an ESP4 readiness preflight for new gateway VMs and a
+  `misc/fix-vpngw-esp4.sh` repair helper for existing gateways affected by
+  Ubuntu Dirty Frag module-block mitigations.
 - Added a project mypy check and fixed current static typing errors in the
   VPN gateway source tree.
 - Fixed route command SSH handling so `add-routes-local` BGP route discovery and

--- a/services/vpngw/README.md
+++ b/services/vpngw/README.md
@@ -1350,6 +1350,8 @@ Applied at VM creation:
 - UFW firewall (allows IPsec UDP 500/4500, ESP)
 - auditd for command auditing
 - Automated security updates (unattended-upgrades)
+- ESP4 preflight that removes only `esp4` deny rules left by temporary
+  Dirty Frag mitigations, then gates VPN services until ESP4 is loadable
 - IP forwarding enabled, ICMP redirects disabled
 
 ### Dynamic Firewall
@@ -1416,6 +1418,40 @@ sudo ipsec statusall
 sudo journalctl -u strongswan-starter -f
 sudo journalctl -u nebius-vpngw-agent -f
 ```
+
+### ESP4 Blocked After Dirty Frag Mitigation
+
+Some Ubuntu images temporarily blocked the kernel `esp4` module under
+`/etc/modprobe.d` as a mitigation for Dirty Frag kernel issues. This gateway
+requires IPv4 ESP for strongSwan/XFRM; if `esp4` remains blocked, IKE can
+establish but ESP CHILD_SAs fail to install in the kernel.
+
+New gateway VMs run an automatic preflight during cloud-init:
+
+- package upgrades still run as usual
+- only `esp4` block lines are commented out with a `nebius-vpngw` marker
+- `esp6`, `rxrpc`, and unrelated module policy are left unchanged
+- if an `esp4` policy change or kernel update requires reboot, config push
+  waits until the VM has rebooted and `modprobe esp4` succeeds
+
+Fixed future images take the no-op path unless Ubuntu package upgrades require
+a reboot.
+
+For an existing gateway that suddenly loses ESP4, use the repair helper from a
+source checkout:
+
+```bash
+./misc/fix-vpngw-esp4.sh --local-config-file <local-config-file>
+# or:
+./misc/fix-vpngw-esp4.sh --host ubuntu@<gateway-ip>
+```
+
+The helper prints all target gateways and requires typing `REBOOT` unless
+`--yes` is passed. It upgrades packages, applies the same ESP4 preflight,
+reboots each gateway serially, confirms the remote boot ID changed, verifies
+`modprobe esp4`, and restarts `strongswan-starter` and `nebius-vpngw-agent`.
+VPN traffic through the target gateway is disrupted for a few minutes during
+reboot.
 
 ### BGP Issues
 

--- a/services/vpngw/doc/design.md
+++ b/services/vpngw/doc/design.md
@@ -1174,7 +1174,9 @@ sysctl --system (loads 99-zzz-vpngw.conf)
     ↓
 ufw.service (firewall)
     ↓
-strongswan.service (IPsec)
+nebius-vpngw-esp4-preflight.service
+    ↓
+strongswan-starter.service (IPsec)
     ↓
 frr.service (BGP)
     ↓
@@ -1191,10 +1193,11 @@ Each service has a systemd override in `/etc/systemd/system/<service>.d/override
 After=network-online.target cloud-init.service
 Wants=network-online.target
 
-# /etc/systemd/system/strongswan.service.d/override.conf
+# /etc/systemd/system/strongswan-starter.service.d/override.conf
 [Unit]
-After=ufw.service network-online.target
+After=nebius-vpngw-esp4-preflight.service ufw.service network-online.target
 Wants=ufw.service
+Requires=nebius-vpngw-esp4-preflight.service
 
 # /etc/systemd/system/frr.service.d/override.conf
 [Unit]
@@ -1210,6 +1213,8 @@ Wants=strongswan.service frr.service
 **Why This Ordering Matters:**
 
 - **UFW after cloud-init**: Prevents cloud-init network changes from racing with UFW
+- **ESP4 preflight before strongSwan**: Ensures the IPv4 ESP kernel module is
+  loadable before strongSwan tries to install CHILD_SAs into XFRM
 - **strongSwan after UFW**: Ensures netfilter framework is initialized before IPsec tunnels
 - **FRR after strongSwan**: BGP needs XFRM interfaces created by strongSwan
 - **Agent after FRR**: Routing guard validates routes installed by FRR
@@ -1353,6 +1358,9 @@ ip route show 169.254.169.0/24  # Metadata service OK
 - UFW firewall (allows IPsec UDP 500/4500, ESP)
 - auditd for command and config file monitoring
 - Automated security updates (unattended-upgrades)
+- ESP4 module preflight that removes only temporary `esp4` deny rules, leaves
+  `esp6`/`rxrpc` policy untouched, and gates VPN services until `esp4` is
+  loadable after any required reboot
 - IP forwarding enabled, ICMP redirects disabled
 
 ### CRITICAL: UFW Must Be Active

--- a/services/vpngw/misc/README.md
+++ b/services/vpngw/misc/README.md
@@ -7,6 +7,36 @@ This folder contains deployment helpers that are separate from the installed
 
 - `gcp-vpngw.sh`: configure one GCP-side HA VPN connection to a Nebius VPN
   gateway and print the matching Nebius `connections:` block.
+- `fix-vpngw-esp4.sh`: repair gateway VMs where the Ubuntu image or a temporary
+  Dirty Frag mitigation left the required `esp4` module blocked.
+
+## `fix-vpngw-esp4.sh`
+
+`fix-vpngw-esp4.sh` is an operational repair helper for existing gateway VMs.
+It uploads and runs the same packaged ESP4 preflight used during new-VM
+provisioning, upgrades Ubuntu packages, reboots each target gateway serially,
+confirms the remote boot ID changed, verifies `modprobe esp4`, and restarts the
+gateway services.
+
+The script requires typed `REBOOT` confirmation unless `--yes` is supplied
+because VPN traffic through each target is disrupted for a few minutes.
+
+Common forms:
+
+```bash
+./misc/fix-vpngw-esp4.sh --host ubuntu@<gateway-ip>
+./misc/fix-vpngw-esp4.sh --local-config-file <local-config-file>
+./misc/fix-vpngw-esp4.sh --host <gateway-ip> \
+  --ssh-user ubuntu --identity-file ~/.ssh/id_ed25519
+```
+
+Useful options:
+
+- `--host <user@ip>`: add one target gateway; repeat for multiple gateways
+- `--local-config-file <path>`: discover targets from `gateway_group.external_ips`
+- `--dry-run`: print planned actions without connecting or rebooting
+- `--wait-timeout <seconds>`: change the post-reboot SSH wait timeout
+- `--yes`: skip the typed confirmation for automation
 
 ## `gcp-vpngw.sh`
 

--- a/services/vpngw/misc/fix-vpngw-esp4.sh
+++ b/services/vpngw/misc/fix-vpngw-esp4.sh
@@ -1,0 +1,478 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+S_RESET=""
+S_BOLD=""
+S_DIM=""
+S_RED=""
+S_YELLOW=""
+S_GREEN=""
+S_CYAN=""
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
+PROJECT_ROOT="$(cd -- "${SCRIPT_DIR}/.." && pwd -P)"
+HELPER_SRC="${PROJECT_ROOT}/src/nebius_vpngw/systemd/nebius-vpngw-esp4-preflight.sh"
+REMOTE_TMP_HELPER="/tmp/nebius-vpngw-esp4-preflight.sh"
+
+LOCAL_CONFIG_FILE="${LOCAL_CONFIG_FILE:-}"
+SSH_USER="${VPNGW_SSH_USER:-ubuntu}"
+IDENTITY_FILE="${VPNGW_SSH_KEY:-}"
+YES=0
+DRY_RUN=0
+WAIT_TIMEOUT=900
+HOSTS=()
+SUMMARY=()
+
+init_output_style() {
+  if [[ ( -t 1 || -t 2 ) && "${TERM:-}" != "dumb" && -z "${NO_COLOR:-}" ]]; then
+    S_RESET=$'\033[0m'
+    S_BOLD=$'\033[1m'
+    S_DIM=$'\033[2m'
+    S_RED=$'\033[31m'
+    S_YELLOW=$'\033[33m'
+    S_GREEN=$'\033[32m'
+    S_CYAN=$'\033[36m'
+  fi
+}
+
+log_error() {
+  printf '%b\n' "${S_RED}${S_BOLD}ERROR:${S_RESET}${S_RED} $*${S_RESET}" >&2
+}
+
+log_warn() {
+  printf '%b\n' "${S_YELLOW}$*${S_RESET}" >&2
+}
+
+log_note() {
+  printf '%b\n' "${S_DIM}$*${S_RESET}"
+}
+
+log_success() {
+  printf '%b\n' "${S_GREEN}$*${S_RESET}"
+}
+
+show_usage() {
+  local script_ref="${0}"
+
+  if [[ "${script_ref}" != /* && "${script_ref}" != ./* ]]; then
+    script_ref="./${script_ref}"
+  fi
+
+  printf '%b\n' "${S_BOLD}Usage:${S_RESET}"
+  printf '%b\n' "  ${S_CYAN}${script_ref}${S_RESET} ${S_DIM}--host <user@ip> [--host <user@ip> ...]${S_RESET}"
+  printf '%b\n' "  ${S_CYAN}${script_ref}${S_RESET} ${S_DIM}--local-config-file <path>${S_RESET}"
+  printf '\n'
+  printf '%b\n' "${S_BOLD}Options:${S_RESET}"
+  printf '  %-28s %s\n' "--host TARGET" "Gateway SSH target; repeatable. If no user is supplied, --ssh-user is used."
+  printf '  %-28s %s\n' "-c, --local-config-file PATH" "Discover gateway public IPs from gateway_group.external_ips."
+  printf '  %-28s %s\n' "--ssh-user USER" "Default SSH user for bare IP hosts (default: ubuntu)."
+  printf '  %-28s %s\n' "--identity-file PATH" "SSH private key path."
+  printf '  %-28s %s\n' "--wait-timeout SECONDS" "Time to wait for SSH after reboot (default: 900)."
+  printf '  %-28s %s\n' "--dry-run" "Print planned actions without connecting or rebooting."
+  printf '  %-28s %s\n' "--yes" "Skip typed REBOOT confirmation."
+  printf '  %-28s %s\n' "-h, --help" "Show help."
+  printf '\n'
+  printf '%b\n' "${S_BOLD}Examples:${S_RESET}"
+  printf '%b\n' "  ${S_CYAN}${script_ref} --host ubuntu@203.0.113.10${S_RESET}"
+  printf '%b\n' "  ${S_CYAN}${script_ref} --local-config-file nebius-vpngw.config.yaml${S_RESET}"
+  printf '%b\n' "  ${S_CYAN}${script_ref} --host 203.0.113.10 --ssh-user ubuntu --identity-file ~/.ssh/id_ed25519${S_RESET}"
+}
+
+expand_path() {
+  local path="$1"
+  case "${path}" in
+    \~/*) printf '%s/%s' "${HOME}" "${path#\~/}" ;;
+    *) printf '%s' "${path}" ;;
+  esac
+}
+
+require_integer() {
+  local value="$1"
+  local label="$2"
+  if [[ ! "${value}" =~ ^[0-9]+$ || "${value}" == "0" ]]; then
+    log_error "${label} must be a positive integer"
+    exit 1
+  fi
+}
+
+parse_args() {
+  while (($#)); do
+    case "$1" in
+      --host)
+        if [[ $# -lt 2 || -z "${2:-}" ]]; then
+          log_error "--host requires a value"
+          exit 1
+        fi
+        HOSTS+=("$2")
+        shift 2
+        ;;
+      -c|--local-config-file)
+        if [[ $# -lt 2 || -z "${2:-}" ]]; then
+          log_error "--local-config-file requires a value"
+          exit 1
+        fi
+        LOCAL_CONFIG_FILE="$2"
+        shift 2
+        ;;
+      --ssh-user)
+        if [[ $# -lt 2 || -z "${2:-}" ]]; then
+          log_error "--ssh-user requires a value"
+          exit 1
+        fi
+        SSH_USER="$2"
+        shift 2
+        ;;
+      --identity-file)
+        if [[ $# -lt 2 || -z "${2:-}" ]]; then
+          log_error "--identity-file requires a value"
+          exit 1
+        fi
+        IDENTITY_FILE="$2"
+        shift 2
+        ;;
+      --wait-timeout)
+        if [[ $# -lt 2 || -z "${2:-}" ]]; then
+          log_error "--wait-timeout requires a value"
+          exit 1
+        fi
+        WAIT_TIMEOUT="$2"
+        require_integer "${WAIT_TIMEOUT}" "--wait-timeout"
+        shift 2
+        ;;
+      --yes)
+        YES=1
+        shift
+        ;;
+      --dry-run)
+        DRY_RUN=1
+        shift
+        ;;
+      -h|--help)
+        show_usage
+        exit 0
+        ;;
+      *)
+        log_error "Unknown option: $1"
+        show_usage >&2
+        exit 1
+        ;;
+    esac
+  done
+}
+
+discover_config_identity() {
+  local config_file="$1"
+
+  if [[ -n "${IDENTITY_FILE}" ]]; then
+    return 0
+  fi
+
+  IDENTITY_FILE="$(
+    python3 - "${config_file}" <<'PY'
+from pathlib import Path
+import sys
+
+try:
+    import yaml
+except Exception as exc:
+    print(f"failed to import PyYAML: {exc}", file=sys.stderr)
+    raise SystemExit(2)
+
+cfg = yaml.safe_load(Path(sys.argv[1]).read_text(encoding="utf-8")) or {}
+vm_spec = (cfg.get("gateway_group") or {}).get("vm_spec") or {}
+print(str(vm_spec.get("ssh_private_key_path") or ""))
+PY
+  )"
+}
+
+discover_config_hosts() {
+  local config_file="$1"
+
+  if [[ ! -f "${config_file}" ]]; then
+    log_error "Config file not found: ${config_file}"
+    exit 1
+  fi
+
+  discover_config_identity "${config_file}"
+
+  while IFS= read -r target; do
+    [[ -n "${target}" ]] || continue
+    HOSTS+=("${target}")
+  done < <(
+    python3 - "${config_file}" "${SSH_USER}" <<'PY'
+from pathlib import Path
+import sys
+
+try:
+    import yaml
+except Exception as exc:
+    print(f"failed to import PyYAML: {exc}", file=sys.stderr)
+    raise SystemExit(2)
+
+cfg = yaml.safe_load(Path(sys.argv[1]).read_text(encoding="utf-8")) or {}
+gateway_group = cfg.get("gateway_group") or {}
+vm_spec = gateway_group.get("vm_spec") or {}
+ssh_user = str(vm_spec.get("ssh_username") or sys.argv[2] or "").strip()
+external_ips = gateway_group.get("external_ips") or []
+
+targets = []
+for entry in external_ips:
+    if isinstance(entry, str):
+        candidates = [entry]
+    elif isinstance(entry, list):
+        candidates = entry
+    else:
+        continue
+    for candidate in candidates:
+        ip = str(candidate or "").strip()
+        if not ip or ip.startswith("${"):
+            continue
+        targets.append(f"{ssh_user}@{ip}" if ssh_user and "@" not in ip else ip)
+
+for target in dict.fromkeys(targets):
+    print(target)
+PY
+  )
+}
+
+normalize_target() {
+  local target="$1"
+
+  if [[ "${target}" == *@* ]]; then
+    printf '%s' "${target}"
+  else
+    printf '%s@%s' "${SSH_USER}" "${target}"
+  fi
+}
+
+build_ssh_cmd() {
+  local target="$1"
+  SSH_CMD=(ssh)
+  if [[ -n "${IDENTITY_FILE}" ]]; then
+    SSH_CMD+=(-i "$(expand_path "${IDENTITY_FILE}")")
+  fi
+  SSH_CMD+=(
+    -o StrictHostKeyChecking=no
+    -o UserKnownHostsFile=/dev/null
+    -o ConnectTimeout=10
+    -o LogLevel=ERROR
+    "${target}"
+  )
+}
+
+build_scp_cmd() {
+  SCP_CMD=(scp)
+  if [[ -n "${IDENTITY_FILE}" ]]; then
+    SCP_CMD+=(-i "$(expand_path "${IDENTITY_FILE}")")
+  fi
+  SCP_CMD+=(
+    -o StrictHostKeyChecking=no
+    -o UserKnownHostsFile=/dev/null
+    -o ConnectTimeout=10
+    -o LogLevel=ERROR
+  )
+}
+
+get_remote_boot_id() {
+  local target="$1"
+  local boot_id=""
+
+  build_ssh_cmd "${target}"
+  boot_id="$("${SSH_CMD[@]}" "cat /proc/sys/kernel/random/boot_id" 2>/dev/null)"
+  boot_id="${boot_id//$'\r'/}"
+  boot_id="${boot_id//$'\n'/}"
+
+  if [[ -z "${boot_id}" ]]; then
+    return 1
+  fi
+
+  printf '%s' "${boot_id}"
+}
+
+print_targets() {
+  printf '%b\n' "${S_BOLD}Target gateway(s):${S_RESET}"
+  local target=""
+  for target in "${HOSTS[@]}"; do
+    printf '  - %s\n' "$(normalize_target "${target}")"
+  done
+}
+
+confirm_reboot() {
+  local reply=""
+
+  print_targets
+  printf '\n'
+  printf '%b\n' "${S_YELLOW}This will upgrade packages and reboot each VPN gateway serially.${S_RESET}"
+  printf '%b\n' "${S_YELLOW}VPN traffic through each target will be disrupted for a few minutes.${S_RESET}"
+
+  if [[ "${DRY_RUN}" -eq 1 || "${YES}" -eq 1 ]]; then
+    return 0
+  fi
+
+  printf '%b' "${S_BOLD}Type REBOOT to continue:${S_RESET} "
+  if ! read -r reply; then
+    printf '\n' >&2
+    log_error "Confirmation aborted."
+    exit 1
+  fi
+
+  if [[ "${reply}" != "REBOOT" ]]; then
+    log_warn "Cancelled. No gateway was changed."
+    exit 1
+  fi
+}
+
+validate_inputs() {
+  if [[ -n "${LOCAL_CONFIG_FILE}" ]]; then
+    discover_config_hosts "${LOCAL_CONFIG_FILE}"
+  fi
+
+  if [[ "${#HOSTS[@]}" -eq 0 ]]; then
+    log_error "No gateway targets found. Use --host or --local-config-file."
+    exit 1
+  fi
+
+  if [[ ! -f "${HELPER_SRC}" ]]; then
+    log_error "ESP4 helper not found: ${HELPER_SRC}"
+    exit 1
+  fi
+}
+
+upload_helper() {
+  local target="$1"
+
+  build_scp_cmd
+  "${SCP_CMD[@]}" "${HELPER_SRC}" "${target}:${REMOTE_TMP_HELPER}"
+}
+
+run_remote_prepare_and_reboot() {
+  local target="$1"
+
+  build_ssh_cmd "${target}"
+  "${SSH_CMD[@]}" "sudo bash -s" <<'REMOTE'
+set -euo pipefail
+
+install -m 0755 -o root -g root /tmp/nebius-vpngw-esp4-preflight.sh /usr/local/bin/nebius-vpngw-esp4-preflight.sh
+apt-get update
+DEBIAN_FRONTEND=noninteractive apt-get upgrade -y
+
+set +e
+/usr/local/bin/nebius-vpngw-esp4-preflight.sh --prepare
+rc=$?
+set -e
+if [[ "${rc}" -ne 0 && "${rc}" -ne 75 ]]; then
+  exit "${rc}"
+fi
+
+systemctl reboot --no-block
+REMOTE
+}
+
+wait_for_rebooted_ssh() {
+  local target="$1"
+  local previous_boot_id="$2"
+  local deadline=$((SECONDS + WAIT_TIMEOUT))
+  local current_boot_id=""
+
+  while ((SECONDS < deadline)); do
+    if current_boot_id="$(get_remote_boot_id "${target}")"; then
+      if [[ "${current_boot_id}" != "${previous_boot_id}" ]]; then
+        return 0
+      fi
+    fi
+    sleep 5
+  done
+
+  return 1
+}
+
+run_remote_verify_and_restart() {
+  local target="$1"
+
+  build_ssh_cmd "${target}"
+  "${SSH_CMD[@]}" "sudo bash -s" <<'REMOTE'
+set -euo pipefail
+
+/usr/local/bin/nebius-vpngw-esp4-preflight.sh --verify
+
+if systemctl list-unit-files strongswan-starter.service >/dev/null 2>&1; then
+  systemctl restart strongswan-starter
+elif systemctl list-unit-files strongswan.service >/dev/null 2>&1; then
+  systemctl restart strongswan
+fi
+
+systemctl restart nebius-vpngw-agent
+
+if systemctl list-unit-files strongswan-starter.service >/dev/null 2>&1; then
+  systemctl is-active strongswan-starter
+elif systemctl list-unit-files strongswan.service >/dev/null 2>&1; then
+  systemctl is-active strongswan
+else
+  echo "strongSwan service not found"
+fi
+systemctl is-active nebius-vpngw-agent
+REMOTE
+}
+
+repair_target() {
+  local raw_target="$1"
+  local target=""
+  local previous_boot_id=""
+
+  target="$(normalize_target "${raw_target}")"
+
+  printf '%b\n' "${S_BOLD}Repairing ${target}${S_RESET}"
+  if [[ "${DRY_RUN}" -eq 1 ]]; then
+    log_note "Dry run: would upload ${HELPER_SRC}"
+    log_note "Dry run: would run apt-get update && apt-get upgrade -y"
+    log_note "Dry run: would run ESP4 preflight, reboot, confirm boot ID changed, verify, and restart services"
+    SUMMARY+=("${target}: dry-run")
+    return 0
+  fi
+
+  log_note "Uploading ESP4 helper"
+  upload_helper "${target}"
+
+  log_note "Capturing current boot ID"
+  if ! previous_boot_id="$(get_remote_boot_id "${target}")"; then
+    log_error "Could not read boot ID from ${target}"
+    return 1
+  fi
+
+  log_note "Running package upgrade, ESP4 preflight, and reboot"
+  run_remote_prepare_and_reboot "${target}"
+
+  log_note "Waiting for SSH after reboot"
+  sleep 10
+  if ! wait_for_rebooted_ssh "${target}" "${previous_boot_id}"; then
+    log_error "Timed out waiting for ${target} to reboot and return over SSH"
+    return 1
+  fi
+
+  log_note "Verifying ESP4 and restarting gateway services"
+  run_remote_verify_and_restart "${target}"
+
+  log_success "${target}: ESP4 ready and gateway services restarted"
+  SUMMARY+=("${target}: repaired")
+}
+
+main() {
+  init_output_style
+  parse_args "$@"
+  validate_inputs
+  confirm_reboot
+
+  local target=""
+  for target in "${HOSTS[@]}"; do
+    repair_target "${target}"
+  done
+
+  printf '\n%b\n' "${S_BOLD}Summary:${S_RESET}"
+  for target in "${SUMMARY[@]}"; do
+    printf '  - %s\n' "${target}"
+  done
+}
+
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+  main "$@"
+fi

--- a/services/vpngw/pyproject.toml
+++ b/services/vpngw/pyproject.toml
@@ -34,7 +34,8 @@ dev = [
 	"ruff>=0.14.0,<1.0.0",
 	"pyinstaller>=6.17.0,<7.0.0",
 	"build>=1.3.0,<2.0.0",
-	"setuptools-scm>=8",
+	"setuptools-scm>=9.2",
+	"vcs-versioning>=2.2.2,<3.0.0",
 	"types-PyYAML>=6.0.12,<7.0.0"
 ]
 
@@ -130,5 +131,5 @@ source = ["nebius_vpngw"]
 skip_empty = true
 
 [build-system]
-requires = ["setuptools>=64", "setuptools-scm>=8"]
+requires = ["setuptools>=80", "setuptools-scm>=9.2", "vcs-versioning>=2.2.2,<3.0.0"]
 build-backend = "setuptools.build_meta"

--- a/services/vpngw/src/nebius_vpngw/cli.py
+++ b/services/vpngw/src/nebius_vpngw/cli.py
@@ -754,6 +754,32 @@ def _should_prompt_add_routes_after_apply(
     )
 
 
+def _vm_ready_for_config_push(health: dict[str, t.Any]) -> bool:
+    """Return True when it is safe to SSH-push gateway config."""
+    return bool(
+        health.get("reachable")
+        and health.get("cloud_init_complete")
+        and health.get("esp4_ready", True)
+        and not health.get("esp4_reboot_pending", False)
+    )
+
+
+def _vm_packages_verified(health: dict[str, t.Any]) -> bool:
+    """Return True when bootstrap packages were verified on the VM."""
+    return bool(health.get("strongswan_installed") and health.get("frr_installed"))
+
+
+def _print_vm_wait_reason(vm_name: str, health: dict[str, t.Any]) -> None:
+    if not health.get("reachable"):
+        print(f"[dim]{vm_name}: SSH not ready yet[/dim]")
+    elif not health.get("cloud_init_complete"):
+        print(f"[dim]{vm_name}: Cloud-init still running (packages being installed)[/dim]")
+    elif health.get("esp4_reboot_pending"):
+        print(f"[dim]{vm_name}: ESP4/kernel update prepared; waiting for reboot[/dim]")
+    elif not health.get("esp4_ready", True):
+        print(f"[dim]{vm_name}: ESP4 is not loadable yet[/dim]")
+
+
 def _resolve_local_config(
     local_config_file: Path | None,
     *,
@@ -1168,11 +1194,7 @@ def apply(
             all_healthy = True
             for vm_name, vm_ip in vm_ips.items():
                 health = vm_mgr.check_vm_health(vm_name, vm_ip)
-                if (
-                    health["cloud_init_complete"]
-                    and health["strongswan_installed"]
-                    and health["frr_installed"]
-                ):
+                if _vm_ready_for_config_push(health) and _vm_packages_verified(health):
                     print(f"[green]{vm_name} ({vm_ip}): {health['message']}[/green]")
                 elif health["reachable"]:
                     print(f"[yellow]{vm_name} ({vm_ip}): {health['message']}[/yellow]")
@@ -1181,42 +1203,53 @@ def apply(
                     print(f"[red]{vm_name} ({vm_ip}): {health['message']}[/red]")
                     all_healthy = False
 
-            # If VMs are not fully healthy (cloud-init not complete or packages not installed), wait additional time
+            # If VMs are not fully healthy, wait for the bootstrap gate before pushing configs.
             if not all_healthy:
                 import time
 
                 print(
-                    "[yellow]Waiting for cloud-init to complete and packages to be installed...[/yellow]"
+                    "[yellow]Waiting for cloud-init, ESP4 readiness, and package installation...[/yellow]"
                 )
-                max_wait = 300  # Wait up to 5 minutes for cloud-init
+                max_wait = 900  # First boot can include apt upgrade plus one reboot.
                 wait_interval = 10
+                wait_elapsed = 0
                 for attempt in range(max_wait // wait_interval):
                     time.sleep(wait_interval)
+                    wait_elapsed = (attempt + 1) * wait_interval
                     all_ready = True
+                    packages_verified = True
                     for vm_name, vm_ip in vm_ips.items():
                         health = vm_mgr.check_vm_health(vm_name, vm_ip)
-                        # Check if VM is reachable AND cloud-init is complete
-                        if not health["reachable"] or not health["cloud_init_complete"]:
+                        if not _vm_ready_for_config_push(health):
                             all_ready = False
-                            if not health["reachable"]:
-                                print(f"[dim]{vm_name}: SSH not ready yet[/dim]")
-                            elif not health["cloud_init_complete"]:
-                                print(
-                                    f"[dim]{vm_name}: Cloud-init still running (packages being installed)[/dim]"
-                                )
+                            _print_vm_wait_reason(vm_name, health)
                             break
+                        if not _vm_packages_verified(health):
+                            packages_verified = False
                     if all_ready:
+                        if not packages_verified:
+                            print(
+                                "[yellow]Bootstrap gate is ready, but package/service verification is incomplete; continuing with config push.[/yellow]"
+                            )
+                        else:
+                            print(
+                                f"[green]✓ All VMs ready: SSH accessible, cloud-init complete, ESP4 ready, and packages verified (waited {wait_elapsed}s)[/green]"
+                            )
                         print(
-                            f"[green]✓ All VMs ready: SSH accessible and cloud-init complete (waited {(attempt + 1) * wait_interval}s)[/green]"
+                            f"[green]✓ Config push gate passed after {wait_elapsed}s[/green]"
                         )
                         break
                     print(
-                        f"[dim]Waiting for bootstrap to complete... ({(attempt + 1) * wait_interval}s elapsed)[/dim]"
+                        f"[dim]Waiting for bootstrap to complete... ({wait_elapsed}s elapsed)[/dim]"
                     )
                 else:
                     print(
-                        "[yellow]Warning: Cloud-init did not complete within timeout, attempting config push anyway...[/yellow]"
+                        "[red]VM bootstrap did not become ready for config push within timeout.[/red]"
                     )
+                    print(
+                        "[yellow]Rerun apply after cloud-init and any ESP4/kernel reboot finish.[/yellow]"
+                    )
+                    raise typer.Exit(code=1)
         else:
             print("[yellow]Some VMs did not become reachable within timeout[/yellow]")
 

--- a/services/vpngw/src/nebius_vpngw/deploy/ssh_push.py
+++ b/services/vpngw/src/nebius_vpngw/deploy/ssh_push.py
@@ -447,6 +447,16 @@ WantedBy=multi-user.target
                                 with sftp.file("/tmp/setup-vpngw-firewall.sh", "w") as f:
                                     f.write(firewall_script.read_text())
                                 print("[SSHPush] Staged firewall setup script")
+
+                            esp4_preflight_script = (
+                                systemd_dir / "nebius-vpngw-esp4-preflight.sh"
+                            )
+                            if esp4_preflight_script.exists():
+                                with sftp.file(
+                                    "/tmp/nebius-vpngw-esp4-preflight.sh", "w"
+                                ) as f:
+                                    f.write(esp4_preflight_script.read_text())
+                                print("[SSHPush] Staged ESP4 preflight helper")
                     except Exception as e:
                         print(f"[SSHPush] Failed to stage systemd unit: {e}")
                 else:
@@ -503,6 +513,8 @@ WantedBy=multi-user.target
             "if [ -f /etc/systemd/system/nebius-vpngw-health-monitor.service ]; then sudo chmod 0644 /etc/systemd/system/nebius-vpngw-health-monitor.service; fi",
             "if [ -f /tmp/setup-vpngw-firewall.sh ]; then sudo mv /tmp/setup-vpngw-firewall.sh /usr/local/bin/setup-vpngw-firewall.sh; fi",
             "if [ -f /usr/local/bin/setup-vpngw-firewall.sh ]; then sudo chmod 0755 /usr/local/bin/setup-vpngw-firewall.sh; fi",
+            "if [ -f /tmp/nebius-vpngw-esp4-preflight.sh ]; then sudo mv /tmp/nebius-vpngw-esp4-preflight.sh /usr/local/bin/nebius-vpngw-esp4-preflight.sh; fi",
+            "if [ -f /usr/local/bin/nebius-vpngw-esp4-preflight.sh ]; then sudo chmod 0755 /usr/local/bin/nebius-vpngw-esp4-preflight.sh; fi",
             # Refresh systemd unit if staged
             "if [ -f /tmp/nebius-vpngw-agent.service ]; then sudo mv /tmp/nebius-vpngw-agent.service /etc/systemd/system/nebius-vpngw-agent.service; fi",
             "sudo chmod 0644 /etc/systemd/system/nebius-vpngw-agent.service",

--- a/services/vpngw/src/nebius_vpngw/deploy/vm_manager.py
+++ b/services/vpngw/src/nebius_vpngw/deploy/vm_manager.py
@@ -17,6 +17,13 @@ def _read_firewall_setup_script() -> str:
     return script_path.read_text(encoding="utf-8")
 
 
+def _read_esp4_preflight_script() -> str:
+    script_path = (
+        Path(__file__).resolve().parents[1] / "systemd" / "nebius-vpngw-esp4-preflight.sh"
+    )
+    return script_path.read_text(encoding="utf-8")
+
+
 def _parse_ipv4_network(cidr: str) -> ipaddress.IPv4Network | None:
     """Parse a CIDR as IPv4 only.
 
@@ -538,6 +545,8 @@ class VMManager:
                 'strongswan_installed': bool,
                 'frr_installed': bool,
                 'agent_installed': bool,
+                'esp4_ready': bool,
+                'esp4_reboot_pending': bool,
                 'message': str
             }
         """
@@ -550,6 +559,8 @@ class VMManager:
             "strongswan_installed": False,
             "frr_installed": False,
             "agent_installed": False,
+            "esp4_ready": False,
+            "esp4_reboot_pending": False,
             "message": "VM not reachable",
         }
 
@@ -633,6 +644,44 @@ class VMManager:
         except Exception:
             pass
 
+        if result["cloud_init_complete"]:
+            try:
+                esp4_check = subprocess.run(
+                    [
+                        "ssh",
+                        "-o",
+                        "ConnectTimeout=5",
+                        "-o",
+                        "StrictHostKeyChecking=no",
+                        "-o",
+                        "UserKnownHostsFile=/dev/null",
+                        "-o",
+                        "LogLevel=ERROR",
+                        f"ubuntu@{public_ip}",
+                        (
+                            "if [ -f /var/lib/nebius-vpngw/esp4-reboot-pending ]; then "
+                            "echo reboot-pending; exit 75; "
+                            "fi; "
+                            "if [ -x /usr/local/bin/nebius-vpngw-esp4-preflight.sh ]; then "
+                            "sudo /usr/local/bin/nebius-vpngw-esp4-preflight.sh --verify "
+                            ">/dev/null 2>&1; "
+                            "else "
+                            "sudo modprobe esp4 >/dev/null 2>&1; "
+                            "fi"
+                        ),
+                    ],
+                    capture_output=True,
+                    timeout=20,
+                    text=True,
+                )
+                if esp4_check.returncode == 0:
+                    result["esp4_ready"] = True
+                elif esp4_check.returncode == 75 or "reboot-pending" in esp4_check.stdout:
+                    result["esp4_reboot_pending"] = True
+                    result["esp4_ready"] = False
+            except Exception:
+                result["esp4_ready"] = False
+
         # Check installed packages
         try:
             pkg_check = subprocess.run(
@@ -667,10 +716,17 @@ class VMManager:
             result["cloud_init_complete"]
             and result["strongswan_installed"]
             and result["frr_installed"]
+            and result["esp4_ready"]
         ):
-            result["message"] = "✓ VM ready: cloud-init complete, strongSwan and FRR installed"
+            result["message"] = (
+                "✓ VM ready: cloud-init complete, strongSwan and FRR installed, ESP4 ready"
+            )
             if result["agent_installed"]:
                 result["message"] += ", agent running"
+        elif result["esp4_reboot_pending"]:
+            result["message"] = "⏳ ESP4/kernel update prepared; waiting for gateway reboot"
+        elif result["cloud_init_complete"] and not result["esp4_ready"]:
+            result["message"] = "⚠ Cloud-init complete but ESP4 is not ready"
         elif result["cloud_init_complete"]:
             result["message"] = "⚠ Cloud-init complete but packages not verified"
         else:
@@ -3366,14 +3422,36 @@ class VMManager:
                 cloud += f"            {prefix}\n"
 
         firewall_script = _read_firewall_setup_script()
+        esp4_preflight_script = _read_esp4_preflight_script()
         cloud += (
             "  - path: /usr/local/bin/setup-vpngw-firewall.sh\n"
             '    permissions: "0755"\n'
             "    owner: root:root\n"
             "    content: |\n" + textwrap.indent(firewall_script.rstrip() + "\n", "            ")
+            + "  - path: /usr/local/bin/nebius-vpngw-esp4-preflight.sh\n"
+            '    permissions: "0755"\n'
+            "    owner: root:root\n"
+            "    content: |\n"
+            + textwrap.indent(esp4_preflight_script.rstrip() + "\n", "            ")
         )
 
         cloud += (
+            "  - path: /etc/systemd/system/nebius-vpngw-esp4-preflight.service\n"
+            '    permissions: "0644"\n'
+            "    owner: root:root\n"
+            "    content: |\n"
+            "            [Unit]\n"
+            "            Description=Nebius VPNGW ESP4 kernel module readiness preflight\n"
+            "            After=local-fs.target systemd-modules-load.service\n"
+            "            Before=strongswan-starter.service strongswan.service frr.service nebius-vpngw-agent.service\n"
+            "            \n"
+            "            [Service]\n"
+            "            Type=oneshot\n"
+            "            ExecStart=/usr/local/bin/nebius-vpngw-esp4-preflight.sh --verify\n"
+            "            RemainAfterExit=yes\n"
+            "            \n"
+            "            [Install]\n"
+            "            WantedBy=multi-user.target\n"
             "  - path: /etc/frr/daemons\n"
             '    permissions: "0644"\n'
             "    owner: frr:frr\n"
@@ -3452,8 +3530,9 @@ class VMManager:
             "    owner: root:root\n"
             "    content: |\n"
             "            [Unit]\n"
-            "            After=ufw.service network-online.target\n"
+            "            After=nebius-vpngw-esp4-preflight.service ufw.service network-online.target\n"
             "            Wants=ufw.service\n"
+            "            Requires=nebius-vpngw-esp4-preflight.service\n"
             "  - path: /etc/systemd/system/frr.service.d/override.conf\n"
             '    permissions: "0644"\n'
             "    owner: root:root\n"
@@ -3474,12 +3553,15 @@ class VMManager:
         cloud += (
             "runcmd:\n"
             '  - [ bash, -lc, "mkdir -p /etc/nebius-vpngw" ]\n'
+            '  - [ bash, -lc, "mkdir -p /var/lib/nebius-vpngw" ]\n'
             '  - [ bash, -lc, "mkdir -p /etc/ipsec.d" ]\n'
             "  # Install FRR 10.x from official repository (fixes route installation bug in 8.4.4)\n"
             '  - [ bash, -c, "curl -s https://deb.frrouting.org/frr/keys.asc | tee /usr/share/keyrings/frrouting.asc > /dev/null" ]\n'
             '  - [ bash, -c, "UBUNTU_CODENAME=$(lsb_release -cs); echo \\"deb [signed-by=/usr/share/keyrings/frrouting.asc] https://deb.frrouting.org/frr $UBUNTU_CODENAME frr-stable\\" > /etc/apt/sources.list.d/frr.list" ]\n'
             "  - [ apt-get, update ]\n"
             '  - [ bash, -c, "DEBIAN_FRONTEND=noninteractive apt-get install -y frr frr-pythontools" ]\n'
+            "  # Prepare ESP4 after Ubuntu package upgrades; defer VPN services if a reboot is required\n"
+            '  - [ bash, -lc, "/usr/local/bin/nebius-vpngw-esp4-preflight.sh --prepare; rc=$?; if [ $rc -eq 75 ]; then exit 0; fi; exit $rc" ]\n'
             "  # Comment out conflicting sysctl settings in /etc/sysctl.conf (prevents our 99-zzz-vpngw.conf from being overridden)\n"
             "  - [ bash, -c, \"sed -i 's/^net.ipv4.ip_forward=.*/#&  # Overridden by 99-zzz-vpngw.conf/' /etc/sysctl.conf\" ]\n"
             "  - [ bash, -c, \"sed -i 's/^net.ipv4.conf.all.rp_filter=.*/#&  # Overridden by 99-zzz-vpngw.conf/' /etc/sysctl.conf\" ]\n"
@@ -3498,16 +3580,18 @@ class VMManager:
             "  - [ systemctl, enable, auditd ]\n"
             "  - [ systemctl, enable, fail2ban ]\n"
             "  - [ systemctl, enable, log-restart-required.timer ]\n"
+            "  - [ systemctl, enable, nebius-vpngw-esp4-preflight ]\n"
             "  - [ systemctl, enable, strongswan-starter ]\n"
             "  - [ systemctl, enable, frr ]\n"
             "  - [ systemctl, enable, nebius-vpngw-agent ]\n"
             "  - [ systemctl, start, auditd ]\n"
             "  - [ systemctl, start, fail2ban ]\n"
             "  - [ systemctl, start, log-restart-required.timer ]\n"
-            "  - [ systemctl, start, strongswan-starter ]\n"
-            "  - [ systemctl, start, frr ]\n"
+            '  - [ bash, -lc, "if [ ! -f /var/lib/nebius-vpngw/esp4-reboot-pending ]; then systemctl start nebius-vpngw-esp4-preflight strongswan-starter frr; fi" ]\n'
             "  # Reload SSH to apply hardening config\n"
             "  - [ systemctl, reload, ssh ]\n"
+            "  # Reboot only after cloud-init has written files and enabled services\n"
+            '  - [ bash, -lc, "if [ -f /var/lib/nebius-vpngw/esp4-reboot-pending ]; then logger -t vpngw \\"Rebooting to activate ESP4/kernel update before VPN services start\\"; shutdown -r +1 \\"Nebius VPN Gateway rebooting to activate ESP4/kernel update\\"; fi" ]\n'
             "  # Log completion\n"
             "  - [ bash, -c, \"logger -t vpngw 'Cloud-init hardening complete for VPN gateway'\" ]\n"
         )

--- a/services/vpngw/src/nebius_vpngw/systemd/nebius-vpngw-esp4-preflight.sh
+++ b/services/vpngw/src/nebius_vpngw/systemd/nebius-vpngw-esp4-preflight.sh
@@ -1,0 +1,201 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+STATE_DIR="${VPNGW_ESP4_STATE_DIR:-/var/lib/nebius-vpngw}"
+MODPROBE_DIR="${VPNGW_ESP4_MODPROBE_DIR:-/etc/modprobe.d}"
+REBOOT_REQUIRED_FILE="${VPNGW_ESP4_REBOOT_REQUIRED_FILE:-/var/run/reboot-required}"
+READY_MARKER="${STATE_DIR}/esp4-ready"
+REBOOT_PENDING_MARKER="${STATE_DIR}/esp4-reboot-pending"
+CHANGED_MARKER="${STATE_DIR}/esp4-modprobe-policy-updated"
+LOG_TAG="nebius-vpngw-esp4"
+REBOOT_NEEDED_RC=75
+
+BLOCK_PATTERN='^[[:space:]]*(install[[:space:]]+esp4[[:space:]]+/usr/bin/(false|true)|install[[:space:]]+esp4[[:space:]]+/bin/(false|true)|blacklist[[:space:]]+esp4)([[:space:]]|$)'
+
+log() {
+  local message="$1"
+  printf '[%s] %s\n' "${LOG_TAG}" "${message}"
+  if command -v logger >/dev/null 2>&1; then
+    logger -t "${LOG_TAG}" -- "${message}" || true
+  fi
+}
+
+usage() {
+  cat <<'EOF'
+Usage:
+  nebius-vpngw-esp4-preflight.sh --prepare
+  nebius-vpngw-esp4-preflight.sh --verify
+
+Options:
+  --prepare  Remove only esp4 module deny rules and request reboot when needed
+  --verify   Verify esp4 is loadable and write the ready marker
+  -h, --help Show help
+
+Environment for tests:
+  VPNGW_ESP4_MODPROBE_DIR
+  VPNGW_ESP4_STATE_DIR
+  VPNGW_ESP4_REBOOT_REQUIRED_FILE
+  VPNGW_ESP4_SKIP_INITRAMFS=1
+  VPNGW_ESP4_SKIP_MODPROBE=1
+EOF
+}
+
+require_root() {
+  if [[ "${EUID}" -ne 0 && -z "${VPNGW_ESP4_ALLOW_NON_ROOT:-}" ]]; then
+    log "must run as root"
+    exit 1
+  fi
+}
+
+ensure_state_dir() {
+  mkdir -p "${STATE_DIR}"
+}
+
+comment_esp4_blocks_in_file() {
+  local file="$1"
+  local tmp=""
+  local rc=0
+
+  tmp="$(mktemp)"
+  if awk -v pattern="${BLOCK_PATTERN}" '
+    $0 ~ pattern && $0 !~ /^# nebius-vpngw: disabled ESP4 block:/ {
+      print "# nebius-vpngw: disabled ESP4 block: " $0
+      changed = 1
+      next
+    }
+    { print }
+    END {
+      if (changed) {
+        exit 10
+      }
+    }
+  ' "${file}" > "${tmp}"; then
+    rm -f "${tmp}"
+    return 1
+  else
+    rc=$?
+    if [[ "${rc}" -ne 10 ]]; then
+      rm -f "${tmp}"
+      return "${rc}"
+    fi
+  fi
+
+  cp -a "${file}" "${file}.nebius-vpngw-esp4.$(date +%Y%m%d%H%M%S).bak"
+  cat "${tmp}" > "${file}"
+  rm -f "${tmp}"
+  return 0
+}
+
+remediate_modprobe_policy() {
+  local changed=1
+  local file=""
+
+  shopt -s nullglob
+  for file in "${MODPROBE_DIR}"/*.conf; do
+    [[ -f "${file}" ]] || continue
+    if comment_esp4_blocks_in_file "${file}"; then
+      log "disabled esp4 block in ${file}"
+      changed=0
+    fi
+  done
+  shopt -u nullglob
+
+  return "${changed}"
+}
+
+update_initramfs_if_needed() {
+  if [[ "${VPNGW_ESP4_SKIP_INITRAMFS:-}" == "1" ]]; then
+    log "skipping update-initramfs because VPNGW_ESP4_SKIP_INITRAMFS=1"
+    return 0
+  fi
+  if ! command -v update-initramfs >/dev/null 2>&1; then
+    log "update-initramfs is not available"
+    return 1
+  fi
+  update-initramfs -u -k all
+}
+
+verify_esp4_loadable() {
+  if [[ "${VPNGW_ESP4_SKIP_MODPROBE:-}" == "1" ]]; then
+    log "skipping modprobe because VPNGW_ESP4_SKIP_MODPROBE=1"
+    return 0
+  fi
+  if ! command -v modprobe >/dev/null 2>&1; then
+    log "modprobe is not available"
+    return 1
+  fi
+  modprobe esp4
+}
+
+write_ready() {
+  rm -f "${REBOOT_PENDING_MARKER}"
+  touch "${READY_MARKER}"
+  log "esp4 is ready"
+}
+
+write_reboot_pending() {
+  rm -f "${READY_MARKER}"
+  touch "${REBOOT_PENDING_MARKER}"
+  log "reboot is required before esp4 readiness can be confirmed"
+}
+
+prepare() {
+  local changed=0
+
+  require_root
+  ensure_state_dir
+
+  if remediate_modprobe_policy; then
+    changed=1
+    touch "${CHANGED_MARKER}"
+    update_initramfs_if_needed
+  fi
+
+  if [[ "${changed}" -eq 1 || -f "${REBOOT_REQUIRED_FILE}" ]]; then
+    write_reboot_pending
+    exit "${REBOOT_NEEDED_RC}"
+  fi
+
+  if verify_esp4_loadable; then
+    write_ready
+    return 0
+  fi
+
+  log "esp4 is not loadable"
+  return 1
+}
+
+verify() {
+  require_root
+  ensure_state_dir
+
+  if verify_esp4_loadable; then
+    write_ready
+    return 0
+  fi
+
+  log "esp4 is not loadable"
+  return 1
+}
+
+main() {
+  local action="${1:-}"
+
+  case "${action}" in
+    --prepare)
+      prepare
+      ;;
+    --verify)
+      verify
+      ;;
+    -h|--help)
+      usage
+      ;;
+    *)
+      usage >&2
+      exit 1
+      ;;
+  esac
+}
+
+main "$@"

--- a/services/vpngw/tests/integration/test_release_build.py
+++ b/services/vpngw/tests/integration/test_release_build.py
@@ -42,6 +42,7 @@ def test_wheel_build_uses_package_local_version_file(tmp_path) -> None:
         names = set(wheel_zip.namelist())
 
     assert "nebius_vpngw/_version.py" in names
+    assert "nebius_vpngw/systemd/nebius-vpngw-esp4-preflight.sh" in names
     assert "services/vpngw/src/nebius_vpngw/_version.py" not in names
 
 

--- a/services/vpngw/tests/unit/test_cli_helpers.py
+++ b/services/vpngw/tests/unit/test_cli_helpers.py
@@ -177,6 +177,79 @@ def test_apply_prints_add_routes_hint_after_initial_static_creation(tmp_path: Pa
     assert "<your-config.yaml>" not in result.stdout
 
 
+def test_apply_waits_for_esp4_ready_before_config_push(tmp_path: Path) -> None:
+    config_path = tmp_path / "static.config.yaml"
+    config_path.write_text("version: 1\n", encoding="utf-8")
+
+    local_cfg = {
+        "tenant_id": "tenant-test",
+        "project_id": "project-test",
+        "region_id": "eu-west1",
+        "gateway_group": {"vm_spec": {}},
+        "gateway": {"local_prefixes": ["10.0.0.0/16"]},
+        "defaults": {"routing": {"mode": "static"}},
+    }
+    plan = _static_route_plan()
+    pushed_targets: list[str] = []
+
+    pending_health = {
+        "reachable": True,
+        "cloud_init_complete": True,
+        "strongswan_installed": True,
+        "frr_installed": True,
+        "agent_installed": False,
+        "esp4_ready": False,
+        "esp4_reboot_pending": True,
+        "message": "ESP4/kernel update prepared; waiting for gateway reboot",
+    }
+    ready_health = {
+        "reachable": True,
+        "cloud_init_complete": True,
+        "strongswan_installed": True,
+        "frr_installed": True,
+        "agent_installed": True,
+        "esp4_ready": True,
+        "esp4_reboot_pending": False,
+        "message": "VM ready",
+    }
+    health_results = [pending_health, pending_health, ready_health]
+
+    class FakeVMManager:
+        def __init__(self, *args, **kwargs) -> None:
+            pass
+
+        def check_changes(self, spec) -> list[tuple[str, VMDiff]]:
+            return []
+
+        def ensure_group(self, spec, recreate=False, local_prefixes=None) -> dict[str, str]:
+            return {"nebius-vpn-gw-0": "203.0.113.10"}
+
+        def wait_for_vm_network(self, vm_name, vm_ip, timeout=180) -> bool:
+            return True
+
+        def check_vm_health(self, vm_name, vm_ip) -> dict[str, object]:
+            return health_results.pop(0)
+
+    class FakeSSHPush:
+        def push_config_and_reload(self, target, inst_cfg, cfg) -> None:
+            pushed_targets.append(target)
+
+    with (
+        patch("nebius_vpngw.cli.load_local_config", return_value=local_cfg),
+        patch("nebius_vpngw.cli.merge_with_peer_configs", return_value=plan),
+        patch("nebius_vpngw.cli._ensure_authentication", return_value="token"),
+        patch("nebius_vpngw.cli.VMManager", FakeVMManager),
+        patch("nebius_vpngw.cli.SSHPush", return_value=FakeSSHPush()),
+        patch("time.sleep", return_value=None),
+    ):
+        result = CliRunner().invoke(app, ["apply", "--local-config-file", str(config_path)])
+
+    assert result.exit_code == 0
+    assert pushed_targets == ["203.0.113.10"]
+    assert "waiting for reboot" in result.stdout
+    assert "Config push gate passed" in result.stdout
+
+
 def test_prep_network_allows_missing_peer_psk_placeholders(
     tmp_path: Path,
     sample_config: dict,

--- a/services/vpngw/tests/unit/test_esp4_preflight_script.py
+++ b/services/vpngw/tests/unit/test_esp4_preflight_script.py
@@ -1,0 +1,206 @@
+from __future__ import annotations
+
+import os
+import shlex
+import subprocess
+from pathlib import Path
+
+import pytest
+import yaml
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+HELPER_SCRIPT = PROJECT_ROOT / "src/nebius_vpngw/systemd/nebius-vpngw-esp4-preflight.sh"
+FIX_SCRIPT = PROJECT_ROOT / "misc/fix-vpngw-esp4.sh"
+
+
+@pytest.mark.parametrize("script", [HELPER_SCRIPT, FIX_SCRIPT])
+def test_shell_scripts_parse(script: Path) -> None:
+    result = subprocess.run(["bash", "-n", str(script)], capture_output=True, text=True)
+
+    assert result.returncode == 0, result.stderr
+
+
+def _helper_env(tmp_path: Path) -> dict[str, str]:
+    env = os.environ.copy()
+    env.update(
+        {
+            "VPNGW_ESP4_MODPROBE_DIR": str(tmp_path / "modprobe.d"),
+            "VPNGW_ESP4_STATE_DIR": str(tmp_path / "state"),
+            "VPNGW_ESP4_REBOOT_REQUIRED_FILE": str(tmp_path / "reboot-required"),
+            "VPNGW_ESP4_SKIP_INITRAMFS": "1",
+            "VPNGW_ESP4_SKIP_MODPROBE": "1",
+            "VPNGW_ESP4_ALLOW_NON_ROOT": "1",
+        }
+    )
+    return env
+
+
+def test_esp4_preflight_comments_only_esp4_blocks(tmp_path: Path) -> None:
+    modprobe_dir = tmp_path / "modprobe.d"
+    modprobe_dir.mkdir()
+    policy_file = modprobe_dir / "dirty-frag.conf"
+    policy_file.write_text(
+        "\n".join(
+            [
+                "install esp4 /bin/false",
+                "install esp6 /bin/false",
+                "install rxrpc /bin/false",
+                "blacklist esp4",
+                "blacklist esp6",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    result = subprocess.run(
+        [str(HELPER_SCRIPT), "--prepare"],
+        capture_output=True,
+        text=True,
+        env=_helper_env(tmp_path),
+    )
+
+    assert result.returncode == 75, result.stderr
+    updated = policy_file.read_text(encoding="utf-8")
+    assert "# nebius-vpngw: disabled ESP4 block: install esp4 /bin/false" in updated
+    assert "# nebius-vpngw: disabled ESP4 block: blacklist esp4" in updated
+    assert "install esp6 /bin/false" in updated
+    assert "install rxrpc /bin/false" in updated
+    assert "blacklist esp6" in updated
+    assert list(modprobe_dir.glob("dirty-frag.conf.nebius-vpngw-esp4.*.bak"))
+    assert (tmp_path / "state/esp4-reboot-pending").exists()
+
+
+def test_esp4_preflight_noop_when_esp4_is_not_blocked(tmp_path: Path) -> None:
+    modprobe_dir = tmp_path / "modprobe.d"
+    modprobe_dir.mkdir()
+    policy_file = modprobe_dir / "dirty-frag.conf"
+    original = "install esp6 /bin/false\ninstall rxrpc /bin/false\n"
+    policy_file.write_text(original, encoding="utf-8")
+
+    result = subprocess.run(
+        [str(HELPER_SCRIPT), "--prepare"],
+        capture_output=True,
+        text=True,
+        env=_helper_env(tmp_path),
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert policy_file.read_text(encoding="utf-8") == original
+    assert not list(modprobe_dir.glob("*.bak"))
+    assert (tmp_path / "state/esp4-ready").exists()
+    assert not (tmp_path / "state/esp4-reboot-pending").exists()
+
+
+def test_fix_vpngw_esp4_help_and_dry_run_host() -> None:
+    help_result = subprocess.run([str(FIX_SCRIPT), "--help"], capture_output=True, text=True)
+    dry_run_result = subprocess.run(
+        [str(FIX_SCRIPT), "--dry-run", "--host", "203.0.113.10"],
+        capture_output=True,
+        text=True,
+    )
+
+    assert help_result.returncode == 0
+    assert "fix-vpngw-esp4.sh" in help_result.stdout
+    assert dry_run_result.returncode == 0, dry_run_result.stderr
+    assert "ubuntu@203.0.113.10" in dry_run_result.stdout
+    assert "dry-run" in dry_run_result.stdout
+
+
+def test_fix_vpngw_esp4_discovers_hosts_from_local_config(tmp_path: Path) -> None:
+    config_path = tmp_path / "nebius-vpngw.config.yaml"
+    config_path.write_text(
+        yaml.safe_dump(
+            {
+                "gateway_group": {
+                    "external_ips": [["203.0.113.10"], ["${VPNGW_IP}"], ["203.0.113.11"]],
+                    "vm_spec": {
+                        "ssh_username": "operator",
+                        "ssh_private_key_path": "~/.ssh/id_ed25519",
+                    },
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    result = subprocess.run(
+        [str(FIX_SCRIPT), "--dry-run", "--local-config-file", str(config_path)],
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "operator@203.0.113.10" in result.stdout
+    assert "operator@203.0.113.11" in result.stdout
+    assert "${VPNGW_IP}" not in result.stdout
+
+
+def test_fix_vpngw_esp4_expands_tilde_identity_path() -> None:
+    result = subprocess.run(
+        [
+            "bash",
+            "-c",
+            f"source {FIX_SCRIPT}; HOME=/tmp/vpngw-home expand_path '~/.ssh/id_ed25519'",
+        ],
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout == "/tmp/vpngw-home/.ssh/id_ed25519"
+
+
+def test_fix_vpngw_esp4_waits_for_boot_id_change(tmp_path: Path) -> None:
+    counter_path = tmp_path / "ssh-calls"
+    counter_path.write_text("0", encoding="utf-8")
+
+    result = subprocess.run(
+        [
+            "bash",
+            "-c",
+            f"""
+source {FIX_SCRIPT}
+counter_path={shlex.quote(str(counter_path))}
+fake_ssh() {{
+  calls="$(<"${{counter_path}}")"
+  calls=$((calls + 1))
+  printf '%s' "${{calls}}" > "${{counter_path}}"
+  if [[ "${{calls}}" -eq 1 ]]; then
+    printf 'old-boot\\n'
+  else
+    printf 'new-boot\\n'
+  fi
+}}
+build_ssh_cmd() {{ SSH_CMD=(fake_ssh); }}
+sleep() {{ :; }}
+WAIT_TIMEOUT=5
+wait_for_rebooted_ssh 'ubuntu@203.0.113.10' 'old-boot'
+printf 'calls=%s\\n' "$(<"${{counter_path}}")"
+""",
+        ],
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout == "calls=2\n"
+
+
+def test_fix_vpngw_esp4_rejects_unknown_option() -> None:
+    result = subprocess.run([str(FIX_SCRIPT), "--unknown"], capture_output=True, text=True)
+
+    assert result.returncode == 1
+    assert "Unknown option" in result.stderr
+
+
+def test_fix_vpngw_esp4_requires_confirmation_for_mutating_run() -> None:
+    result = subprocess.run(
+        [str(FIX_SCRIPT), "--host", "203.0.113.10"],
+        input="",
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 1
+    assert "Confirmation aborted" in result.stderr

--- a/services/vpngw/tests/unit/test_gateway_subnet_config.py
+++ b/services/vpngw/tests/unit/test_gateway_subnet_config.py
@@ -4,6 +4,7 @@ import ipaddress
 from types import SimpleNamespace
 
 import pytest
+import yaml
 from pydantic import ValidationError
 
 from nebius_vpngw.config_loader import GatewayGroupSpec
@@ -128,4 +129,10 @@ def test_build_cloud_init_includes_ssh_key_and_local_prefixes() -> None:
     assert "10.0.0.0/16" in rendered
     assert "172.16.0.0/24" in rendered
     assert "/usr/local/bin/setup-vpngw-firewall.sh" in rendered
+    assert "/usr/local/bin/nebius-vpngw-esp4-preflight.sh" in rendered
+    assert "/etc/systemd/system/nebius-vpngw-esp4-preflight.service" in rendered
+    assert "/var/lib/nebius-vpngw/esp4-reboot-pending" in rendered
+    assert "systemctl start nebius-vpngw-esp4-preflight strongswan-starter frr" in rendered
+    assert "  - [ systemctl, start, strongswan-starter ]" not in rendered
     assert "net.ipv4.ip_forward = 1" in rendered
+    assert yaml.safe_load(rendered)["package_upgrade"] is True

--- a/services/vpngw/tests/unit/test_vm_manager_health.py
+++ b/services/vpngw/tests/unit/test_vm_manager_health.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+import subprocess
+from collections.abc import Sequence
+
+import pytest
+
+from nebius_vpngw.deploy.vm_manager import VMManager
+
+
+def _completed(stdout: str = "", returncode: int = 0) -> subprocess.CompletedProcess[str]:
+    return subprocess.CompletedProcess(args=["ssh"], returncode=returncode, stdout=stdout, stderr="")
+
+
+def _fake_ssh_run_for_esp4(
+    esp4_result: subprocess.CompletedProcess[str],
+) -> object:
+    def fake_run(cmd: Sequence[str], *args: object, **kwargs: object) -> subprocess.CompletedProcess[str]:
+        remote_cmd = str(cmd[-1])
+        if remote_cmd == "echo connected":
+            return _completed()
+        if "cloud-init status" in remote_cmd:
+            return _completed("status: done\n")
+        if "python3 -m pip --version" in remote_cmd:
+            return _completed("pip 24.0\n")
+        if "esp4-reboot-pending" in remote_cmd:
+            return esp4_result
+        if "dpkg -l strongswan frr" in remote_cmd:
+            return _completed("ii  strongswan  5.9\nii  frr  10.5\nactive\n")
+        raise AssertionError(f"unexpected command: {remote_cmd}")
+
+    return fake_run
+
+
+@pytest.mark.parametrize(
+    ("esp4_result", "esp4_ready", "esp4_reboot_pending", "message_fragment"),
+    [
+        (_completed(returncode=0), True, False, "ESP4 ready"),
+        (_completed(stdout="reboot-pending\n", returncode=75), False, True, "waiting for gateway reboot"),
+        (_completed(stdout="blocked\n", returncode=1), False, False, "ESP4 is not ready"),
+    ],
+)
+def test_check_vm_health_reports_esp4_states(
+    monkeypatch: pytest.MonkeyPatch,
+    esp4_result: subprocess.CompletedProcess[str],
+    esp4_ready: bool,
+    esp4_reboot_pending: bool,
+    message_fragment: str,
+) -> None:
+    monkeypatch.setattr("time.sleep", lambda _: None)
+    monkeypatch.setattr("subprocess.run", _fake_ssh_run_for_esp4(esp4_result))
+
+    health = VMManager(project_id="project-test", zone="eu-west1").check_vm_health(
+        "nebius-vpn-gw-0",
+        "203.0.113.10",
+    )
+
+    assert health["reachable"] is True
+    assert health["cloud_init_complete"] is True
+    assert health["esp4_ready"] is esp4_ready
+    assert health["esp4_reboot_pending"] is esp4_reboot_pending
+    assert message_fragment in health["message"]

--- a/services/vpngw/uv.lock
+++ b/services/vpngw/uv.lock
@@ -802,6 +802,7 @@ dev = [
     { name = "ruff" },
     { name = "setuptools-scm" },
     { name = "types-pyyaml" },
+    { name = "vcs-versioning" },
 ]
 
 [package.metadata]
@@ -820,9 +821,10 @@ requires-dist = [
     { name = "pyyaml", specifier = ">=6.0.3,<7.0.0" },
     { name = "rich", specifier = ">=14.2.0,<15.0.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.14.0,<1.0.0" },
-    { name = "setuptools-scm", marker = "extra == 'dev'", specifier = ">=8" },
+    { name = "setuptools-scm", marker = "extra == 'dev'", specifier = ">=9.2" },
     { name = "typer", specifier = ">=0.20.0,<1.0.0" },
     { name = "types-pyyaml", marker = "extra == 'dev'", specifier = ">=6.0.12,<7.0.0" },
+    { name = "vcs-versioning", marker = "extra == 'dev'", specifier = ">=2.2.2,<3.0.0" },
 ]
 provides-extras = ["dev"]
 
@@ -1398,6 +1400,20 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949, upload-time = "2025-10-01T02:14:41.687Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7", size = 14611, upload-time = "2025-10-01T02:14:40.154Z" },
+]
+
+[[package]]
+name = "vcs-versioning"
+version = "2.2.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "packaging" },
+    { name = "tomli", marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/09/95/c95bb74950763a163defcf4cedf6c5edfca1d623fd5031b76516ece85076/vcs_versioning-2.2.2.tar.gz", hash = "sha256:4ac4ded78720cdb4d0291ae58ace87e1e9201912e1023f3029c6cce5c9152cfb", size = 143135, upload-time = "2026-06-29T13:26:06.901Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/85/9e/1f06f4ddc3a74ccfe0877490caaf4a5233e65401160afc8cb13207815f5e/vcs_versioning-2.2.2-py3-none-any.whl", hash = "sha256:fe7fb216f8780a5516e7864a9333aacb1b70015b087a9be3918da76ef2760808", size = 108014, upload-time = "2026-06-29T13:26:05.367Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Prepare the nebius-vpngw v0.5.9 changelog section.
- Include the ESP4 readiness preflight and repair helper, route SSH handling fixes, and mypy/typecheck work.
- Fix the vcs-versioning build dependency required by the semver-pep440 wheel build path.

## Validation
- make check
- make test-integration
- make build
- bash -n publish-release.sh
- bash -n misc/fix-vpngw-esp4.sh
- bash -n src/nebius_vpngw/systemd/nebius-vpngw-esp4-preflight.sh