### PR TITLE
Align hook provenance and publish helpers

### DIFF
--- a/skills/CHANGELOG.md
+++ b/skills/CHANGELOG.md
@@ -6,6 +6,11 @@ All notable changes to the reusable Codex skills are tracked here.
 
 ### Added
 
+- Added hook file provenance to `install-skills.sh` hook payload sync so
+  source-owned unmodified hook files can auto-upgrade safely, plus
+  `--overwrite-hook-files <name[,name...]>` for intentional basename-scoped
+  hook payload replacement with backups under
+  `$CODEX_HOME/.install-hooks-state/backups/`.
 - Added the `agent-nebius-auth` setup-only skill for bootstrapping and
   repairing Codex Agent Nebius service-account authentication, including an
   idempotent setup script and a `PreToolUse` hook that injects short-lived
@@ -140,6 +145,12 @@ All notable changes to the reusable Codex skills are tracked here.
 
 ### Changed
 
+- Aligned `publish-helm`, `publish-image`, and `publish-release` project-local
+  shell helper templates with their canonical doer scripts: generated helpers
+  now use `--mode prep|publish|verify`, require explicit `--tag`, reject the
+  old `--prep`/`--publish` interface, keep setup defaults overridable by flags,
+  include artifact-specific verify modes, and check duplicate release tags before
+  the branch-sync fetch can alter local tag refs.
 - Hardened `publish-release`, `publish-image`, and `publish-helm` so release
   prep and publish phases must start from a clean, synced default branch; prep
   now creates and pushes `release/<tag>` from that branch, and the old

--- a/skills/CHANGELOG.md
+++ b/skills/CHANGELOG.md
@@ -145,6 +145,11 @@ All notable changes to the reusable Codex skills are tracked here.
 
 ### Changed
 
+- Made `install-skills.sh --overwrite-hook-files` accept shell-split
+  comma-and-space basename lists, for example
+  `--overwrite-hook-files stop_sdlc_continue.py, test_sdlc_hooks.py`, and
+  improved the `--install-hooks` error when the source hook directory is
+  omitted before another option.
 - Aligned `publish-helm`, `publish-image`, and `publish-release` project-local
   shell helper templates with their canonical doer scripts: generated helpers
   now use `--mode prep|publish|verify`, require explicit `--tag`, reject the

--- a/skills/README.md
+++ b/skills/README.md
@@ -778,7 +778,10 @@ instead of removed automatically.
 ./install-skills.sh --install-all-hooks --register-hooks --replace-hooks-json
 
 # Intentionally replace reviewed hook payload files by basename
-./install-skills.sh --install-all-hooks --overwrite-hook-files stop_sdlc_continue.py,test_sdlc_hooks.py
+./install-skills.sh --install-all-hooks --overwrite-hook-files stop_sdlc_continue.py, test_sdlc_hooks.py
+
+# Intentionally replace reviewed hook payload files from one hook source
+./install-skills.sh --install-hooks sdlc-start/assets/hooks --overwrite-hook-files stop_sdlc_continue.py, test_sdlc_hooks.py
 
 # Copy hooks into a non-default Codex home
 CODEX_HOME=~/custom-codex ./install-skills.sh --install-all-hooks --register-hooks
@@ -848,7 +851,8 @@ CODEX_HOME=~/custom-codex ./install-skills.sh --install-all-hooks --register-hoo
   containing every reviewed hook bundle under this source folder.
 - `--overwrite-hook-files <name[,name...]>` can be combined with either hook
   install mode to intentionally replace reviewed hook payload files by
-  basename. It backs up each replaced target under
+  basename. The names can be comma-separated, comma-and-space separated, or
+  provided by repeating the flag. It backs up each replaced target under
   `${CODEX_HOME:-$HOME/.codex}/.install-hooks-state/backups/`, rejects unknown
   names and duplicate source basenames, and does not affect `hooks.json`.
 - Hook install modes report extra files under

--- a/skills/README.md
+++ b/skills/README.md
@@ -681,7 +681,8 @@ be removed with `--remove-skill` when they are not same-source managed.
 - `rsync`
 - `git` for GitHub sources
 - standard POSIX-style utilities for hook installation: `install`, `find`,
-  `cmp`, `chmod`, `awk`, `cut`, `sort`, and `mktemp`
+  `cmp`, `chmod`, `awk`, `cut`, `sort`, `date`, `mktemp`, and `shasum` or
+  `sha256sum`
 - `python3` when using hook registration
 
 ### Usage
@@ -689,8 +690,8 @@ be removed with `--remove-skill` when they are not same-source managed.
 ```bash
 ./install-skills.sh [source] [destination_dir]
 ./install-skills.sh --remove-skill <skill_name> [destination_dir]
-./install-skills.sh --install-hooks <source_hook_dir> [--register-hooks] [--replace-hooks-json]
-./install-skills.sh --install-all-hooks [--register-hooks] [--replace-hooks-json]
+./install-skills.sh --install-hooks <source_hook_dir> [--register-hooks] [--replace-hooks-json] [--overwrite-hook-files <name[,name...]>]
+./install-skills.sh --install-all-hooks [--register-hooks] [--replace-hooks-json] [--overwrite-hook-files <name[,name...]>]
 ./install-skills.sh --help
 ```
 
@@ -701,7 +702,9 @@ The `--install-hooks` option is deliberately separate from normal skill
 installation. It copies hook files from an explicit source hook directory into
 `${CODEX_HOME:-$HOME/.codex}/hooks`, stripping `.template` suffixes for
 installed files. It copies missing hook files, leaves matching files unchanged,
-and stops before replacing any differing existing hook file. Add
+and upgrades source-owned unmodified hook files using local provenance hashes.
+It stops before replacing unproven local edits unless the file basename is
+listed with `--overwrite-hook-files`. Add
 `--register-hooks` to merge that bundle's
 `hooks.json` or `hooks.json.template` registration manifest into
 `${CODEX_HOME:-$HOME/.codex}/hooks.json`.
@@ -712,8 +715,9 @@ With `--register-hooks`, it also merges each discovered bundle's registration
 manifest while preserving existing hook entries. Add `--replace-hooks-json`
 only when you intentionally want to back up and replace `hooks.json` with a
 clean file built from the selected source manifests. Hook install modes are
-idempotent: unchanged files are not recopied, differing existing hook files are
-left for manual review, registration appends only missing source entries by
+idempotent: unchanged files are not recopied, source-owned unmodified hook files
+can auto-upgrade, unproven local edits stay untouched unless listed with
+`--overwrite-hook-files`, registration appends only missing source entries by
 default, refuses duplicate Python hook files within the same hook event, and
 any extra installed hook files or hook registrations are reported for review
 instead of removed automatically.
@@ -773,6 +777,9 @@ instead of removed automatically.
 # Copy all reviewed hook bundles and replace hooks.json with only those entries
 ./install-skills.sh --install-all-hooks --register-hooks --replace-hooks-json
 
