### PR TITLE
Release soperator chart 4.0.2-ps.4

### DIFF
--- a/helm-charts/soperator/CHANGELOG.md
+++ b/helm-charts/soperator/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this chart are tracked here.
 
 ## [Unreleased]
 
+## [soperator-chart-v4.0.2-ps.4] - 2026-07-07
+
 - Added the active/passive jail rootfs storage contract. The chart now renders
   `jail-rootfs-slot-a`, `jail-rootfs-slot-b`, and generated
   `jailPersistentMounts` PVC-backed volume sources, defaults login replicas to

--- a/helm-charts/soperator/Chart.yaml
+++ b/helm-charts/soperator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: soperator
 description: Self-managed Nebius Soperator deployment for MK8s clusters
 type: application
-version: 4.0.2-ps.3
+version: 4.0.2-ps.4
 appVersion: "4.0.2"
 kubeVersion: ">=1.29.0-0"
 annotations:

--- a/services/nebius-cxcli/CHANGELOG.md
+++ b/services/nebius-cxcli/CHANGELOG.md
@@ -581,7 +581,7 @@ All notable changes to this project are tracked here. This changelog follows
   Removed the ambiguous `--k8s` and `--soperator` acceptance-test selectors;
   operators now select runtime behavior through `--suite`: `k8s-cuda` or
   `slurm` for smoke, and `k8s-nccl` or `slurm-nccl` for benchmark.
-- Updated the bundled Soperator portable chart pin to `4.0.2-ps.3`, matching
+- Updated the bundled Soperator portable chart pin to `4.0.2-ps.4`, matching
   the current parent chart package release while keeping local-source
   resolution tied to `helm-charts/soperator/Chart.yaml`.
 - Changed `component add apps:soperator` so production-cluster adds fail fast on

--- a/services/nebius-cxcli/component_sources.yaml
+++ b/services/nebius-cxcli/component_sources.yaml
@@ -212,7 +212,7 @@ components:
         portable:
           repo: oci://cr.eu-north1.nebius.cloud/e00th0mgv3zddz7468/charts/soperator
           chart: soperator
-          version: 4.0.2-ps.3
+          version: 4.0.2-ps.4
         local:
           path: ../../helm-charts/soperator
       ui:

--- a/services/nebius-cxcli/tests/test_cli.py
+++ b/services/nebius-cxcli/tests/test_cli.py
@@ -12324,7 +12324,7 @@ def test_soperator_onboard_prints_target_compatible_layout_decisions(
     assert "## Upgrade Guidance" in summary
     assert "- Upgrade path evaluation:" in summary
     assert "  - Kubernetes: 1.34" in summary
-    assert "  - Soperator chart: 1.23.3 -> 4.0.2-ps.3" in summary
+    assert f"  - Soperator chart: 1.23.3 -> {_soperator_test_chart_version()}" in summary
     assert "Soperator upgrade path: status=supported" in summary
 
 

--- a/services/nebius-cxcli/tests/test_cli_command_coverage.py
+++ b/services/nebius-cxcli/tests/test_cli_command_coverage.py
@@ -4628,7 +4628,7 @@ def test_soperator_upgrade_dry_run_blocks_k8s_boundary_before_chart_upgrade(
     assert "Managed upgrade order (execution blocked)" in rendered
     assert "Current Kubernetes version: `1.32`" in rendered
     assert "Requested Kubernetes target: `1.33`" in rendered
-    assert "Soperator chart: `1.22.3` -> `4.0.2-ps.3`" in rendered
+    assert f"Soperator chart: `1.22.3` -> `{target_chart_version}`" in rendered
     assert (
         f"nebius-cxcli soperator upgrade {paths.config_path} --target mk8s "
         f"--to-chart-version {target_chart_version}"


### PR DESCRIPTION
## Summary
- Prepare the soperator Helm chart package release `4.0.2-ps.4`.
- Move the chart `[Unreleased]` entries into `soperator-chart-v4.0.2-ps.4` and update `Chart.yaml`.
- Align the cxcli bundled Soperator portable chart pin and changelog note to `4.0.2-ps.4`.

## Validation
- `publish-helm-doer.sh --mode prep --tag 4.0.2-ps.4 --project-dir /Users/rezab/repos/nebius-ps-services --chart-dir helm-charts/soperator --chart-name soperator --tag-prefix soperator-chart --main-branch main`
- `git diff --check`
- `NEBIUS_CXCLI_COMPONENT_SOURCES_PROFILE=local uv run nebius-cxcli validate-sources component_sources.yaml`
- `uv run pytest tests/test_component_sources.py tests/test_config_model.py::test_starter_payload_local_profile_uses_local_chart_and_portable_fallback`
- explicit chart/catalog version assertion: `4.0.2-ps.4`