+# Intentionally replace reviewed hook payload files by basename
+./install-skills.sh --install-all-hooks --overwrite-hook-files stop_sdlc_continue.py,test_sdlc_hooks.py
+
 # Copy hooks into a non-default Codex home
 CODEX_HOME=~/custom-codex ./install-skills.sh --install-all-hooks --register-hooks
 ```
@@ -812,13 +819,14 @@ CODEX_HOME=~/custom-codex ./install-skills.sh --install-all-hooks --register-hoo
   guardrails, not skills. Use a hook-only source directory such as
   `sdlc-start/assets/hooks` or `config-codex/assets/hooks`. Without
   `--register-hooks`, this only syncs files under
-  `${CODEX_HOME:-$HOME/.codex}/hooks`, and it stops before replacing any
-  differing existing hook file.
+  `${CODEX_HOME:-$HOME/.codex}/hooks`. It upgrades source-owned unmodified hook
+  files using local provenance hashes and stops before replacing unproven local
+  edits unless the basename is listed with `--overwrite-hook-files`.
 - `--install-all-hooks` discovers only skill-owned hook-only directories named
   `*/assets/hooks` under this source folder, checks for conflicting installed
   file names, and syncs all reviewed hook bundles into
-  `${CODEX_HOME:-$HOME/.codex}/hooks` without overwriting differing existing
-  hook files.
+  `${CODEX_HOME:-$HOME/.codex}/hooks` with the same provenance and explicit
+  overwrite behavior.
 - `--register-hooks` can be combined with either hook-install mode. It looks
   for `hooks.json` or `hooks.json.template` in the hook directory or its parent,
   validates the source and destination JSON, backs up an existing
@@ -838,6 +846,11 @@ CODEX_HOME=~/custom-codex ./install-skills.sh --install-all-hooks --register-hoo
   registrations that are not in the selected source. Use
   `--install-all-hooks --register-hooks --replace-hooks-json` for a clean file
   containing every reviewed hook bundle under this source folder.
+- `--overwrite-hook-files <name[,name...]>` can be combined with either hook
+  install mode to intentionally replace reviewed hook payload files by
+  basename. It backs up each replaced target under
+  `${CODEX_HOME:-$HOME/.codex}/.install-hooks-state/backups/`, rejects unknown
+  names and duplicate source basenames, and does not affect `hooks.json`.
 - Hook install modes report extra files under
   `${CODEX_HOME:-$HOME/.codex}/hooks` and extra `hooks.json` registrations that
   are not present in the selected source manifests. These reports are advisory:

--- a/skills/agent-nebius-auth/scripts/test_install_hook_registration.py
+++ b/skills/agent-nebius-auth/scripts/test_install_hook_registration.py
@@ -386,6 +386,62 @@ class AgentNebiusAuthHookInstallRegistrationTest(unittest.TestCase):
         self.assertEqual(entry["source_sha"], self.file_sha256(hook_source / "demo.py"))
         self.assertEqual(entry["target_sha"], self.file_sha256(target))
 
+    def test_overwrite_hook_files_accepts_shell_split_comma_space_list(self) -> None:
+        hook_source = self.make_hook_source(
+            {
+                "one.py": "print('one v1')\n",
+                "two.py": "print('two v1')\n",
+            }
+        )
+        first = self.run_custom_hook_installer(hook_source)
+        first_target = self.installed_hook_target("one.py")
+        second_target = self.installed_hook_target("two.py")
+        first_target.write_text("print('one local')\n", encoding="utf-8")
+        second_target.write_text("print('two local')\n", encoding="utf-8")
+        (hook_source / "one.py").write_text("print('one v2')\n", encoding="utf-8")
+        (hook_source / "two.py").write_text("print('two v2')\n", encoding="utf-8")
+
+        second = self.run_custom_hook_installer(
+            hook_source,
+            "--overwrite-hook-files",
+            "one.py,",
+            "two.py",
+        )
+
+        self.assertEqual(first.returncode, 0, first.stdout + first.stderr)
+        self.assertEqual(second.returncode, 0, second.stdout + second.stderr)
+        self.assertEqual(first_target.read_text(encoding="utf-8"), "print('one v2')\n")
+        self.assertEqual(second_target.read_text(encoding="utf-8"), "print('two v2')\n")
+        self.assertEqual(
+            len(list((self.codex_home / ".install-hooks-state" / "backups").glob("*/one.py"))),
+            1,
+        )
+        self.assertEqual(
+            len(list((self.codex_home / ".install-hooks-state" / "backups").glob("*/two.py"))),
+            1,
+        )
+
+    def test_install_all_hooks_accepts_shell_split_comma_space_overwrite_list(self) -> None:
+        result = subprocess.run(
+            [
+                "bash",
+                str(self.installer),
+                "--install-all-hooks",
+                "--overwrite-hook-files",
+                "test_sdlc_hooks.py,",
+                "stop_sdlc_continue.py",
+            ],
+            cwd=str(self.repo_root),
+            env=self.env,
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertTrue(self.installed_hook_target("tests/test_sdlc_hooks.py").exists())
+        self.assertTrue(self.installed_hook_target("stop_sdlc_continue.py").exists())
+
     def test_overwrite_hook_files_unknown_basename_fails_before_mutation(self) -> None:
         hook_source = self.make_hook_source({"demo.py": "print('v1')\n"})
 
@@ -439,6 +495,26 @@ class AgentNebiusAuthHookInstallRegistrationTest(unittest.TestCase):
             "--overwrite-hook-files must be combined with --install-hooks or --install-all-hooks",
             result.stderr,
         )
+
+    def test_install_hooks_requires_source_before_other_options(self) -> None:
+        result = subprocess.run(
+            [
+                "bash",
+                str(self.installer),
+                "--install-hooks",
+                "--overwrite-hook-files",
+                "demo.py",
+            ],
+            cwd=str(self.repo_root),
+            env=self.env,
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+
+        self.assertNotEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertIn("--install-hooks requires a source hook directory", result.stderr)
+        self.assertIn("Use --install-all-hooks", result.stdout)
 
     def test_repeated_install_all_hooks_reports_unchanged_by_source(self) -> None:
         first = self.run_all_hooks_installer()

--- a/skills/agent-nebius-auth/scripts/test_install_hook_registration.py
+++ b/skills/agent-nebius-auth/scripts/test_install_hook_registration.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import json
+import hashlib
 import os
 from pathlib import Path
 import subprocess
@@ -63,6 +64,35 @@ class AgentNebiusAuthHookInstallRegistrationTest(unittest.TestCase):
     def installed_hook_path(self) -> Path:
         return self.codex_home / "hooks" / "pre_tool_use_nebius_auth.py"
 
+    def installed_hook_target(self, relative_path: str) -> Path:
+        return self.codex_home / "hooks" / relative_path
+
+    def hook_provenance_path(self) -> Path:
+        return self.codex_home / ".install-hooks-state" / "hook-files.tsv"
+
+    def hook_provenance(self) -> dict[str, dict[str, str]]:
+        entries: dict[str, dict[str, str]] = {}
+        for line in self.hook_provenance_path().read_text(encoding="utf-8").splitlines():
+            dest_rel, source_id, source_rel, source_sha, target_sha = line.split("\t")
+            entries[dest_rel] = {
+                "source_id": source_id,
+                "source_rel": source_rel,
+                "source_sha": source_sha,
+                "target_sha": target_sha,
+            }
+        return entries
+
+    def file_sha256(self, path: Path) -> str:
+        return hashlib.sha256(path.read_bytes()).hexdigest()
+
+    def make_hook_source(self, files: dict[str, str]) -> Path:
+        hook_source = self.root / f"hook-source-{len(list(self.root.glob('hook-source-*')))}"
+        for relative_path, content in files.items():
+            target = hook_source / relative_path
+            target.parent.mkdir(parents=True, exist_ok=True)
+            target.write_text(content, encoding="utf-8")
+        return hook_source
+
     def hook_registrations(self) -> list[dict[str, str]]:
         hooks = json.loads((self.codex_home / "hooks.json").read_text(encoding="utf-8"))
         return [
@@ -95,6 +125,26 @@ class AgentNebiusAuthHookInstallRegistrationTest(unittest.TestCase):
                 str(self.installer),
                 "--install-hooks",
                 HOOK_SOURCE,
+            ],
+            cwd=str(self.repo_root),
+            env=self.env,
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+
+    def run_custom_hook_installer(
+        self,
+        hook_source: Path,
+        *extra_args: str,
+    ) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            [
+                "bash",
+                str(self.installer),
+                "--install-hooks",
+                str(hook_source),
+                *extra_args,
             ],
             cwd=str(self.repo_root),
             env=self.env,
@@ -267,6 +317,128 @@ class AgentNebiusAuthHookInstallRegistrationTest(unittest.TestCase):
         self.assertFalse((self.codex_home / "hooks.json").exists())
         self.assertIn("refusing to replace existing customized hook file", result.stderr)
         self.assertIn("pre_tool_use_nebius_auth.py", result.stderr)
+
+    def test_hook_install_records_file_provenance(self) -> None:
+        result = self.run_installer_copy_only()
+
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        source_hook = self.repo_root / HOOK_SOURCE / "pre_tool_use_nebius_auth.py"
+        entries = self.hook_provenance()
+        self.assertIn("pre_tool_use_nebius_auth.py", entries)
+        entry = entries["pre_tool_use_nebius_auth.py"]
+        self.assertEqual(entry["source_id"], f"local:{(self.repo_root / HOOK_SOURCE).resolve()}")
+        self.assertEqual(entry["source_rel"], "pre_tool_use_nebius_auth.py")
+        self.assertEqual(entry["source_sha"], self.file_sha256(source_hook))
+        self.assertEqual(entry["target_sha"], self.file_sha256(self.installed_hook_path()))
+
+    def test_source_changed_unmodified_hook_auto_upgrades_from_provenance(self) -> None:
+        hook_source = self.make_hook_source({"demo.py": "print('v1')\n"})
+        first = self.run_custom_hook_installer(hook_source)
+        (hook_source / "demo.py").write_text("print('v2')\n", encoding="utf-8")
+
+        second = self.run_custom_hook_installer(hook_source)
+
+        self.assertEqual(first.returncode, 0, first.stdout + first.stderr)
+        self.assertEqual(second.returncode, 0, second.stdout + second.stderr)
+        target = self.installed_hook_target("demo.py")
+        self.assertEqual(target.read_text(encoding="utf-8"), "print('v2')\n")
+        entry = self.hook_provenance()["demo.py"]
+        self.assertEqual(entry["source_sha"], self.file_sha256(hook_source / "demo.py"))
+        self.assertEqual(entry["target_sha"], self.file_sha256(target))
+        self.assertIn("files: updated 1", second.stdout)
+
+    def test_local_hook_edit_still_refuses_after_provenance(self) -> None:
+        hook_source = self.make_hook_source({"demo.py": "print('v1')\n"})
+        first = self.run_custom_hook_installer(hook_source)
+        target = self.installed_hook_target("demo.py")
+        custom_hook = "print('local edit')\n"
+        target.write_text(custom_hook, encoding="utf-8")
+
+        second = self.run_custom_hook_installer(hook_source)
+
+        self.assertEqual(first.returncode, 0, first.stdout + first.stderr)
+        self.assertNotEqual(second.returncode, 0, second.stdout + second.stderr)
+        self.assertEqual(target.read_text(encoding="utf-8"), custom_hook)
+        self.assertIn("refusing to replace existing customized hook file", second.stderr)
+        self.assertIn("--overwrite-hook-files demo.py", second.stderr)
+
+    def test_overwrite_hook_files_replaces_custom_hook_with_backup(self) -> None:
+        hook_source = self.make_hook_source({"demo.py": "print('v1')\n"})
+        first = self.run_custom_hook_installer(hook_source)
+        target = self.installed_hook_target("demo.py")
+        custom_hook = "print('local edit')\n"
+        target.write_text(custom_hook, encoding="utf-8")
+        (hook_source / "demo.py").write_text("print('v2')\n", encoding="utf-8")
+
+        second = self.run_custom_hook_installer(
+            hook_source,
+            "--overwrite-hook-files",
+            "demo.py",
+        )
+
+        self.assertEqual(first.returncode, 0, first.stdout + first.stderr)
+        self.assertEqual(second.returncode, 0, second.stdout + second.stderr)
+        self.assertEqual(target.read_text(encoding="utf-8"), "print('v2')\n")
+        backups = list((self.codex_home / ".install-hooks-state" / "backups").glob("*/demo.py"))
+        self.assertEqual(len(backups), 1)
+        self.assertEqual(backups[0].read_text(encoding="utf-8"), custom_hook)
+        entry = self.hook_provenance()["demo.py"]
+        self.assertEqual(entry["source_sha"], self.file_sha256(hook_source / "demo.py"))
+        self.assertEqual(entry["target_sha"], self.file_sha256(target))
+
+    def test_overwrite_hook_files_unknown_basename_fails_before_mutation(self) -> None:
+        hook_source = self.make_hook_source({"demo.py": "print('v1')\n"})
+
+        result = self.run_custom_hook_installer(
+            hook_source,
+            "--overwrite-hook-files",
+            "missing.py",
+        )
+
+        self.assertNotEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertFalse(self.installed_hook_target("demo.py").exists())
+        self.assertFalse(self.hook_provenance_path().exists())
+        self.assertIn("not present in selected source: missing.py", result.stderr)
+
+    def test_overwrite_hook_files_duplicate_basename_fails_before_mutation(self) -> None:
+        hook_source = self.make_hook_source(
+            {
+                "one/duplicate.py": "print('same')\n",
+                "two/duplicate.py": "print('same')\n",
+            }
+        )
+
+        result = self.run_custom_hook_installer(
+            hook_source,
+            "--overwrite-hook-files",
+            "duplicate.py",
+        )
+
+        self.assertNotEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertFalse(self.installed_hook_target("one/duplicate.py").exists())
+        self.assertFalse(self.installed_hook_target("two/duplicate.py").exists())
+        self.assertIn("duplicate basename: duplicate.py", result.stderr)
+
+    def test_overwrite_hook_files_requires_hook_install_mode(self) -> None:
+        result = subprocess.run(
+            [
+                "bash",
+                str(self.installer),
+                "--overwrite-hook-files",
+                "demo.py",
+            ],
+            cwd=str(self.repo_root),
+            env=self.env,
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+
+        self.assertNotEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertIn(
+            "--overwrite-hook-files must be combined with --install-hooks or --install-all-hooks",
+            result.stderr,
+        )
 
     def test_repeated_install_all_hooks_reports_unchanged_by_source(self) -> None:
         first = self.run_all_hooks_installer()

--- a/skills/config-codex/README.md
+++ b/skills/config-codex/README.md
@@ -505,12 +505,15 @@ Low-level hook file sync can use the root installer:
 The first command syncs every reviewed hook-only bundle under the source skills
 folder. The second command syncs only this skill's hook payload templates. Both
 copy into `$CODEX_HOME/hooks` with `.template` stripped from installed file
-names, copy missing hook files, leave matching hook files unchanged, and stop
-before replacing any differing existing hook file. Add `--register-hooks` when
-the installer should semantically merge the bundle's hook registration into
+names, copy missing hook files, leave matching hook files unchanged, and
+upgrade source-owned unmodified hook files using local provenance hashes. They
+still stop before replacing unproven local edits unless the hook basename is
+listed with `--overwrite-hook-files`, which backs up each replaced target under
+`$CODEX_HOME/.install-hooks-state/backups/`. Add `--register-hooks` when the
+installer should semantically merge the bundle's hook registration into
 `$CODEX_HOME/hooks.json`; registration still does not trust hooks, patch
-`config.toml`, replace `AGENTS.md`, or replace the full `config-codex` setup
-workflow.
+`config.toml`, replace `AGENTS.md`, replace hook payload files, or replace the
+full `config-codex` setup workflow.
 
 - `agents/openai.yaml`: UI metadata and implicit invocation policy.
 

--- a/skills/config-codex/references/local-setup.md
+++ b/skills/config-codex/references/local-setup.md
@@ -131,9 +131,12 @@ merge model for hook bundles by default: it validates `hooks.json`, preserves
 existing entries, and appends only missing source entries. It also refuses
 duplicate Python hook files within the same hook event so stale variants cannot
 silently run alongside current registrations. Hook file installation copies
-missing files, leaves matching files unchanged, and stops before replacing any
-differing existing hook file so local customizations can be reviewed manually.
-It still does not trust hooks or patch `config.toml`. Add
+missing files, leaves matching files unchanged, and upgrades source-owned
+unmodified hook files using local provenance hashes. It stops before replacing
+unproven local edits so local customizations can be reviewed manually unless
+the operator intentionally lists the hook basename with `--overwrite-hook-files`,
+which backs up each replaced target first. It still does not trust hooks or
+patch `config.toml`. Add
 `--replace-hooks-json` only when the operator intentionally wants to back up
 and replace `hooks.json` with a clean file built from the selected source
 manifests. Hook install modes are idempotent and report extra installed hook

--- a/skills/install-skills.sh
+++ b/skills/install-skills.sh
@@ -136,7 +136,8 @@ show_usage() {
   printf '%b\n' "                    file built only from selected source manifest(s)"
   printf '%b\n' "  ${S_YELLOW}--overwrite-hook-files${S_RESET}"
   printf '%b\n' "                    Intentionally replace listed hook file basenames,"
-  printf '%b\n' "                    comma-separated or repeated; backs up each target first"
+  printf '%b\n' "                    comma-separated, comma-and-space separated, or repeated;"
+  printf '%b\n' "                    backs up each target first"
   printf '\n'
 
   printf '%b\n' "${S_BOLD}Examples:${S_RESET}"
@@ -150,7 +151,8 @@ show_usage() {
   printf '%b\n' "  ${S_CYAN}./install-skills.sh --install-hooks config-codex/assets/hooks --register-hooks${S_RESET}"
   printf '%b\n' "  ${S_CYAN}./install-skills.sh --install-all-hooks --register-hooks${S_RESET}"
   printf '%b\n' "  ${S_CYAN}./install-skills.sh --install-all-hooks --register-hooks --replace-hooks-json${S_RESET}"
-  printf '%b\n' "  ${S_CYAN}./install-skills.sh --install-all-hooks --overwrite-hook-files stop_sdlc_continue.py,test_sdlc_hooks.py${S_RESET}"
+  printf '%b\n' "  ${S_CYAN}./install-skills.sh --install-all-hooks --overwrite-hook-files stop_sdlc_continue.py, test_sdlc_hooks.py${S_RESET}"
+  printf '%b\n' "  ${S_CYAN}./install-skills.sh --install-hooks sdlc-start/assets/hooks --overwrite-hook-files stop_sdlc_continue.py, test_sdlc_hooks.py${S_RESET}"
   printf '\n'
 
   printf '%b\n' "${S_BOLD}Notes:${S_RESET}"
@@ -729,23 +731,36 @@ normalize_overwrite_hook_files() {
   local part=""
   local name=""
   local tmp_file=""
+  local raw_values=()
+  local raw_count=0
+  local idx=0
   local parts=()
 
   shift
+  raw_values=("$@")
+  raw_count="${#raw_values[@]}"
   tmp_file="$(mktemp)"
   : > "${tmp_file}"
-  for raw in "$@"; do
+  for ((idx = 0; idx < raw_count; idx++)); do
+    raw="${raw_values[idx]}"
     compact="${raw//[[:space:]]/}"
-    if [[ -z "${compact}" || "${compact}" == ","* || "${compact}" == *"," || "${compact}" == *",,"* ]]; then
+    if [[ -z "${compact}" || "${compact}" == ","* || "${compact}" == *",,"* ]]; then
       log_error "--overwrite-hook-files contains an empty hook file name."
       rm -f "${tmp_file}"
       exit 1
     fi
+    if [[ "${compact}" == *"," ]]; then
+      if [[ "${idx}" -eq $((raw_count - 1)) ]]; then
+        log_error "--overwrite-hook-files contains an empty hook file name."
+        rm -f "${tmp_file}"
+        exit 1
+      fi
+      compact="${compact%,}"
+    fi
 
-    IFS=',' read -r -a parts <<< "${raw}"
+    IFS=',' read -r -a parts <<< "${compact}"
     for part in "${parts[@]}"; do
-      name="${part#"${part%%[![:space:]]*}"}"
-      name="${name%"${name##*[![:space:]]}"}"
+      name="${part}"
       if [[ -z "${name}" ]]; then
         log_error "--overwrite-hook-files contains an empty hook file name."
         rm -f "${tmp_file}"
@@ -1955,8 +1970,9 @@ while [[ $# -gt 0 ]]; do
       shift 2
       ;;
     --install-hooks)
-      if [[ $# -lt 2 ]]; then
+      if [[ $# -lt 2 || "${2}" == -* ]]; then
         log_error "--install-hooks requires a source hook directory."
+        log_note "Use --install-all-hooks to sync every reviewed hook bundle, or pass a hook-only source such as sdlc-start/assets/hooks."
         show_usage >&2
         exit 1
       fi
@@ -1996,13 +2012,16 @@ while [[ $# -gt 0 ]]; do
       shift
       ;;
     --overwrite-hook-files)
-      if [[ $# -lt 2 ]]; then
+      shift
+      if [[ $# -eq 0 || "${1}" == -* ]]; then
         log_error "--overwrite-hook-files requires a comma-separated hook file basename list."
         show_usage >&2
         exit 1
       fi
-      OVERWRITE_HOOK_FILES+=("$2")
-      shift 2
+      while [[ $# -gt 0 && "${1}" != -* ]]; do
+        OVERWRITE_HOOK_FILES+=("$1")
+        shift
+      done
       ;;
     --)
       shift

--- a/skills/install-skills.sh
+++ b/skills/install-skills.sh
@@ -5,8 +5,8 @@ set -euo pipefail
 #
 # Usage: ./install-skills.sh [source] [destination_dir]
 #        ./install-skills.sh --remove-skill <skill_name> [destination_dir]
-#        ./install-skills.sh --install-hooks <source_hook_dir> [--register-hooks] [--replace-hooks-json]
-#        ./install-skills.sh --install-all-hooks [--register-hooks] [--replace-hooks-json]
+#        ./install-skills.sh --install-hooks <source_hook_dir> [--register-hooks] [--replace-hooks-json] [--overwrite-hook-files <name[,name...]>]
+#        ./install-skills.sh --install-all-hooks [--register-hooks] [--replace-hooks-json] [--overwrite-hook-files <name[,name...]>]
 #        ./install-skills.sh --help
 # No-argument install: source is this script's directory and destination is
 # ~/.agents/skills. --remove-skill without a destination removes from the same
@@ -16,8 +16,8 @@ set -euo pipefail
 #   - https://github.com/<owner>/<repo>/tree/<ref>/<subpath>
 #
 # Requirements: bash, rsync, and git (GitHub sources only). Hook installation
-# also uses install, find, cmp, chmod, awk, cut, sort, and mktemp. Hook
-# registration also uses python3.
+# also uses install, find, cmp, chmod, awk, cut, sort, date, mktemp, and
+# shasum or sha256sum. Hook registration also uses python3.
 # How behavior is enforced:
 #   - Skill detection: only directories containing SKILL.md are treated as skills.
 #   - Idempotency: rsync keeps destination in sync (--delete, --omit-dir-times) and
@@ -29,11 +29,13 @@ set -euo pipefail
 #   - Drift visibility: destination skills missing from the selected source are
 #     listed at the end with a --remove-skill hint instead of being removed unless
 #     they are still marked as owned by the same source.
-#   - Hook drift visibility: hook installation copies missing hook files and
-#     leaves differing existing hook files for manual review. It lists extra
-#     installed hook files and hooks.json registrations that are not present in
-#     the selected source manifests, but it never deletes them automatically
-#     unless --replace-hooks-json is explicitly set for registrations.
+#   - Hook drift visibility: hook installation copies missing hook files,
+#     upgrades source-owned unmodified hook files using provenance hashes, and
+#     leaves unproven local edits for manual review unless explicitly listed
+#     with --overwrite-hook-files. It lists extra installed hook files and
+#     hooks.json registrations that are not present in the selected source
+#     manifests, but it never deletes them automatically unless
+#     --replace-hooks-json is explicitly set for registrations.
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 DEFAULT_SRC_DIR="${SCRIPT_DIR}"
@@ -94,8 +96,8 @@ show_usage() {
   printf '%b\n' "${S_BOLD}Usage:${S_RESET}"
   printf '%b\n' "  ${S_CYAN}./install-skills.sh${S_RESET} ${S_DIM}[source] [destination_dir]${S_RESET}"
   printf '%b\n' "  ${S_CYAN}./install-skills.sh${S_RESET} ${S_DIM}--remove-skill <skill_name> [destination_dir]${S_RESET}"
-  printf '%b\n' "  ${S_CYAN}./install-skills.sh${S_RESET} ${S_DIM}--install-hooks <source_hook_dir> [--register-hooks] [--replace-hooks-json]${S_RESET}"
-  printf '%b\n' "  ${S_CYAN}./install-skills.sh${S_RESET} ${S_DIM}--install-all-hooks [--register-hooks] [--replace-hooks-json]${S_RESET}"
+  printf '%b\n' "  ${S_CYAN}./install-skills.sh${S_RESET} ${S_DIM}--install-hooks <source_hook_dir> [--register-hooks] [--replace-hooks-json] [--overwrite-hook-files <name[,name...]>]${S_RESET}"
+  printf '%b\n' "  ${S_CYAN}./install-skills.sh${S_RESET} ${S_DIM}--install-all-hooks [--register-hooks] [--replace-hooks-json] [--overwrite-hook-files <name[,name...]>]${S_RESET}"
   printf '%b\n' "  ${S_CYAN}./install-skills.sh${S_RESET} ${S_DIM}--help${S_RESET}"
   printf '\n'
 
@@ -120,7 +122,7 @@ show_usage() {
   printf '%b\n' "  ${S_YELLOW}--remove-skill${S_RESET}   Remove one skill by its visible Codex skill name or folder name"
   printf '%b\n' "  ${S_YELLOW}--install-hooks${S_RESET}  Copy hook files from a source hook directory into"
   printf '%b\n' "                    ${S_CYAN}\${CODEX_HOME:-~/.codex}/hooks${S_RESET}, stripping .template suffixes"
-  printf '%b\n' "                    and refusing to replace differing existing hook files"
+  printf '%b\n' "                    and refusing unproven local hook edits"
   printf '%b\n' "                    without modifying hooks.json unless --register-hooks is also set"
   printf '%b\n' "  ${S_YELLOW}--install-all-hooks${S_RESET}"
   printf '%b\n' "                    Copy hook files from every ${S_CYAN}*/assets/hooks${S_RESET} directory"
@@ -132,6 +134,9 @@ show_usage() {
   printf '%b\n' "  ${S_YELLOW}--replace-hooks-json${S_RESET}"
   printf '%b\n' "                    With --register-hooks, replace hooks.json with a clean"
   printf '%b\n' "                    file built only from selected source manifest(s)"
+  printf '%b\n' "  ${S_YELLOW}--overwrite-hook-files${S_RESET}"
+  printf '%b\n' "                    Intentionally replace listed hook file basenames,"
+  printf '%b\n' "                    comma-separated or repeated; backs up each target first"
   printf '\n'
 
   printf '%b\n' "${S_BOLD}Examples:${S_RESET}"
@@ -145,6 +150,7 @@ show_usage() {
   printf '%b\n' "  ${S_CYAN}./install-skills.sh --install-hooks config-codex/assets/hooks --register-hooks${S_RESET}"
   printf '%b\n' "  ${S_CYAN}./install-skills.sh --install-all-hooks --register-hooks${S_RESET}"
   printf '%b\n' "  ${S_CYAN}./install-skills.sh --install-all-hooks --register-hooks --replace-hooks-json${S_RESET}"
+  printf '%b\n' "  ${S_CYAN}./install-skills.sh --install-all-hooks --overwrite-hook-files stop_sdlc_continue.py,test_sdlc_hooks.py${S_RESET}"
   printf '\n'
 
   printf '%b\n' "${S_BOLD}Notes:${S_RESET}"
@@ -157,10 +163,12 @@ show_usage() {
   printf '%b\n' "  - Reinstalling from a source that still contains the skill will add it back."
   printf '%b\n' "  - ${S_CYAN}--install-hooks${S_RESET} is opt-in because hooks are runtime guardrails, not skills."
   printf '%b\n' "  - ${S_CYAN}--install-all-hooks${S_RESET} discovers only hook-only ${S_CYAN}*/assets/hooks${S_RESET} directories under this source."
-  printf '%b\n' "  - Existing hook files with different content are left unchanged for manual review."
+  printf '%b\n' "  - Source-owned unmodified hook files are upgraded using local provenance hashes."
+  printf '%b\n' "  - Unproven local hook edits are left unchanged for manual review unless listed with ${S_CYAN}--overwrite-hook-files${S_RESET}."
   printf '%b\n' "  - ${S_CYAN}--register-hooks${S_RESET} preserves existing ${S_CYAN}hooks.json${S_RESET} entries and appends missing source entries."
   printf '%b\n' "  - ${S_CYAN}--register-hooks${S_RESET} refuses duplicate Python hook files within the same hook event."
   printf '%b\n' "  - ${S_CYAN}--replace-hooks-json${S_RESET} explicitly backs up and replaces ${S_CYAN}hooks.json${S_RESET} with selected source entries."
+  printf '%b\n' "  - ${S_CYAN}--overwrite-hook-files${S_RESET} affects hook payload files only, not ${S_CYAN}hooks.json${S_RESET}."
   printf '%b\n' "  - Hook installation reports extra installed hook files and ${S_CYAN}hooks.json${S_RESET} entries not present in the selected source."
   printf '%b\n' "  - After installing new or changed hooks, restart Codex and review/trust the hook entries in ${S_CYAN}/hooks${S_RESET}."
   printf '%b\n' "  - If newly installed skills are not visible, restart the VS Code extension host ${S_DIM}(Developer: Restart Extension Host)${S_RESET}."
@@ -185,6 +193,30 @@ hash_string() {
 
   # Fallback key if hashing tools are unavailable.
   printf '%s' "${value}" | tr '/ :@' '____'
+}
+
+hash_file() {
+  local file="$1"
+
+  if command -v shasum >/dev/null 2>&1; then
+    shasum -a 256 "${file}" | awk '{print $1}'
+    return
+  fi
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "${file}" | awk '{print $1}'
+    return
+  fi
+
+  log_error "either 'shasum' or 'sha256sum' is required for hook file provenance."
+  exit 1
+}
+
+require_hook_hash_command() {
+  if ! command -v shasum >/dev/null 2>&1 && ! command -v sha256sum >/dev/null 2>&1; then
+    log_error "either 'shasum' or 'sha256sum' is required for hook file provenance."
+    log_note "Install one SHA-256 tool and run again."
+    exit 1
+  fi
 }
 
 expand_home_path() {
@@ -591,34 +623,240 @@ hook_source_label() {
   printf '%s\n' "${hook_src}"
 }
 
+hook_source_id() {
+  local hook_src="$1"
+
+  printf 'local:%s\n' "${hook_src}"
+}
+
+hook_state_dir() {
+  local codex_home="$1"
+
+  printf '%s/.install-hooks-state\n' "${codex_home}"
+}
+
+hook_state_file() {
+  local codex_home="$1"
+
+  printf '%s/hook-files.tsv\n' "$(hook_state_dir "${codex_home}")"
+}
+
+read_hook_target_hash_from_state() {
+  local codex_home="$1"
+  local dest_rel="$2"
+  local source_id="$3"
+  local state_file=""
+
+  state_file="$(hook_state_file "${codex_home}")"
+  [[ -f "${state_file}" ]] || return 1
+
+  awk -F '\t' -v dest_rel="${dest_rel}" -v source_id="${source_id}" '
+    $1 == dest_rel && $2 == source_id { print $5; found = 1; exit }
+    END { exit found ? 0 : 1 }
+  ' "${state_file}"
+}
+
+write_hook_file_provenance() {
+  local codex_home="$1"
+  local dest_rel="$2"
+  local source_id="$3"
+  local source_rel="$4"
+  local source_sha="$5"
+  local target_sha="$6"
+  local state_dir=""
+  local state_file=""
+  local tmp_state=""
+
+  state_dir="$(hook_state_dir "${codex_home}")"
+  state_file="$(hook_state_file "${codex_home}")"
+  mkdir -p "${state_dir}"
+  tmp_state="$(mktemp)"
+
+  if [[ -f "${state_file}" ]]; then
+    awk -F '\t' -v dest_rel="${dest_rel}" '$1 != dest_rel { print }' "${state_file}" > "${tmp_state}"
+  fi
+  printf '%s\t%s\t%s\t%s\t%s\n' \
+    "${dest_rel}" \
+    "${source_id}" \
+    "${source_rel}" \
+    "${source_sha}" \
+    "${target_sha}" >> "${tmp_state}"
+  sort -u "${tmp_state}" -o "${tmp_state}"
+  mv "${tmp_state}" "${state_file}"
+}
+
+hook_file_can_auto_upgrade() {
+  local codex_home="$1"
+  local dest_rel="$2"
+  local source_id="$3"
+  local dest="$4"
+  local recorded_target_sha=""
+  local current_target_sha=""
+
+  [[ -f "${dest}" ]] || return 1
+  if ! recorded_target_sha="$(read_hook_target_hash_from_state "${codex_home}" "${dest_rel}" "${source_id}")"; then
+    return 1
+  fi
+  current_target_sha="$(hash_file "${dest}")"
+  [[ "${current_target_sha}" == "${recorded_target_sha}" ]]
+}
+
+hook_overwrite_backup_dir() {
+  local codex_home="$1"
+
+  if [[ -z "${HOOK_OVERWRITE_BACKUP_DIR}" ]]; then
+    HOOK_OVERWRITE_BACKUP_DIR="$(hook_state_dir "${codex_home}")/backups/$(date -u +%Y%m%d%H%M%S)-$$"
+  fi
+  printf '%s\n' "${HOOK_OVERWRITE_BACKUP_DIR}"
+}
+
+backup_hook_file_for_overwrite() {
+  local codex_home="$1"
+  local dest_rel="$2"
+  local dest="$3"
+  local backup_dest=""
+
+  backup_dest="$(hook_overwrite_backup_dir "${codex_home}")/${dest_rel}"
+  mkdir -p "$(dirname "${backup_dest}")"
+  cp -p "${dest}" "${backup_dest}"
+  log_note "Backed up overwritten hook file: ${backup_dest}"
+}
+
+normalize_overwrite_hook_files() {
+  local output_file="$1"
+  local raw=""
+  local compact=""
+  local part=""
+  local name=""
+  local tmp_file=""
+  local parts=()
+
+  shift
+  tmp_file="$(mktemp)"
+  : > "${tmp_file}"
+  for raw in "$@"; do
+    compact="${raw//[[:space:]]/}"
+    if [[ -z "${compact}" || "${compact}" == ","* || "${compact}" == *"," || "${compact}" == *",,"* ]]; then
+      log_error "--overwrite-hook-files contains an empty hook file name."
+      rm -f "${tmp_file}"
+      exit 1
+    fi
+
+    IFS=',' read -r -a parts <<< "${raw}"
+    for part in "${parts[@]}"; do
+      name="${part#"${part%%[![:space:]]*}"}"
+      name="${name%"${name##*[![:space:]]}"}"
+      if [[ -z "${name}" ]]; then
+        log_error "--overwrite-hook-files contains an empty hook file name."
+        rm -f "${tmp_file}"
+        exit 1
+      fi
+      if [[ "${name}" == */* || "${name}" == *\\* || "${name}" == "." || "${name}" == ".." ]]; then
+        log_error "--overwrite-hook-files accepts hook file basenames only: ${name}"
+        rm -f "${tmp_file}"
+        exit 1
+      fi
+      printf '%s\n' "${name}" >> "${tmp_file}"
+    done
+  done
+  sort -u "${tmp_file}" > "${output_file}"
+  rm -f "${tmp_file}"
+}
+
+is_hook_overwrite_requested() {
+  local overwrite_names_file="$1"
+  local basename="$2"
+
+  [[ -s "${overwrite_names_file}" ]] || return 1
+  grep -Fxq -- "${basename}" "${overwrite_names_file}"
+}
+
+validate_hook_overwrite_requests() {
+  local overwrite_names_file="$1"
+  local catalog=""
+  local hook_src=""
+  local src=""
+  local rel=""
+  local dest_rel=""
+  local basename=""
+  local duplicate=""
+  local requested=""
+
+  [[ -s "${overwrite_names_file}" ]] || return 0
+
+  shift
+  catalog="$(mktemp)"
+  for hook_src in "$@"; do
+    while IFS= read -r -d '' src; do
+      rel="${src#"${hook_src}/"}"
+      is_installable_hook_rel "${rel}" || continue
+      dest_rel="${rel%.template}"
+      basename="$(basename "${dest_rel}")"
+      printf '%s\t%s\t%s\n' "${basename}" "${dest_rel}" "${src}" >> "${catalog}"
+    done < <(find "${hook_src}" -type f -print0)
+  done
+
+  duplicate="$(cut -f 1 "${catalog}" | sort | uniq -d | head -n 1 || true)"
+  if [[ -n "${duplicate}" ]]; then
+    log_error "--overwrite-hook-files cannot use basename-only matching because selected hook sources contain duplicate basename: ${duplicate}"
+    awk -F '\t' -v basename="${duplicate}" '$1 == basename { print "  - " $2 " (" $3 ")" }' "${catalog}" >&2
+    rm -f "${catalog}"
+    exit 1
+  fi
+
+  while IFS= read -r requested; do
+    [[ -n "${requested}" ]] || continue
+    if ! awk -F '\t' -v requested="${requested}" '$1 == requested { found = 1; exit } END { exit found ? 0 : 1 }' "${catalog}"; then
+      log_error "--overwrite-hook-files requested a hook file not present in selected source: ${requested}"
+      rm -f "${catalog}"
+      exit 1
+    fi
+  done < "${overwrite_names_file}"
+
+  rm -f "${catalog}"
+}
+
 HOOK_SYNC_INSTALLED=0
 HOOK_SYNC_UNCHANGED=0
 HOOK_SYNC_TOTAL=0
 HOOK_FILE_STATUS_FILE=""
+HOOK_OVERWRITE_BACKUP_DIR=""
 
 preflight_hook_file_conflicts() {
   local codex_home="$1"
+  local overwrite_names_file="$2"
   local hook_dest="${codex_home}/hooks"
   local hook_src=""
   local src=""
   local rel=""
   local dest_rel=""
   local dest=""
+  local source_id=""
+  local basename=""
   local conflicts=0
 
-  shift
+  shift 2
   for hook_src in "$@"; do
+    source_id="$(hook_source_id "${hook_src}")"
     while IFS= read -r -d '' src; do
       rel="${src#"${hook_src}/"}"
       is_installable_hook_rel "${rel}" || continue
       dest_rel="${rel%.template}"
       dest="${hook_dest}/${dest_rel}"
       if [[ -f "${dest}" ]] && ! cmp -s "${src}" "${dest}"; then
+        basename="$(basename "${dest_rel}")"
+        if hook_file_can_auto_upgrade "${codex_home}" "${dest_rel}" "${source_id}" "${dest}"; then
+          continue
+        fi
+        if is_hook_overwrite_requested "${overwrite_names_file}" "${basename}"; then
+          continue
+        fi
         if [[ "${conflicts}" -eq 0 ]]; then
           log_error "refusing to replace existing customized hook file(s)"
         fi
         printf '%b\n' "  source: ${S_CYAN}${src}${S_RESET}" >&2
         printf '%b\n' "  target: ${S_CYAN}${dest}${S_RESET}" >&2
+        printf '%b\n' "  overwrite: ${S_CYAN}--overwrite-hook-files ${basename}${S_RESET}" >&2
         conflicts=$((conflicts + 1))
       fi
     done < <(find "${hook_src}" -type f -print0)
@@ -626,7 +864,7 @@ preflight_hook_file_conflicts() {
 
   if [[ "${conflicts}" -gt 0 ]]; then
     log_note "Review the target file(s), then remove or update them manually before rerunning hook installation."
-    log_note "This installer copies missing hook files and repairs matching file permissions, but it does not overwrite local hook customizations."
+    log_note "This installer upgrades source-owned unmodified hook files, but it does not overwrite unproven local hook edits unless they are listed with --overwrite-hook-files."
     exit 1
   fi
 }
@@ -634,16 +872,25 @@ preflight_hook_file_conflicts() {
 sync_hook_files() {
   local hook_src="$1"
   local codex_home="$2"
+  local overwrite_names_file="$3"
   local hook_dest="${codex_home}/hooks"
   local source_label=""
+  local source_id=""
   local src=""
   local rel=""
   local dest_rel=""
+  local dest=""
+  local basename=""
+  local source_sha=""
+  local target_sha=""
+  local auto_upgrade=0
+  local overwrite_requested=0
 
   HOOK_SYNC_INSTALLED=0
   HOOK_SYNC_UNCHANGED=0
   HOOK_SYNC_TOTAL=0
   source_label="$(hook_source_label "${hook_src}")"
+  source_id="$(hook_source_id "${hook_src}")"
 
   mkdir -p "${hook_dest}"
 
@@ -652,13 +899,35 @@ sync_hook_files() {
     is_installable_hook_rel "${rel}" || continue
 
     dest_rel="${rel%.template}"
+    dest="${hook_dest}/${dest_rel}"
+    basename="$(basename "${dest_rel}")"
+    source_sha="$(hash_file "${src}")"
     HOOK_SYNC_TOTAL=$((HOOK_SYNC_TOTAL + 1))
-    if [[ -f "${hook_dest}/${dest_rel}" ]] && cmp -s "${src}" "${hook_dest}/${dest_rel}"; then
-      chmod 0644 "${hook_dest}/${dest_rel}"
+    if [[ -f "${dest}" ]] && cmp -s "${src}" "${dest}"; then
+      chmod 0644 "${dest}"
+      target_sha="$(hash_file "${dest}")"
+      write_hook_file_provenance "${codex_home}" "${dest_rel}" "${source_id}" "${rel}" "${source_sha}" "${target_sha}"
       HOOK_SYNC_UNCHANGED=$((HOOK_SYNC_UNCHANGED + 1))
     else
-      mkdir -p "$(dirname "${hook_dest}/${dest_rel}")"
-      install -m 0644 "${src}" "${hook_dest}/${dest_rel}"
+      auto_upgrade=0
+      overwrite_requested=0
+      if [[ -f "${dest}" ]] && hook_file_can_auto_upgrade "${codex_home}" "${dest_rel}" "${source_id}" "${dest}"; then
+        auto_upgrade=1
+      fi
+      if is_hook_overwrite_requested "${overwrite_names_file}" "${basename}"; then
+        overwrite_requested=1
+      fi
+      if [[ -f "${dest}" && "${auto_upgrade}" -eq 0 && "${overwrite_requested}" -eq 1 ]]; then
+        backup_hook_file_for_overwrite "${codex_home}" "${dest_rel}" "${dest}"
+      elif [[ -f "${dest}" && "${auto_upgrade}" -eq 0 && "${overwrite_requested}" -eq 0 ]]; then
+        log_error "refusing to replace existing customized hook file: ${dest}"
+        log_note "Use --overwrite-hook-files ${basename} after reviewing the target, or update/remove it manually."
+        exit 1
+      fi
+      mkdir -p "$(dirname "${dest}")"
+      install -m 0644 "${src}" "${dest}"
+      target_sha="$(hash_file "${dest}")"
+      write_hook_file_provenance "${codex_home}" "${dest_rel}" "${source_id}" "${rel}" "${source_sha}" "${target_sha}"
       HOOK_SYNC_INSTALLED=$((HOOK_SYNC_INSTALLED + 1))
     fi
   done < <(find "${hook_src}" -type f -print0)
@@ -1444,6 +1713,7 @@ install_hooks() {
   local report_extras="${4:-1}"
   local replace_hooks_json="${5:-0}"
   local hook_src=""
+  local overwrite_names_file=""
   local file_status_file=""
   local registration_status_file=""
 
@@ -1451,6 +1721,10 @@ install_hooks() {
   require_command "cmp" "for hook idempotency checks"
   require_command "chmod" "for hook permission repair"
   require_command "find" "for hook source discovery"
+  require_command "awk" "for hook provenance checks"
+  require_command "sort" "for hook overwrite validation"
+  require_command "date" "for hook overwrite backups"
+  require_hook_hash_command
 
   if ! hook_src="$(resolve_hook_source_dir "${hook_source_arg}")"; then
     log_error "hook source directory not found: ${hook_source_arg}"
@@ -1458,8 +1732,12 @@ install_hooks() {
     exit 1
   fi
 
+  overwrite_names_file="$(mktemp)"
+  normalize_overwrite_hook_files "${overwrite_names_file}" "${OVERWRITE_HOOK_FILES[@]}"
+  validate_hook_overwrite_requests "${overwrite_names_file}" "${hook_src}"
+
   reject_inline_agent_nebius_auth_config_hook "${codex_home}" "${hook_src}"
-  preflight_hook_file_conflicts "${codex_home}" "${hook_src}"
+  preflight_hook_file_conflicts "${codex_home}" "${overwrite_names_file}" "${hook_src}"
 
   if [[ "${register_hooks}" -eq 1 ]]; then
     require_command "python3" "for hooks.json registration"
@@ -1473,7 +1751,7 @@ install_hooks() {
   file_status_file="$(mktemp)"
   registration_status_file="$(mktemp)"
   HOOK_FILE_STATUS_FILE="${file_status_file}"
-  sync_hook_files "${hook_src}" "${codex_home}"
+  sync_hook_files "${hook_src}" "${codex_home}" "${overwrite_names_file}"
   HOOK_FILE_STATUS_FILE=""
   if [[ "${register_hooks}" -eq 1 ]]; then
     HOOK_REGISTRATION_STATUS_FILE="${registration_status_file}"
@@ -1486,7 +1764,7 @@ install_hooks() {
   if [[ "${HOOK_STATUS_REVIEW_NEEDED}" -eq 1 ]]; then
     log_action_required "Action required: hook files or registrations changed. Restart Codex and review/trust entries in /hooks."
   fi
-  rm -f "${file_status_file}" "${registration_status_file}"
+  rm -f "${file_status_file}" "${registration_status_file}" "${overwrite_names_file}"
   if [[ "${report_extras}" -eq 1 ]]; then
     print_extra_destination_hooks "${codex_home}" "${hook_src}"
   fi
@@ -1574,6 +1852,7 @@ install_all_hooks() {
   local source_root=""
   local hook_src=""
   local hook_dirs=()
+  local overwrite_names_file=""
   local file_status_file=""
   local registration_status_file=""
 
@@ -1587,6 +1866,10 @@ install_all_hooks() {
   require_command "cmp" "for hook idempotency checks"
   require_command "chmod" "for hook permission repair"
   require_command "find" "for hook source discovery"
+  require_command "awk" "for hook provenance checks"
+  require_command "sort" "for hook overwrite validation"
+  require_command "date" "for hook overwrite backups"
+  require_hook_hash_command
 
   while IFS= read -r hook_src; do
     [[ -n "${hook_src}" ]] || continue
@@ -1600,9 +1883,12 @@ install_all_hooks() {
   fi
 
   validate_hook_dest_collisions "${hook_dirs[@]}"
+  overwrite_names_file="$(mktemp)"
+  normalize_overwrite_hook_files "${overwrite_names_file}" "${OVERWRITE_HOOK_FILES[@]}"
+  validate_hook_overwrite_requests "${overwrite_names_file}" "${hook_dirs[@]}"
 
   reject_inline_agent_nebius_auth_config_hook "${codex_home}" "${hook_dirs[@]}"
-  preflight_hook_file_conflicts "${codex_home}" "${hook_dirs[@]}"
+  preflight_hook_file_conflicts "${codex_home}" "${overwrite_names_file}" "${hook_dirs[@]}"
 
   if [[ "${register_hooks}" -eq 1 ]]; then
     require_command "python3" "for hooks.json registration"
@@ -1619,7 +1905,7 @@ install_all_hooks() {
   registration_status_file="$(mktemp)"
   HOOK_FILE_STATUS_FILE="${file_status_file}"
   for hook_src in "${hook_dirs[@]}"; do
-    sync_hook_files "${hook_src}" "${codex_home}"
+    sync_hook_files "${hook_src}" "${codex_home}" "${overwrite_names_file}"
   done
   HOOK_FILE_STATUS_FILE=""
 
@@ -1634,7 +1920,7 @@ install_all_hooks() {
   if [[ "${HOOK_STATUS_REVIEW_NEEDED}" -eq 1 ]]; then
     log_action_required "Action required: hook files or registrations changed. Restart Codex and review/trust entries in /hooks."
   fi
-  rm -f "${file_status_file}" "${registration_status_file}"
+  rm -f "${file_status_file}" "${registration_status_file}" "${overwrite_names_file}"
 
   print_extra_destination_hooks "${codex_home}" "${hook_dirs[@]}"
 }
@@ -1646,6 +1932,7 @@ HOOK_INSTALL_SOURCE=""
 INSTALL_ALL_HOOKS=0
 REGISTER_HOOKS=0
 REPLACE_HOOKS_JSON=0
+OVERWRITE_HOOK_FILES=()
 POSITIONAL=()
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -1708,6 +1995,15 @@ while [[ $# -gt 0 ]]; do
       REPLACE_HOOKS_JSON=1
       shift
       ;;
+    --overwrite-hook-files)
+      if [[ $# -lt 2 ]]; then
+        log_error "--overwrite-hook-files requires a comma-separated hook file basename list."
+        show_usage >&2
+        exit 1
+      fi
+      OVERWRITE_HOOK_FILES+=("$2")
+      shift 2
+      ;;
     --)
       shift
       while [[ $# -gt 0 ]]; do
@@ -1747,6 +2043,12 @@ fi
 
 if [[ "${REPLACE_HOOKS_JSON}" -eq 1 && "${REGISTER_HOOKS}" -eq 0 ]]; then
   log_error "--replace-hooks-json must be combined with --register-hooks."
+  show_usage >&2
+  exit 1
+fi
+
+if [[ "${#OVERWRITE_HOOK_FILES[@]}" -gt 0 && -z "${HOOK_INSTALL_SOURCE}" && "${INSTALL_ALL_HOOKS}" -eq 0 ]]; then
+  log_error "--overwrite-hook-files must be combined with --install-hooks or --install-all-hooks."
   show_usage >&2
   exit 1
 fi

--- a/skills/publish-helm/README.md
+++ b/skills/publish-helm/README.md
@@ -43,7 +43,9 @@ Published OCI chart
 
 ## Core Concepts
 
-- Doer mode does not depend on a project-local `publish-helm.sh`.
+- Doer mode does not depend on a project-local `publish-helm.sh`, but the
+  setup template is a maintained runnable helper and should keep the same
+  `--mode prep|publish|verify` contract as the skill-owned doer.
 - The default branch is the release source of truth. If work is still on a
   feature branch, merge that branch to the default branch before prep or
   publish.

--- a/skills/publish-helm/SKILL.md
+++ b/skills/publish-helm/SKILL.md
@@ -109,8 +109,10 @@ Use setup mode when the chart does not already have a release flow:
 - `assets/CHANGELOG.md.template`
 - `assets/publish-helm.sh.template`
 
-The project-local helper script is optional after this refactor. The skill-owned
-`scripts/publish-helm-doer.sh` remains the canonical doer path.
+The project-local helper script is optional, but it is a maintained runnable
+helper template, not a documentation stub. Keep it behaviorally aligned with
+the skill-owned `scripts/publish-helm-doer.sh`, which remains the canonical
+doer path.
 
 ## Guardrails
 

--- a/skills/publish-helm/assets/CHANGELOG.md.template
+++ b/skills/publish-helm/assets/CHANGELOG.md.template
@@ -9,9 +9,11 @@ All notable changes to this chart are tracked here. This changelog follows
 - Keep `## [Unreleased]` at the top and add bullets as changes land.
 - Before release tagging, start from clean synced `__MAIN_BRANCH__` and move
   `Unreleased` into a dated release section with
-  `./publish-helm.sh --prep X.Y.Z`; it creates and pushes a release branch.
+  `./publish-helm.sh --mode prep --tag X.Y.Z`; it creates and pushes a release
+  branch.
 - After the release-prep PR merges to `__MAIN_BRANCH__`, run
-  `./publish-helm.sh --publish X.Y.Z` on clean synced `__MAIN_BRANCH__`.
+  `./publish-helm.sh --mode publish --tag X.Y.Z` on clean synced
+  `__MAIN_BRANCH__`.
 - The prep step updates both this chart-local changelog and `Chart.yaml`.
 - The publish step only creates and pushes tag `__PROJECT_TAG_PREFIX__-vX.Y.Z`;
   it fails fast if `Chart.yaml` does not already match the tag version. The

--- a/skills/publish-helm/assets/publish-helm.sh.template
+++ b/skills/publish-helm/assets/publish-helm.sh.template
@@ -19,6 +19,7 @@ S_RED=""
 S_YELLOW=""
 S_GREEN=""
 S_CYAN=""
+VERIFY_PULL_DIR=""
 
 init_output_style() {
   if [[ ( -t 1 || -t 2 ) && "${TERM:-}" != "dumb" && -z "${NO_COLOR:-}" ]]; then
@@ -44,29 +45,47 @@ log_success() {
   printf '%b\n' "${S_GREEN}${1}${S_RESET}"
 }
 
+cleanup_verify_pull_dir() {
+  if [[ -n "${VERIFY_PULL_DIR:-}" ]]; then
+    rm -rf "${VERIFY_PULL_DIR}"
+  fi
+}
+
 show_usage() {
   printf '%b\n' "${S_BOLD}Usage:${S_RESET}"
-  printf '%b\n' "  ${S_CYAN}./publish-helm.sh${S_RESET} ${S_DIM}--prep X.Y.Z[-prerelease] [--no-push]${S_RESET}"
-  printf '%b\n' "  ${S_CYAN}./publish-helm.sh${S_RESET} ${S_DIM}--publish X.Y.Z[-prerelease]${S_RESET}"
+  printf '%b\n' "  ${S_CYAN}./publish-helm.sh${S_RESET} ${S_DIM}--mode prep --tag X.Y.Z[-prerelease] [options]${S_RESET}"
+  printf '%b\n' "  ${S_CYAN}./publish-helm.sh${S_RESET} ${S_DIM}--mode publish --tag X.Y.Z[-prerelease] [options]${S_RESET}"
+  printf '%b\n' "  ${S_CYAN}./publish-helm.sh${S_RESET} ${S_DIM}--mode verify --tag X.Y.Z[-prerelease] --oci-repository OCI_BASE [options]${S_RESET}"
   printf '\n'
 
   printf '%b\n' "${S_BOLD}Modes:${S_RESET}"
-  printf '%b\n' "  ${S_YELLOW}--prep${S_RESET}     Require clean synced ${MAIN_BRANCH}, create release/${TAG_PREFIX}-vX.Y.Z[-prerelease], update ${CHANGELOG_FILE} and ${CHART_FILE}, validate the chart, commit it, and push the release branch."
+  printf '%b\n' "  ${S_YELLOW}prep${S_RESET}      Require clean synced default branch, create release/<tag>, update the changelog and Chart.yaml, validate the chart, commit it, and push the release branch."
   printf '%b\n' "                 Clean-worktree check is strict and includes untracked files."
-  printf '%b\n' "                 Fails if tag ${TAG_PREFIX}-vX.Y.Z[-prerelease] already exists locally or on origin."
-  printf '%b\n' "  ${S_YELLOW}--publish${S_RESET}  Create and push tag ${TAG_PREFIX}-vX.Y.Z[-prerelease]."
-  printf '%b\n' "                 Fails if ${CHART_FILE} does not already declare the release version; run --prep first."
+  printf '%b\n' "                 Fails if the tag already exists locally or on origin."
+  printf '%b\n' "  ${S_YELLOW}publish${S_RESET}   Create and push the annotated release tag."
+  printf '%b\n' "                 Fails if Chart.yaml does not already declare the release version; run prep first."
   printf '%b\n' "                 Tag push triggers .github/workflows/helm-chart-publish.yml."
+  printf '%b\n' "  ${S_YELLOW}verify${S_RESET}    Pull the published chart from an OCI repository base."
   printf '\n'
 
   printf '%b\n' "${S_BOLD}Options:${S_RESET}"
-  printf '%b\n' "  ${S_YELLOW}--no-push${S_RESET}          For --prep only: do not push the branch."
-  printf '%b\n' "  ${S_YELLOW}-h, --help${S_RESET}         Show help."
+  printf '%b\n' "  ${S_YELLOW}--tag TAG${S_RESET}             Version or full ${TAG_PREFIX}-vX.Y.Z[-prerelease] tag."
+  printf '%b\n' "  ${S_YELLOW}--project-dir DIR${S_RESET}     Project directory, default repository root for this helper."
+  printf '%b\n' "  ${S_YELLOW}--main-branch BRANCH${S_RESET}  Default branch, default ${MAIN_BRANCH}."
+  printf '%b\n' "  ${S_YELLOW}--tag-prefix PREFIX${S_RESET}   Release tag prefix, default ${TAG_PREFIX}."
+  printf '%b\n' "  ${S_YELLOW}--chart-dir DIR${S_RESET}       Chart directory, default ${CHART_DIR}."
+  printf '%b\n' "  ${S_YELLOW}--chart-name NAME${S_RESET}     Chart name, default ${CHART_NAME}."
+  printf '%b\n' "  ${S_YELLOW}--changelog FILE${S_RESET}      Changelog path, default ${CHANGELOG_FILE}."
+  printf '%b\n' "  ${S_YELLOW}--oci-repository OCI${S_RESET}  Verify mode: OCI repository base without chart name or version."
+  printf '%b\n' "  ${S_YELLOW}--public-verify${S_RESET}       Verify mode hint: use the current Helm auth session as-is."
+  printf '%b\n' "  ${S_YELLOW}--no-push${S_RESET}             Prep only: do not push the branch."
+  printf '%b\n' "  ${S_YELLOW}-h, --help${S_RESET}            Show help."
   printf '\n'
 
   printf '%b\n' "${S_BOLD}Examples:${S_RESET}"
-  printf '%b\n' "  ${S_CYAN}./publish-helm.sh --prep 0.1.0${S_RESET}"
-  printf '%b\n' "  ${S_CYAN}./publish-helm.sh --publish 0.1.0${S_RESET}"
+  printf '%b\n' "  ${S_CYAN}./publish-helm.sh --mode prep --tag 0.1.0${S_RESET}"
+  printf '%b\n' "  ${S_CYAN}./publish-helm.sh --mode publish --tag 0.1.0${S_RESET}"
+  printf '%b\n' "  ${S_CYAN}./publish-helm.sh --mode verify --tag 0.1.0 --oci-repository oci://registry.example.com/org/charts${S_RESET}"
   printf '\n'
   printf '%b\n' "${S_DIM}The chart upload target is owned by the tag-triggered workflow or project configuration, not this helper.${S_RESET}"
 }
@@ -464,7 +483,7 @@ ensure_chart_version_matches_tag() {
 
   if [[ "${chart_version}" != "${expected_version}" ]]; then
     log_error "${CHART_FILE} version ${chart_version} does not match release ${expected_version}."
-    log_note "Run --prep ${expected_version} and merge that ${CHART_FILE} change before publishing."
+    log_note "Run --mode prep --tag ${expected_version} and merge that ${CHART_FILE} change before publishing."
     exit 1
   fi
 }
@@ -505,8 +524,8 @@ prep_release() {
   local release_branch=""
   local staged_paths=("${CHANGELOG_FILE}" "${CHART_FILE}")
 
-  ensure_release_source_ready "${branch}" "prep"
   ensure_tag_absent "${tag}"
+  ensure_release_source_ready "${branch}" "prep"
   release_branch="$(release_branch_name "${tag}")"
   ensure_release_branch_absent "${release_branch}"
   git switch -c "${release_branch}"
@@ -547,36 +566,70 @@ prep_release() {
   fi
 }
 
-create_and_push_tag() {
+publish_tag() {
   local tag="$1"
+  local version="${tag##*-v}"
+  ensure_clean_worktree
   ensure_release_section_ready "${tag}"
   ensure_chart_version_matches_tag "${tag}"
   ensure_tag_absent "${tag}"
   git tag -a "${tag}" -m "Release ${tag}"
   git push origin "refs/tags/${tag}"
   log_success "Tag pushed: ${tag}"
-  log_success "The chart publish workflow will run from this tag push."
+  log_success "The chart publish workflow will run from this tag push for version ${version}."
+}
+
+validate_oci_repository_base() {
+  local oci_repository="$1"
+  local chart_name="$2"
+  [[ -n "${oci_repository}" ]] || { log_error "--oci-repository is required for verify mode."; exit 1; }
+  [[ "${oci_repository}" == oci://* ]] || { log_error "--oci-repository must start with oci://"; exit 1; }
+  if [[ "${oci_repository%/}" == */"${chart_name}" ]]; then
+    log_error "--oci-repository must be the repository base and must not include chart name '${chart_name}'."
+    exit 1
+  fi
+}
+
+verify_chart() {
+  local oci_repository="$1"
+  local chart_name="$2"
+  local version="$3"
+  require_cmd "helm"
+  validate_oci_repository_base "${oci_repository}" "${chart_name}"
+  VERIFY_PULL_DIR="$(mktemp -d)"
+  trap cleanup_verify_pull_dir EXIT
+  helm pull "${oci_repository%/}/${chart_name}" --version "${version}" -d "${VERIFY_PULL_DIR}"
+  log_success "Verified chart pull: ${oci_repository%/}/${chart_name} --version ${version}"
 }
 
 main() {
   init_output_style
 
   local mode=""
-  local raw_version=""
+  local raw_tag=""
+  local tag_prefix="${TAG_PREFIX}"
+  local project_dir="${REPO_ROOT}"
+  local main_branch="${MAIN_BRANCH}"
+  local chart_dir="${CHART_DIR}"
+  local chart_name="${CHART_NAME}"
+  local changelog="${CHANGELOG_FILE}"
+  local oci_repository=""
   local no_push=0
 
   while [[ $# -gt 0 ]]; do
     case "$1" in
-      --prep|--publish)
-        if [[ -n "${mode}" ]]; then
-          log_error "Choose only one mode: --prep or --publish."
-          exit 1
-        fi
-        mode="${1#--}"
-        shift
-        ;;
+      --mode) mode="${2:-}"; shift 2 ;;
+      --tag) raw_tag="${2:-}"; shift 2 ;;
+      --tag-prefix) tag_prefix="${2:-}"; shift 2 ;;
+      --project-dir) project_dir="${2:-}"; shift 2 ;;
+      --main-branch) main_branch="${2:-}"; shift 2 ;;
+      --chart-dir) chart_dir="${2:-}"; shift 2 ;;
+      --chart-name) chart_name="${2:-}"; shift 2 ;;
+      --changelog) changelog="${2:-}"; shift 2 ;;
+      --oci-repository) oci_repository="${2:-}"; shift 2 ;;
+      --public-verify) shift ;;
       --allow-non-main)
-        log_error "--allow-non-main is not supported; publish must run from the clean synced ${MAIN_BRANCH} branch."
+        log_error "--allow-non-main is not supported; chart publish must run from the clean synced default branch."
         exit 1
         ;;
       --no-push)
@@ -597,35 +650,57 @@ main() {
         exit 1
         ;;
       *)
-        if [[ -n "${raw_version}" ]]; then
-          log_error "Unexpected extra argument: $1"
-          show_usage >&2
-          exit 1
-        fi
-        raw_version="$1"
-        shift
+        log_error "Unexpected argument: $1"
+        show_usage >&2
+        exit 1
         ;;
     esac
   done
 
-  if [[ -z "${mode}" || -z "${raw_version}" ]]; then
-    log_error "Missing required mode or version/tag."
-    if [[ -z "${raw_version}" ]]; then
-      log_note "Provide an explicit version/tag; do not infer it from Chart.yaml, latest tags, branch names, or changelog text."
+  local missing_required=()
+  [[ -n "${mode}" ]] || missing_required+=("--mode")
+  [[ -n "${raw_tag}" ]] || missing_required+=("--tag")
+  [[ -n "${chart_name}" ]] || missing_required+=("--chart-name")
+  if ((${#missing_required[@]} > 0)); then
+    log_error "Missing required option(s): ${missing_required[*]}"
+    if [[ " ${missing_required[*]} " == *" --tag "* ]]; then
+      log_note "Provide an explicit release version/tag; do not infer it from Chart.yaml, latest tags, branch names, or changelog text."
     fi
     show_usage >&2
     exit 1
   fi
 
+  case "${mode}" in
+    prep|publish|verify) ;;
+    *)
+      log_error "--mode must be prep, publish, or verify."
+      show_usage >&2
+      exit 1
+      ;;
+  esac
+
   if [[ "${mode}" != "prep" && "${no_push}" -eq 1 ]]; then
-    log_error "--no-push is only valid with --prep."
+    log_error "--no-push is only valid with --mode prep."
     exit 1
   fi
 
-  ensure_repo_ready
+  TAG_PREFIX="${tag_prefix}"
+  MAIN_BRANCH="${main_branch}"
+  CHART_DIR="${chart_dir}"
+  CHART_NAME="${chart_name}"
+  CHART_FILE="${CHART_DIR}/Chart.yaml"
+  CHANGELOG_FILE="${changelog}"
 
   local tag=""
-  tag="$(normalize_tag "${raw_version}")"
+  tag="$(normalize_tag "${raw_tag}")"
+
+  if [[ "${mode}" == "verify" ]]; then
+    verify_chart "${oci_repository}" "${CHART_NAME}" "${tag##*-v}"
+    return 0
+  fi
+
+  cd "${project_dir}"
+  ensure_repo_ready
 
   local branch=""
   branch="$(git rev-parse --abbrev-ref HEAD)"
@@ -635,8 +710,9 @@ main() {
       prep_release "${tag}" "$(( ! no_push ))" "${branch}"
       ;;
     publish)
+      ensure_tag_absent "${tag}"
       ensure_release_source_ready "${branch}" "publish"
-      create_and_push_tag "${tag}"
+      publish_tag "${tag}"
       ;;
     *)
       log_error "Unsupported mode: ${mode}"

--- a/skills/publish-helm/scripts/publish-helm-doer.sh
+++ b/skills/publish-helm/scripts/publish-helm-doer.sh
@@ -435,8 +435,8 @@ prep_release() {
   local charts_staged=""
   local release_branch=""
   local staged_paths=("${changelog}" "${chart_file}")
-  ensure_release_source_ready "${branch}" "${main_branch}" "prep"
   ensure_tag_absent "${tag}"
+  ensure_release_source_ready "${branch}" "${main_branch}" "prep"
   release_branch="$(release_branch_name "${tag}")"
   ensure_release_branch_absent "${release_branch}"
   git switch -c "${release_branch}"
@@ -588,6 +588,7 @@ main() {
       prep_release "${tag}" "${version}" "${chart_dir}" "${chart_name}" "${changelog}" "$((1 - no_push))" "${branch}" "${main_branch}"
       ;;
     publish)
+      ensure_tag_absent "${tag}"
       ensure_release_source_ready "${branch}" "${main_branch}" "publish"
       publish_tag "${tag}" "${version}" "${chart_dir}/Chart.yaml" "${changelog}"
       ;;

--- a/skills/publish-image/README.md
+++ b/skills/publish-image/README.md
@@ -41,7 +41,9 @@ Published image tags and digest
 
 ## Core Concepts
 
-- Doer mode does not depend on a project-local `publish-image.sh`.
+- Doer mode does not depend on a project-local `publish-image.sh`, but the
+  setup template is a maintained runnable helper and should keep the same
+  `--mode prep|publish|verify` contract as the skill-owned doer.
 - The default branch is the release source of truth. If work is still on a
   feature branch, merge that branch to the default branch before prep or
   publish.

--- a/skills/publish-image/SKILL.md
+++ b/skills/publish-image/SKILL.md
@@ -82,8 +82,10 @@ Use setup mode when the project does not already have a release flow:
 - `assets/publish-image.sh.template`
 - `assets/project-name-image-publish.yml.template`
 
-The project-local helper script is optional after this refactor. The skill-owned
-`scripts/publish-image-doer.sh` remains the canonical doer path.
+The project-local helper script is optional, but it is a maintained runnable
+helper template, not a documentation stub. Keep it behaviorally aligned with
+the skill-owned `scripts/publish-image-doer.sh`, which remains the canonical
+doer path.
 
 ## Guardrails
 

--- a/skills/publish-image/assets/CHANGELOG.md.template
+++ b/skills/publish-image/assets/CHANGELOG.md.template
@@ -9,9 +9,11 @@ All notable changes to this project are tracked here. This changelog follows
 - Keep `## [Unreleased]` at the top and add bullets as changes land.
 - Before release tagging, start from clean synced `__MAIN_BRANCH__` and move
   `Unreleased` into a dated release section with
-  `./publish-image.sh --prep X.Y.Z`; it creates and pushes a release branch.
+  `./publish-image.sh --mode prep --tag X.Y.Z`; it creates and pushes a
+  release branch.
 - After the release-prep PR merges to `__MAIN_BRANCH__`, run
-  `./publish-image.sh --publish X.Y.Z` on clean synced `__MAIN_BRANCH__`.
+  `./publish-image.sh --mode publish --tag X.Y.Z` on clean synced
+  `__MAIN_BRANCH__`.
 - Release section format:
   `## [__PROJECT_TAG_PREFIX__-vX.Y.Z] - YYYY-MM-DD`
 

--- a/skills/publish-image/assets/publish-image.sh.template
+++ b/skills/publish-image/assets/publish-image.sh.template
@@ -7,6 +7,7 @@ cd "${SCRIPT_DIR}"
 TAG_PREFIX="__PROJECT_TAG_PREFIX__"
 MAIN_BRANCH="__MAIN_BRANCH__"
 CHANGELOG_FILE="CHANGELOG.md"
+IMAGE_NAME="__IMAGE_NAME__"
 
 S_RESET=""
 S_BOLD=""
@@ -42,23 +43,32 @@ log_success() {
 
 show_usage() {
   printf '%b\n' "${S_BOLD}Usage:${S_RESET}"
-  printf '%b\n' "  ${S_CYAN}./publish-image.sh${S_RESET} ${S_DIM}--prep X.Y.Z [--no-push]${S_RESET}"
-  printf '%b\n' "  ${S_CYAN}./publish-image.sh${S_RESET} ${S_DIM}--publish X.Y.Z${S_RESET}"
+  printf '%b\n' "  ${S_CYAN}./publish-image.sh${S_RESET} ${S_DIM}--mode prep --tag X.Y.Z [options]${S_RESET}"
+  printf '%b\n' "  ${S_CYAN}./publish-image.sh${S_RESET} ${S_DIM}--mode publish --tag X.Y.Z [options]${S_RESET}"
+  printf '%b\n' "  ${S_CYAN}./publish-image.sh${S_RESET} ${S_DIM}--mode verify --tag X.Y.Z --image-name IMAGE [options]${S_RESET}"
   printf '\n'
 
   printf '%b\n' "${S_BOLD}Modes:${S_RESET}"
-  printf '%b\n' "  ${S_YELLOW}--prep${S_RESET}     Require clean synced ${MAIN_BRANCH}, create release/${TAG_PREFIX}-vX.Y.Z, update ${CHANGELOG_FILE}, commit it, and push the release branch."
-  printf '%b\n' "  ${S_YELLOW}--publish${S_RESET}  Create and push tag ${TAG_PREFIX}-vX.Y.Z."
+  printf '%b\n' "  ${S_YELLOW}prep${S_RESET}      Require clean synced default branch, create release/<tag>, update the changelog, commit it, and push the release branch."
+  printf '%b\n' "  ${S_YELLOW}publish${S_RESET}   Create and push the annotated release tag."
+  printf '%b\n' "  ${S_YELLOW}verify${S_RESET}    Verify the published image tag with docker buildx imagetools."
   printf '\n'
 
   printf '%b\n' "${S_BOLD}Options:${S_RESET}"
-  printf '%b\n' "  ${S_YELLOW}--no-push${S_RESET}          For --prep only: do not push the branch."
-  printf '%b\n' "  ${S_YELLOW}-h, --help${S_RESET}         Show help."
+  printf '%b\n' "  ${S_YELLOW}--tag TAG${S_RESET}             Version or full ${TAG_PREFIX}-vX.Y.Z tag."
+  printf '%b\n' "  ${S_YELLOW}--project-dir DIR${S_RESET}     Project directory, default this helper's directory."
+  printf '%b\n' "  ${S_YELLOW}--main-branch BRANCH${S_RESET}  Default branch, default ${MAIN_BRANCH}."
+  printf '%b\n' "  ${S_YELLOW}--tag-prefix PREFIX${S_RESET}   Release tag prefix, default ${TAG_PREFIX}."
+  printf '%b\n' "  ${S_YELLOW}--changelog FILE${S_RESET}      Changelog path, default ${CHANGELOG_FILE}."
+  printf '%b\n' "  ${S_YELLOW}--image-name IMAGE${S_RESET}    Verify mode: image repository without tag."
+  printf '%b\n' "  ${S_YELLOW}--no-push${S_RESET}             Prep only: do not push the branch."
+  printf '%b\n' "  ${S_YELLOW}-h, --help${S_RESET}            Show help."
   printf '\n'
 
   printf '%b\n' "${S_BOLD}Examples:${S_RESET}"
-  printf '%b\n' "  ${S_CYAN}./publish-image.sh --prep 0.1.0${S_RESET}"
-  printf '%b\n' "  ${S_CYAN}./publish-image.sh --publish 0.1.0${S_RESET}"
+  printf '%b\n' "  ${S_CYAN}./publish-image.sh --mode prep --tag 0.1.0${S_RESET}"
+  printf '%b\n' "  ${S_CYAN}./publish-image.sh --mode publish --tag 0.1.0${S_RESET}"
+  printf '%b\n' "  ${S_CYAN}./publish-image.sh --mode verify --tag 0.1.0 --image-name registry.example.com/org/app${S_RESET}"
 }
 
 require_cmd() {
@@ -73,7 +83,7 @@ ensure_repo_ready() {
   require_cmd "git"
   require_cmd "python3"
   if [[ ! -f "${CHANGELOG_FILE}" ]]; then
-    log_error "Missing ${CHANGELOG_FILE} in ${SCRIPT_DIR}"
+    log_error "Missing changelog: ${CHANGELOG_FILE}"
     exit 1
   fi
 }
@@ -310,8 +320,8 @@ prep_release() {
   local branch="$3"
   local release_branch=""
 
-  ensure_release_source_ready "${branch}" "prep"
   ensure_tag_absent "${tag}"
+  ensure_release_source_ready "${branch}" "prep"
   release_branch="$(release_branch_name "${tag}")"
   ensure_release_branch_absent "${release_branch}"
   git switch -c "${release_branch}"
@@ -348,8 +358,9 @@ ensure_tag_absent() {
   fi
 }
 
-create_and_push_tag() {
+publish_tag() {
   local tag="$1"
+  ensure_clean_worktree
   ensure_release_section_ready "${tag}"
   ensure_tag_absent "${tag}"
   git tag -a "${tag}" -m "Release ${tag}"
@@ -358,26 +369,41 @@ create_and_push_tag() {
   log_success "Image workflow will run from this tag push."
 }
 
+verify_image() {
+  local image_name="$1"
+  local version="$2"
+  require_cmd "docker"
+  if [[ -z "${image_name}" ]]; then
+    log_error "--image-name is required for verify mode."
+    exit 1
+  fi
+  docker buildx imagetools inspect "${image_name}:${version}" >/dev/null
+  log_success "Verified image tag: ${image_name}:${version}"
+}
+
 main() {
   init_output_style
-  ensure_repo_ready
 
   local mode=""
-  local raw_version=""
+  local raw_tag=""
+  local tag_prefix="${TAG_PREFIX}"
+  local project_dir="${SCRIPT_DIR}"
+  local main_branch="${MAIN_BRANCH}"
+  local changelog="${CHANGELOG_FILE}"
+  local image_name="${IMAGE_NAME}"
   local no_push=0
 
   while [[ $# -gt 0 ]]; do
     case "$1" in
-      --prep|--publish)
-        if [[ -n "${mode}" ]]; then
-          log_error "Choose only one mode: --prep or --publish."
-          exit 1
-        fi
-        mode="${1#--}"
-        shift
-        ;;
+      --mode) mode="${2:-}"; shift 2 ;;
+      --tag) raw_tag="${2:-}"; shift 2 ;;
+      --tag-prefix) tag_prefix="${2:-}"; shift 2 ;;
+      --project-dir) project_dir="${2:-}"; shift 2 ;;
+      --main-branch) main_branch="${2:-}"; shift 2 ;;
+      --changelog) changelog="${2:-}"; shift 2 ;;
+      --image-name) image_name="${2:-}"; shift 2 ;;
       --allow-non-main)
-        log_error "--allow-non-main is not supported; publish must run from the clean synced ${MAIN_BRANCH} branch."
+        log_error "--allow-non-main is not supported; image publish must run from the clean synced default branch."
         exit 1
         ;;
       --no-push)
@@ -398,29 +424,54 @@ main() {
         exit 1
         ;;
       *)
-        if [[ -n "${raw_version}" ]]; then
-          log_error "Unexpected extra argument: $1"
-          show_usage >&2
-          exit 1
-        fi
-        raw_version="$1"
-        shift
+        log_error "Unexpected argument: $1"
+        show_usage >&2
+        exit 1
         ;;
     esac
   done
 
-  if [[ -z "${mode}" || -z "${raw_version}" ]]; then
+  local missing_required=()
+  [[ -n "${mode}" ]] || missing_required+=("--mode")
+  [[ -n "${raw_tag}" ]] || missing_required+=("--tag")
+  if ((${#missing_required[@]} > 0)); then
+    log_error "Missing required option(s): ${missing_required[*]}"
+    if [[ " ${missing_required[*]} " == *" --tag "* ]]; then
+      log_note "Provide an explicit release version/tag; do not infer it from latest tags, branch names, or changelog text."
+    fi
     show_usage >&2
     exit 1
   fi
 
+  case "${mode}" in
+    prep|publish|verify) ;;
+    *)
+      log_error "--mode must be prep, publish, or verify."
+      show_usage >&2
+      exit 1
+      ;;
+  esac
+
   if [[ "${mode}" != "prep" && "${no_push}" -eq 1 ]]; then
-    log_error "--no-push is only valid with --prep."
+    log_error "--no-push is only valid with --mode prep."
     exit 1
   fi
 
+  TAG_PREFIX="${tag_prefix}"
+  MAIN_BRANCH="${main_branch}"
+  CHANGELOG_FILE="${changelog#./}"
+  IMAGE_NAME="${image_name}"
+
   local tag=""
-  tag="$(normalize_tag "${raw_version}")"
+  tag="$(normalize_tag "${raw_tag}")"
+
+  if [[ "${mode}" == "verify" ]]; then
+    verify_image "${IMAGE_NAME}" "${tag##*-v}"
+    return 0
+  fi
+
+  cd "${project_dir}"
+  ensure_repo_ready
 
   local branch=""
   branch="$(git rev-parse --abbrev-ref HEAD)"
@@ -430,8 +481,12 @@ main() {
       prep_release "${tag}" "$(( 1 - no_push ))" "${branch}"
       ;;
     publish)
+      ensure_tag_absent "${tag}"
       ensure_release_source_ready "${branch}" "publish"
-      create_and_push_tag "${tag}"
+      publish_tag "${tag}"
+      ;;
+    verify)
+      verify_image "${IMAGE_NAME}" "${tag##*-v}"
       ;;
     *)
       log_error "Invalid mode: ${mode}"

--- a/skills/publish-image/scripts/publish-image-doer.sh
+++ b/skills/publish-image/scripts/publish-image-doer.sh
@@ -306,8 +306,8 @@ prep_release() {
   local branch="$4"
   local main_branch="$5"
   local release_branch=""
-  ensure_release_source_ready "${branch}" "${main_branch}" "prep"
   ensure_tag_absent "${tag}"
+  ensure_release_source_ready "${branch}" "${main_branch}" "prep"
   release_branch="$(release_branch_name "${tag}")"
   ensure_release_branch_absent "${release_branch}"
   git switch -c "${release_branch}"
@@ -397,6 +397,7 @@ main() {
       prep_release "${tag}" "${changelog}" "$((1 - no_push))" "${branch}" "${main_branch}"
       ;;
     publish)
+      ensure_tag_absent "${tag}"
       ensure_release_source_ready "${branch}" "${main_branch}" "publish"
       publish_tag "${tag}" "${changelog}"
       ;;

--- a/skills/publish-release/README.md
+++ b/skills/publish-release/README.md
@@ -42,7 +42,9 @@ GitHub Release with assets
 
 ## Core Concepts
 
-- Doer mode does not depend on a project-local `publish-release.sh`.
+- Doer mode does not depend on a project-local `publish-release.sh`, but the
+  setup template is a maintained runnable helper and should keep the same
+  `--mode prep|publish|verify` contract as the skill-owned doer.
 - The default branch is the release source of truth. If work is still on a
   feature branch, merge that branch to the default branch before prep or
   publish.

--- a/skills/publish-release/SKILL.md
+++ b/skills/publish-release/SKILL.md
@@ -78,8 +78,10 @@ Use setup mode when the project does not already have a release flow:
 - `assets/publish-release.sh.template`
 - `assets/project-name-release-publish.yml.template`
 
-The project-local helper script is optional after this refactor. The skill-owned
-`scripts/publish-release-doer.sh` remains the canonical doer path.
+The project-local helper script is optional, but it is a maintained runnable
+helper template, not a documentation stub. Keep it behaviorally aligned with
+the skill-owned `scripts/publish-release-doer.sh`, which remains the canonical
+doer path.
 
 ## Guardrails
 

--- a/skills/publish-release/assets/CHANGELOG.md.template
+++ b/skills/publish-release/assets/CHANGELOG.md.template
@@ -9,9 +9,11 @@ All notable changes to this project are tracked here. This changelog follows
 - Keep `## [Unreleased]` at the top and add bullets as changes land.
 - Before release tagging, start from clean synced `__MAIN_BRANCH__` and move
   `Unreleased` into a dated release section with
-  `./publish-release.sh --prep X.Y.Z`; it creates and pushes a release branch.
+  `./publish-release.sh --mode prep --tag X.Y.Z`; it creates and pushes a
+  release branch.
 - After the release-prep PR merges to `__MAIN_BRANCH__`, run
-  `./publish-release.sh --publish X.Y.Z` on clean synced `__MAIN_BRANCH__`.
+  `./publish-release.sh --mode publish --tag X.Y.Z` on clean synced
+  `__MAIN_BRANCH__`.
 - The prep step fails before editing `CHANGELOG.md` if the target tag already
   exists locally or on `origin`.
 - The prep step preserves a blank line between dated release sections when it

--- a/skills/publish-release/assets/publish-release.sh.template
+++ b/skills/publish-release/assets/publish-release.sh.template
@@ -8,6 +8,7 @@ TAG_PREFIX="__PROJECT_TAG_PREFIX__"
 PACKAGE_IMPORT_NAME="__PACKAGE_IMPORT_NAME__"
 MAIN_BRANCH="__MAIN_BRANCH__"
 CHANGELOG_FILE="CHANGELOG.md"
+ASSET_GLOB="__ASSET_GLOB__"
 
 S_RESET=""
 S_BOLD=""
@@ -43,24 +44,34 @@ log_success() {
 
 show_usage() {
   printf '%b\n' "${S_BOLD}Usage:${S_RESET}"
-  printf '%b\n' "  ${S_CYAN}./publish-release.sh${S_RESET} ${S_DIM}--prep X.Y.Z [--no-push]${S_RESET}"
-  printf '%b\n' "  ${S_CYAN}./publish-release.sh${S_RESET} ${S_DIM}--publish X.Y.Z${S_RESET}"
+  printf '%b\n' "  ${S_CYAN}./publish-release.sh${S_RESET} ${S_DIM}--mode prep --tag X.Y.Z [options]${S_RESET}"
+  printf '%b\n' "  ${S_CYAN}./publish-release.sh${S_RESET} ${S_DIM}--mode publish --tag X.Y.Z [options]${S_RESET}"
+  printf '%b\n' "  ${S_CYAN}./publish-release.sh${S_RESET} ${S_DIM}--mode verify --tag X.Y.Z --asset-glob 'dist/*.whl' [options]${S_RESET}"
   printf '\n'
 
   printf '%b\n' "${S_BOLD}Modes:${S_RESET}"
-  printf '%b\n' "  ${S_YELLOW}--prep${S_RESET}     Require clean synced ${MAIN_BRANCH}, create release/${TAG_PREFIX}-vX.Y.Z, update ${CHANGELOG_FILE}, commit it, and push the release branch."
-  printf '%b\n' "                 Fails if tag ${TAG_PREFIX}-vX.Y.Z already exists locally or on origin."
-  printf '%b\n' "  ${S_YELLOW}--publish${S_RESET}  Create and push tag ${TAG_PREFIX}-vX.Y.Z."
+  printf '%b\n' "  ${S_YELLOW}prep${S_RESET}      Require clean synced default branch, create release/<tag>, update the changelog, commit it, and push the release branch."
+  printf '%b\n' "                 Fails if the tag already exists locally or on origin."
+  printf '%b\n' "  ${S_YELLOW}publish${S_RESET}   Verify runtime version when configured, then create and push the annotated release tag."
+  printf '%b\n' "  ${S_YELLOW}verify${S_RESET}    Verify a built wheel artifact version with --asset-glob."
   printf '\n'
 
   printf '%b\n' "${S_BOLD}Options:${S_RESET}"
-  printf '%b\n' "  ${S_YELLOW}--no-push${S_RESET}          For --prep only: do not push the branch."
-  printf '%b\n' "  ${S_YELLOW}-h, --help${S_RESET}         Show help."
+  printf '%b\n' "  ${S_YELLOW}--tag TAG${S_RESET}                  Version or full ${TAG_PREFIX}-vX.Y.Z tag."
+  printf '%b\n' "  ${S_YELLOW}--project-dir DIR${S_RESET}          Project directory, default this helper's directory."
+  printf '%b\n' "  ${S_YELLOW}--main-branch BRANCH${S_RESET}       Default branch, default ${MAIN_BRANCH}."
+  printf '%b\n' "  ${S_YELLOW}--tag-prefix PREFIX${S_RESET}        Release tag prefix, default ${TAG_PREFIX}."
+  printf '%b\n' "  ${S_YELLOW}--changelog FILE${S_RESET}           Changelog path, default ${CHANGELOG_FILE}."
+  printf '%b\n' "  ${S_YELLOW}--package-import-name NAME${S_RESET} Publish mode: import and verify NAME.__version__."
+  printf '%b\n' "  ${S_YELLOW}--asset-glob GLOB${S_RESET}          Verify mode: wheel glob to verify against release version."
+  printf '%b\n' "  ${S_YELLOW}--no-push${S_RESET}                  Prep only: do not push the branch."
+  printf '%b\n' "  ${S_YELLOW}-h, --help${S_RESET}                 Show help."
   printf '\n'
 
   printf '%b\n' "${S_BOLD}Examples:${S_RESET}"
-  printf '%b\n' "  ${S_CYAN}./publish-release.sh --prep 0.1.0${S_RESET}"
-  printf '%b\n' "  ${S_CYAN}./publish-release.sh --publish 0.1.0${S_RESET}"
+  printf '%b\n' "  ${S_CYAN}./publish-release.sh --mode prep --tag 0.1.0${S_RESET}"
+  printf '%b\n' "  ${S_CYAN}./publish-release.sh --mode publish --tag 0.1.0${S_RESET}"
+  printf '%b\n' "  ${S_CYAN}./publish-release.sh --mode verify --tag 0.1.0 --asset-glob 'dist/*.whl'${S_RESET}"
 }
 
 require_cmd() {
@@ -75,7 +86,7 @@ ensure_repo_ready() {
   require_cmd "git"
   require_cmd "python3"
   if [[ ! -f "${CHANGELOG_FILE}" ]]; then
-    log_error "Missing ${CHANGELOG_FILE} in ${SCRIPT_DIR}"
+    log_error "Missing changelog: ${CHANGELOG_FILE}"
     exit 1
   fi
 }
@@ -183,7 +194,7 @@ ensure_branch_synced() {
   fi
 }
 
-ensure_release_heading_present() {
+ensure_release_section_ready() {
   local tag="$1"
 
   python3 - "${tag}" "${CHANGELOG_FILE}" <<'PY'
@@ -313,8 +324,8 @@ prep_release() {
   local branch="$3"
   local release_branch=""
 
-  ensure_release_source_ready "${branch}" "prep"
   ensure_tag_absent "${tag}"
+  ensure_release_source_ready "${branch}" "prep"
   release_branch="$(release_branch_name "${tag}")"
   ensure_release_branch_absent "${release_branch}"
   git switch -c "${release_branch}"
@@ -350,14 +361,15 @@ ensure_tag_absent() {
   fi
 }
 
-verify_runtime_version_matches_tag() {
-  local tag="$1"
-  local expected_version="${tag##*-v}"
+verify_runtime_version() {
+  local package_import_name="$1"
+  local expected_version="$2"
   local resolved_version=""
+  [[ -n "${package_import_name}" ]] || return 0
 
-  log_note "Verifying runtime version resolves to ${expected_version} on the local tag..."
+  log_note "Verifying runtime version resolves to ${expected_version} before tagging..."
   if ! resolved_version="$(
-    PYTHONPATH="${SCRIPT_DIR}/src${PYTHONPATH:+:${PYTHONPATH}}" python3 - "${expected_version}" "${PACKAGE_IMPORT_NAME}" <<'PY'
+    PYTHONPATH="src${PYTHONPATH:+:${PYTHONPATH}}" python3 - "${expected_version}" "${package_import_name}" <<'PY'
 import importlib
 import sys
 
@@ -374,18 +386,56 @@ print(resolved, end="")
 PY
   )"; then
     log_error \
-      "Runtime version mismatch after tagging. Source checkout resolved to '${resolved_version:-unknown}' instead of '${expected_version}'."
+      "Runtime version mismatch before tagging. Source checkout resolved to '${resolved_version:-unknown}' instead of '${expected_version}'."
     exit 1
   fi
   log_success "Runtime version resolved to ${resolved_version}."
 }
 
-create_and_push_tag() {
+verify_artifact_version() {
+  local asset_glob="$1"
+  local expected_version="$2"
+  [[ -n "${asset_glob}" ]] || return 0
+  require_cmd "python3"
+  local asset=""
+  local assets=()
+
+  while IFS= read -r asset; do
+    assets+=("${asset}")
+  done < <(compgen -G "${asset_glob}" | sort)
+
+  if [[ "${#assets[@]}" -eq 0 ]]; then
+    log_error "No release asset found with glob ${asset_glob}"
+    exit 1
+  fi
+
+  asset="${assets[0]}"
+  python3 - "${asset}" "${expected_version}" <<'PY'
+import sys
+import zipfile
+from email import message_from_bytes
+
+asset, expected = sys.argv[1], sys.argv[2]
+with zipfile.ZipFile(asset) as zf:
+    metadata_names = [name for name in zf.namelist() if name.endswith("METADATA")]
+    if not metadata_names:
+        raise SystemExit(f"No METADATA found in {asset}")
+    metadata = message_from_bytes(zf.read(metadata_names[0]))
+    actual = metadata.get("Version", "")
+if actual != expected:
+    raise SystemExit(f"Artifact {asset} has version {actual!r}, expected {expected!r}")
+PY
+  log_success "Verified artifact version for ${asset}."
+}
+
+publish_tag() {
   local tag="$1"
-  ensure_release_heading_present "${tag}"
+  local version="${tag##*-v}"
+  ensure_clean_worktree
+  ensure_release_section_ready "${tag}"
   ensure_tag_absent "${tag}"
+  verify_runtime_version "${PACKAGE_IMPORT_NAME}" "${version}"
   git tag -a "${tag}" -m "Release ${tag}"
-  verify_runtime_version_matches_tag "${tag}"
   git push origin "refs/tags/${tag}"
   log_success "Tag pushed: ${tag}"
   log_success "Release workflow will run from this tag push."
@@ -393,24 +443,29 @@ create_and_push_tag() {
 
 main() {
   init_output_style
-  ensure_repo_ready
 
   local mode=""
-  local raw_version=""
+  local raw_tag=""
+  local tag_prefix="${TAG_PREFIX}"
+  local project_dir="${SCRIPT_DIR}"
+  local main_branch="${MAIN_BRANCH}"
+  local changelog="${CHANGELOG_FILE}"
+  local package_import_name="${PACKAGE_IMPORT_NAME}"
+  local asset_glob="${ASSET_GLOB}"
   local no_push=0
 
   while [[ $# -gt 0 ]]; do
     case "$1" in
-      --prep|--publish)
-        if [[ -n "${mode}" ]]; then
-          log_error "Choose only one mode: --prep or --publish."
-          exit 1
-        fi
-        mode="${1#--}"
-        shift
-        ;;
+      --mode) mode="${2:-}"; shift 2 ;;
+      --tag) raw_tag="${2:-}"; shift 2 ;;
+      --tag-prefix) tag_prefix="${2:-}"; shift 2 ;;
+      --project-dir) project_dir="${2:-}"; shift 2 ;;
+      --main-branch) main_branch="${2:-}"; shift 2 ;;
+      --changelog) changelog="${2:-}"; shift 2 ;;
+      --package-import-name) package_import_name="${2:-}"; shift 2 ;;
+      --asset-glob) asset_glob="${2:-}"; shift 2 ;;
       --allow-non-main)
-        log_error "--allow-non-main is not supported; publish must run from the clean synced ${MAIN_BRANCH} branch."
+        log_error "--allow-non-main is not supported; release publish must run from the clean synced default branch."
         exit 1
         ;;
       --no-push)
@@ -431,29 +486,56 @@ main() {
         exit 1
         ;;
       *)
-        if [[ -n "${raw_version}" ]]; then
-          log_error "Unexpected extra argument: $1"
-          show_usage >&2
-          exit 1
-        fi
-        raw_version="$1"
-        shift
+        log_error "Unexpected argument: $1"
+        show_usage >&2
+        exit 1
         ;;
     esac
   done
 
-  if [[ -z "${mode}" || -z "${raw_version}" ]]; then
+  local missing_required=()
+  [[ -n "${mode}" ]] || missing_required+=("--mode")
+  [[ -n "${raw_tag}" ]] || missing_required+=("--tag")
+  if ((${#missing_required[@]} > 0)); then
+    log_error "Missing required option(s): ${missing_required[*]}"
+    if [[ " ${missing_required[*]} " == *" --tag "* ]]; then
+      log_note "Provide an explicit release version/tag; do not infer it from latest tags, branch names, or changelog text."
+    fi
     show_usage >&2
     exit 1
   fi
 
+  case "${mode}" in
+    prep|publish|verify) ;;
+    *)
+      log_error "--mode must be prep, publish, or verify."
+      show_usage >&2
+      exit 1
+      ;;
+  esac
+
   if [[ "${mode}" != "prep" && "${no_push}" -eq 1 ]]; then
-    log_error "--no-push is only valid with --prep."
+    log_error "--no-push is only valid with --mode prep."
     exit 1
   fi
 
+  TAG_PREFIX="${tag_prefix}"
+  MAIN_BRANCH="${main_branch}"
+  CHANGELOG_FILE="${changelog#./}"
+  PACKAGE_IMPORT_NAME="${package_import_name}"
+  ASSET_GLOB="${asset_glob}"
+
   local tag=""
-  tag="$(normalize_tag "${raw_version}")"
+  tag="$(normalize_tag "${raw_tag}")"
+
+  cd "${project_dir}"
+
+  if [[ "${mode}" == "verify" ]]; then
+    verify_artifact_version "${ASSET_GLOB}" "${tag##*-v}"
+    return 0
+  fi
+
+  ensure_repo_ready
 
   local branch=""
   branch="$(git rev-parse --abbrev-ref HEAD)"
@@ -463,8 +545,12 @@ main() {
       prep_release "${tag}" "$(( 1 - no_push ))" "${branch}"
       ;;
     publish)
+      ensure_tag_absent "${tag}"
       ensure_release_source_ready "${branch}" "publish"
-      create_and_push_tag "${tag}"
+      publish_tag "${tag}"
+      ;;
+    verify)
+      verify_artifact_version "${ASSET_GLOB}" "${tag##*-v}"
       ;;
     *)
       log_error "Invalid mode: ${mode}"

--- a/skills/publish-release/scripts/publish-release-doer.sh
+++ b/skills/publish-release/scripts/publish-release-doer.sh
@@ -355,8 +355,8 @@ prep_release() {
   local branch="$4"
   local main_branch="$5"
   local release_branch=""
-  ensure_release_source_ready "${branch}" "${main_branch}" "prep"
   ensure_tag_absent "${tag}"
+  ensure_release_source_ready "${branch}" "${main_branch}" "prep"
   release_branch="$(release_branch_name "${tag}")"
   ensure_release_branch_absent "${release_branch}"
   git switch -c "${release_branch}"
@@ -437,6 +437,7 @@ main() {
       prep_release "${tag}" "${changelog}" "$((1 - no_push))" "${branch}" "${main_branch}"
       ;;
     publish)
+      ensure_tag_absent "${tag}"
       ensure_release_source_ready "${branch}" "${main_branch}" "publish"
       publish_tag "${tag}" "${changelog}" "${package_import_name}" "${version}"
       ;;

--- a/skills/sdlc-start/README.md
+++ b/skills/sdlc-start/README.md
@@ -76,9 +76,12 @@ folder. The single-source form copies only SDLC hook files into
 `${CODEX_HOME:-$HOME/.codex}/hooks`. Add `--register-hooks` when the installer
 should merge the SDLC `PreToolUse` and `Stop` entries into `hooks.json`. Add
 `--replace-hooks-json` only when intentionally replacing `hooks.json` with a
-clean file built from the selected source manifests. Registration is
-idempotent, does not trust hooks, refuses duplicate Python hook files within
-the same hook event, and reports extra installed hook files or `hooks.json`
-entries for manual review instead of removing them by default.
+clean file built from the selected source manifests. Hook payload sync records
+local provenance hashes so source-owned unmodified hook files can auto-upgrade;
+unproven local edits still require review unless intentionally listed by
+basename with `--overwrite-hook-files`, which backs up each replaced target.
+Registration is idempotent, does not trust hooks, refuses duplicate Python hook
+files within the same hook event, and reports extra installed hook files or
+`hooks.json` entries for manual review instead of removing them by default.
 Restart Codex and review the PreToolUse and Stop entries in `/hooks` after
 syncing.


### PR DESCRIPTION
## Summary
- add hook payload provenance and basename-scoped --overwrite-hook-files support to install-skills.sh
- update hook install tests, docs, and changelog for safe auto-upgrade and intentional overwrite behavior
- align publish helper templates and docs around --mode prep|publish|verify flows

## Validation
- PYTHONDONTWRITEBYTECODE=1 python3 skills/agent-nebius-auth/scripts/test_install_hook_registration.py
- PYTHONDONTWRITEBYTECODE=1 python3 skills/sdlc-start/assets/hooks/tests/test_sdlc_hooks.py
- bash -n skills/install-skills.sh skills/publish-helm/assets/publish-helm.sh.template skills/publish-image/assets/publish-image.sh.template skills/publish-release/assets/publish-release.sh.template skills/publish-helm/scripts/publish-helm-doer.sh skills/publish-image/scripts/publish-image-doer.sh skills/publish-release/scripts/publish-release-doer.sh
- shellcheck skills/install-skills.sh skills/publish-helm/assets/publish-helm.sh.template skills/publish-image/assets/publish-image.sh.template skills/publish-release/assets/publish-release.sh.template skills/publish-helm/scripts/publish-helm-doer.sh skills/publish-image/scripts/publish-image-doer.sh skills/publish-release/scripts/publish-release-doer.sh
- ruff check skills/agent-nebius-auth/scripts/test_install_hook_registration.py
- markdownlint skills/README.md skills/config-codex/README.md skills/config-codex/references/local-setup.md skills/sdlc-start/README.md skills/CHANGELOG.md skills/publish-helm/README.md skills/publish-helm/SKILL.md skills/publish-helm/assets/CHANGELOG.md.template skills/publish-image/README.md skills/publish-image/SKILL.md skills/publish-image/assets/CHANGELOG.md.template skills/publish-release/README.md skills/publish-release/SKILL.md skills/publish-release/assets/CHANGELOG.md.template
- git diff --check
- conflict-marker scan
- install-skills.sh and publish helper template --help smokes